### PR TITLE
fix: correct goreleaser repo owner to KimKaoPoo

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -27,7 +27,7 @@ checksum:
   name_template: "checksums.txt"
 release:
   github:
-    owner: hsubebe89
+    owner: KimKaoPoo
     name: tm1cli
   draft: false
   prerelease: auto


### PR DESCRIPTION
## Summary

- Fix goreleaser release target from `hsubebe89/tm1cli` to `KimKaoPoo/tm1cli`
- Release workflow was failing with 404 because it tried to publish to the wrong repo

## Test plan

- [x] `.goreleaser.yml` owner field updated