### PR TITLE
docs: add installation guide for binary download and go install

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,52 @@ Manage TM1 servers, list cubes and dimensions, run TI processes, and export data
 
 ## Install
 
+### Download binary (recommended)
+
+Download the latest release for your platform from [Releases](https://github.com/KimKaoPoo/tm1cli/releases/latest).
+
+**macOS (Apple Silicon):**
+
+```bash
+curl -Lo tm1cli.tar.gz https://github.com/KimKaoPoo/tm1cli/releases/latest/download/tm1cli_0.1.0_darwin_arm64.tar.gz
+tar xzf tm1cli.tar.gz
+sudo mv tm1cli /usr/local/bin/
+```
+
+**macOS (Intel):**
+
+```bash
+curl -Lo tm1cli.tar.gz https://github.com/KimKaoPoo/tm1cli/releases/latest/download/tm1cli_0.1.0_darwin_amd64.tar.gz
+tar xzf tm1cli.tar.gz
+sudo mv tm1cli /usr/local/bin/
+```
+
+**Linux (x86_64):**
+
+```bash
+curl -Lo tm1cli.tar.gz https://github.com/KimKaoPoo/tm1cli/releases/latest/download/tm1cli_0.1.0_linux_amd64.tar.gz
+tar xzf tm1cli.tar.gz
+sudo mv tm1cli /usr/local/bin/
+```
+
+**Linux (ARM64):**
+
+```bash
+curl -Lo tm1cli.tar.gz https://github.com/KimKaoPoo/tm1cli/releases/latest/download/tm1cli_0.1.0_linux_arm64.tar.gz
+tar xzf tm1cli.tar.gz
+sudo mv tm1cli /usr/local/bin/
+```
+
+**Windows:**
+
+Download `tm1cli_0.1.0_windows_amd64.zip` from [Releases](https://github.com/KimKaoPoo/tm1cli/releases/latest), extract, and add `tm1cli.exe` to your PATH.
+
+### Go install
+
+```bash
+go install github.com/KimKaoPoo/tm1cli@latest
+```
+
 ### From source
 
 Requires Go 1.22+


### PR DESCRIPTION
## Summary

- Add binary download instructions for macOS (ARM/Intel), Linux (x86_64/ARM64), Windows
- Add `go install` one-liner
- Keep existing "from source" section

## Test plan

- [x] All download URLs point to correct release assets