### PR TITLE
fix: auto-append /api/v1 to server URL

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -51,7 +51,7 @@ For better security, use the TM1CLI_PASSWORD environment variable.`,
   tm1cli config add
 
   # with flags
-  tm1cli config add myserver --url https://host:8010/api/v1 --user myuser --auth basic
+  tm1cli config add myserver --url https://host:8010 --user myuser --auth basic
 
   # with env var for password (no storage)
   export TM1CLI_PASSWORD=mysecret
@@ -94,7 +94,7 @@ func runConfigAdd(cmd *cobra.Command, args []string) error {
 	// URL
 	url := addFlagURL
 	if url == "" {
-		fmt.Print("TM1 REST API URL: ")
+		fmt.Print("TM1 Server URL (e.g. https://host:8010): ")
 		url, _ = reader.ReadString('\n')
 		url = strings.TrimSpace(url)
 	}
@@ -440,7 +440,7 @@ func init() {
 	configCmd.AddCommand(configSettingsCmd)
 
 	// config add flags
-	configAddCmd.Flags().StringVar(&addFlagURL, "url", "", "TM1 REST API URL (https://host:port/api/v1)")
+	configAddCmd.Flags().StringVar(&addFlagURL, "url", "", "TM1 server URL (https://host:port)")
 	configAddCmd.Flags().StringVar(&addFlagUser, "user", "", "Username")
 	configAddCmd.Flags().StringVar(&addFlagPassword, "password", "", "Password (prefer TM1CLI_PASSWORD env var for security)")
 	configAddCmd.Flags().StringVar(&addFlagAuth, "auth", "", "Auth mode: basic or cam (default: basic)")

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -46,6 +46,9 @@ func NewClient(server config.ServerConfig, password string, tlsVerify bool, verb
 	}
 
 	baseURL := strings.TrimRight(server.URL, "/")
+	if !strings.HasSuffix(baseURL, "/api/v1") {
+		baseURL += "/api/v1"
+	}
 
 	return &Client{
 		httpClient: httpClient,


### PR DESCRIPTION
## Summary

- Auto-append `/api/v1` to server URL if not already present
- Users now enter `https://host:8010` instead of `https://host:8010/api/v1`
- Updated prompts, flag descriptions, and examples

## Test plan

- [x] `go test ./...` passes
- [x] URLs without `/api/v1` get it appended
- [x] URLs already ending with `/api/v1` are unchanged