### PR TITLE
chore: bump Makefile version to 0.1.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION := 0.1.0
+VERSION := 0.1.1
 
 build:
 	go build -ldflags "-X tm1cli/cmd.Version=$(VERSION)" -o tm1cli


### PR DESCRIPTION
Bump VERSION in Makefile to match v0.1.1 release.