### PR TITLE
fix: restore auto-append /api/v1 to server URL

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -46,6 +46,9 @@ func NewClient(server config.ServerConfig, password string, tlsVerify bool, verb
 	}
 
 	baseURL := strings.TrimRight(server.URL, "/")
+	if !strings.HasSuffix(baseURL, "/api/v1") {
+		baseURL += "/api/v1"
+	}
 
 	return &Client{
 		httpClient: httpClient,


### PR DESCRIPTION
Lost during conflict resolution in v0.1.1 merge. Without this, all API calls 404.