### PR TITLE
fix: restore CSV/JSON file export lost during merge conflict

### DIFF
--- a/cmd/export.go
+++ b/cmd/export.go
@@ -1,9 +1,11 @@
 package cmd
 
 import (
+	"encoding/csv"
 	"encoding/json"
 	"fmt"
 	"net/url"
+	"os"
 	"strings"
 	"tm1cli/internal/model"
 	"tm1cli/internal/output"
@@ -12,9 +14,10 @@ import (
 )
 
 var (
-	exportView string
-	exportMDX  string
-	exportOut  string
+	exportView     string
+	exportMDX      string
+	exportOut      string
+	exportNoHeader bool
 )
 
 var exportCmd = &cobra.Command{
@@ -28,6 +31,7 @@ REST API:      GET /Cubes('name')/Views('view')/tm1.Execute
                POST /ExecuteMDX`,
 	Example: `  tm1cli export "Sales" --view "Default"
   tm1cli export "Sales" --view "Default" -o report.csv
+  tm1cli export "Sales" --view "Default" -o report.json
   tm1cli export "Sales" --view "Default" --output json`,
 	Args: cobra.ExactArgs(1),
 	RunE: runExport,
@@ -45,16 +49,15 @@ func runExport(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("MDX export is not yet implemented (coming in v0.2.0). Use --view instead.")
 	}
 
-	// TODO: Phase 1.1 — file output
+	// Validate file extension before doing any network calls
 	if exportOut != "" {
 		ext := strings.ToLower(exportOut)
 		if strings.HasSuffix(ext, ".xlsx") {
 			return fmt.Errorf("XLSX export is not yet implemented (coming in v0.2.0).")
 		}
-		if strings.HasSuffix(ext, ".csv") || strings.HasSuffix(ext, ".json") {
-			return fmt.Errorf("File export is not yet implemented (coming in v0.1.1).")
+		if !strings.HasSuffix(ext, ".csv") && !strings.HasSuffix(ext, ".json") {
+			return fmt.Errorf("Unsupported file format. Supported: .csv, .json, .xlsx")
 		}
-		return fmt.Errorf("Unsupported file format. Supported: .csv, .json, .xlsx")
 	}
 
 	cfg, err := loadConfig()
@@ -84,6 +87,22 @@ func runExport(cmd *cobra.Command, args []string) error {
 		return errSilent
 	}
 
+	// JSON file output
+	if strings.HasSuffix(strings.ToLower(exportOut), ".json") {
+		records := cellsetToRecords(resp)
+		if err := writeJSONFile(exportOut, records); err != nil {
+			output.PrintError(err.Error(), jsonMode)
+			return errSilent
+		}
+		fmt.Fprintf(os.Stderr, "Wrote %d records to %s\n", len(records), exportOut)
+		return nil
+	}
+
+	// CSV file output
+	if strings.HasSuffix(strings.ToLower(exportOut), ".csv") {
+		return writeCSV(resp, exportOut, exportNoHeader)
+	}
+
 	if jsonMode {
 		output.PrintJSON(resp)
 		return nil
@@ -93,10 +112,11 @@ func runExport(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func printCellsetTable(resp model.CellsetResponse) {
+// cellsetToRecords converts a CellsetResponse into a flat array of record maps.
+// Row dimension members become DIM1, DIM2, etc. Column headers become value keys.
+func cellsetToRecords(resp model.CellsetResponse) []map[string]interface{} {
 	if len(resp.Axes) < 2 {
-		fmt.Println("No data returned.")
-		return
+		return []map[string]interface{}{}
 	}
 
 	colAxis := resp.Axes[0]
@@ -104,8 +124,77 @@ func printCellsetTable(resp model.CellsetResponse) {
 
 	numCols := len(colAxis.Tuples)
 	if numCols == 0 {
-		fmt.Println("No data returned.")
-		return
+		return []map[string]interface{}{}
+	}
+
+	// Build column header names
+	colHeaders := make([]string, numCols)
+	for i, tuple := range colAxis.Tuples {
+		names := make([]string, len(tuple.Members))
+		for j, m := range tuple.Members {
+			names[j] = m.Name
+		}
+		colHeaders[i] = strings.Join(names, " / ")
+	}
+
+	// Index cells by ordinal
+	cellsByOrdinal := make(map[int]interface{}, len(resp.Cells))
+	for _, cell := range resp.Cells {
+		cellsByOrdinal[cell.Ordinal] = cell.Value
+	}
+
+	// Build records
+	records := make([]map[string]interface{}, 0, len(rowAxis.Tuples))
+	for r, tuple := range rowAxis.Tuples {
+		record := make(map[string]interface{}, len(tuple.Members)+numCols)
+		for d, m := range tuple.Members {
+			record[fmt.Sprintf("DIM%d", d+1)] = m.Name
+		}
+		for c := 0; c < numCols; c++ {
+			ordinal := r*numCols + c
+			if v, ok := cellsByOrdinal[ordinal]; ok {
+				record[colHeaders[c]] = v
+			} else {
+				record[colHeaders[c]] = nil
+			}
+		}
+		records = append(records, record)
+	}
+
+	return records
+}
+
+func writeJSONFile(filePath string, data interface{}) error {
+	f, err := os.Create(filePath)
+	if err != nil {
+		return fmt.Errorf("Cannot write file: %s", err.Error())
+	}
+
+	enc := json.NewEncoder(f)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(data); err != nil {
+		f.Close()
+		return fmt.Errorf("Cannot encode JSON: %s", err.Error())
+	}
+	if err := f.Close(); err != nil {
+		return fmt.Errorf("Cannot write file: %s", err.Error())
+	}
+	return nil
+}
+
+// buildCellsetRows converts a CellsetResponse into headers and row data.
+// Returns nil, nil if the response has fewer than 2 axes or 0 column tuples.
+func buildCellsetRows(resp model.CellsetResponse) ([]string, [][]string) {
+	if len(resp.Axes) < 2 {
+		return nil, nil
+	}
+
+	colAxis := resp.Axes[0]
+	rowAxis := resp.Axes[1]
+
+	numCols := len(colAxis.Tuples)
+	if numCols == 0 {
+		return nil, nil
 	}
 
 	// Build column headers
@@ -124,7 +213,7 @@ func printCellsetTable(resp model.CellsetResponse) {
 		rowMemberCount = len(rowAxis.Tuples[0].Members)
 	}
 
-	// Table headers
+	// Headers
 	headers := make([]string, 0, rowMemberCount+numCols)
 	for i := 0; i < rowMemberCount; i++ {
 		headers = append(headers, fmt.Sprintf("DIM%d", i+1))
@@ -155,7 +244,52 @@ func printCellsetTable(resp model.CellsetResponse) {
 		rows[r] = row
 	}
 
+	return headers, rows
+}
+
+func printCellsetTable(resp model.CellsetResponse) {
+	headers, rows := buildCellsetRows(resp)
+	if headers == nil {
+		fmt.Println("No data returned.")
+		return
+	}
 	output.PrintTable(headers, rows)
+}
+
+func writeCSV(resp model.CellsetResponse, filePath string, noHeader bool) error {
+	headers, rows := buildCellsetRows(resp)
+	if headers == nil {
+		fmt.Fprintln(os.Stderr, "No data to export.")
+		return nil
+	}
+
+	f, err := os.Create(filePath)
+	if err != nil {
+		return fmt.Errorf("Cannot create file: %s", err)
+	}
+	defer f.Close()
+
+	w := csv.NewWriter(f)
+
+	if !noHeader {
+		if err := w.Write(headers); err != nil {
+			return fmt.Errorf("Cannot write CSV header: %s", err)
+		}
+	}
+
+	for _, row := range rows {
+		if err := w.Write(row); err != nil {
+			return fmt.Errorf("Cannot write CSV row: %s", err)
+		}
+	}
+
+	w.Flush()
+	if err := w.Error(); err != nil {
+		return fmt.Errorf("Cannot write CSV: %s", err)
+	}
+
+	fmt.Fprintf(os.Stderr, "Exported %d rows to %s\n", len(rows), filePath)
+	return nil
 }
 
 func init() {
@@ -163,4 +297,5 @@ func init() {
 	exportCmd.Flags().StringVar(&exportView, "view", "", "Saved view name")
 	exportCmd.Flags().StringVar(&exportMDX, "mdx", "", "MDX query string (v0.2.0)")
 	exportCmd.Flags().StringVarP(&exportOut, "out", "o", "", "Output file path (.csv, .json)")
+	exportCmd.Flags().BoolVar(&exportNoHeader, "no-header", false, "Exclude header row from CSV output")
 }

--- a/cmd/export_test.go
+++ b/cmd/export_test.go
@@ -1,8 +1,12 @@
 package cmd
 
 import (
+	"encoding/csv"
 	"encoding/json"
+	"fmt"
 	"net/http"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"tm1cli/internal/model"
@@ -316,16 +320,6 @@ func TestRunExportStubs(t *testing.T) {
 			name:    "mdx flag returns v0.2.0 message",
 			args:    []string{"export", "Sales", "--mdx", "SELECT {[Measures].Members} ON COLUMNS FROM [Sales]"},
 			wantErr: "coming in v0.2.0",
-		},
-		{
-			name:    "out csv returns v0.1.1 message",
-			args:    []string{"export", "Sales", "--view", "Default", "--out", "report.csv"},
-			wantErr: "coming in v0.1.1",
-		},
-		{
-			name:    "out json file returns v0.1.1 message",
-			args:    []string{"export", "Sales", "--view", "Default", "--out", "report.json"},
-			wantErr: "coming in v0.1.1",
 		},
 		{
 			name:    "out xlsx returns v0.2.0 message",
@@ -646,5 +640,839 @@ func TestRunExport_ViewEndpointContainsCubeAndView(t *testing.T) {
 	}
 	if !strings.Contains(capturedPath, "Views('MyView')") {
 		t.Errorf("request path should contain view name, got: %s", capturedPath)
+	}
+}
+
+// ===========================================================================
+// TestCellsetToRecords — unit tests for the cellsetToRecords function
+// ===========================================================================
+
+func TestCellsetToRecords(t *testing.T) {
+	tests := []struct {
+		name       string
+		resp       model.CellsetResponse
+		wantLen    int
+		wantKeys   []string               // keys that must exist in first record
+		wantValues map[string]interface{} // expected values in first record
+	}{
+		{
+			name: "normal 2-axis with 2 cols and 2 rows",
+			resp: model.CellsetResponse{
+				Axes: []model.CellsetAxis{
+					{
+						Ordinal: 0,
+						Tuples: []model.CellsetTuple{
+							{Ordinal: 0, Members: []model.CellsetMember{{Name: "Jan"}}},
+							{Ordinal: 1, Members: []model.CellsetMember{{Name: "Feb"}}},
+						},
+					},
+					{
+						Ordinal: 1,
+						Tuples: []model.CellsetTuple{
+							{Ordinal: 0, Members: []model.CellsetMember{{Name: "Revenue"}}},
+							{Ordinal: 1, Members: []model.CellsetMember{{Name: "Cost"}}},
+						},
+					},
+				},
+				Cells: []model.CellsetCell{
+					{Ordinal: 0, Value: 1000.0},
+					{Ordinal: 1, Value: 2000.0},
+					{Ordinal: 2, Value: 500.0},
+					{Ordinal: 3, Value: 800.0},
+				},
+			},
+			wantLen:  2,
+			wantKeys: []string{"DIM1", "Jan", "Feb"},
+			wantValues: map[string]interface{}{
+				"DIM1": "Revenue",
+				"Jan":  1000.0,
+				"Feb":  2000.0,
+			},
+		},
+		{
+			name: "multi-member row headers produce DIM1 and DIM2",
+			resp: model.CellsetResponse{
+				Axes: []model.CellsetAxis{
+					{
+						Ordinal: 0,
+						Tuples: []model.CellsetTuple{
+							{Ordinal: 0, Members: []model.CellsetMember{{Name: "Q1"}}},
+						},
+					},
+					{
+						Ordinal: 1,
+						Tuples: []model.CellsetTuple{
+							{Ordinal: 0, Members: []model.CellsetMember{{Name: "US"}, {Name: "Revenue"}}},
+						},
+					},
+				},
+				Cells: []model.CellsetCell{
+					{Ordinal: 0, Value: 500.0},
+				},
+			},
+			wantLen:  1,
+			wantKeys: []string{"DIM1", "DIM2", "Q1"},
+			wantValues: map[string]interface{}{
+				"DIM1": "US",
+				"DIM2": "Revenue",
+				"Q1":   500.0,
+			},
+		},
+		{
+			name: "multi-member column headers joined with /",
+			resp: model.CellsetResponse{
+				Axes: []model.CellsetAxis{
+					{
+						Ordinal: 0,
+						Tuples: []model.CellsetTuple{
+							{Ordinal: 0, Members: []model.CellsetMember{{Name: "Jan"}, {Name: "Actual"}}},
+						},
+					},
+					{
+						Ordinal: 1,
+						Tuples: []model.CellsetTuple{
+							{Ordinal: 0, Members: []model.CellsetMember{{Name: "Revenue"}}},
+						},
+					},
+				},
+				Cells: []model.CellsetCell{
+					{Ordinal: 0, Value: 100.0},
+				},
+			},
+			wantLen:  1,
+			wantKeys: []string{"DIM1", "Jan / Actual"},
+			wantValues: map[string]interface{}{
+				"DIM1":         "Revenue",
+				"Jan / Actual": 100.0,
+			},
+		},
+		{
+			name: "fewer than 2 axes returns empty slice",
+			resp: model.CellsetResponse{
+				Axes:  []model.CellsetAxis{{Ordinal: 0}},
+				Cells: nil,
+			},
+			wantLen: 0,
+		},
+		{
+			name: "0 column tuples returns empty slice",
+			resp: model.CellsetResponse{
+				Axes: []model.CellsetAxis{
+					{Ordinal: 0, Tuples: []model.CellsetTuple{}},
+					{Ordinal: 1, Tuples: []model.CellsetTuple{
+						{Ordinal: 0, Members: []model.CellsetMember{{Name: "Row1"}}},
+					}},
+				},
+				Cells: nil,
+			},
+			wantLen: 0,
+		},
+		{
+			name: "null cell values preserved as nil",
+			resp: model.CellsetResponse{
+				Axes: []model.CellsetAxis{
+					{
+						Ordinal: 0,
+						Tuples: []model.CellsetTuple{
+							{Ordinal: 0, Members: []model.CellsetMember{{Name: "Jan"}}},
+						},
+					},
+					{
+						Ordinal: 1,
+						Tuples: []model.CellsetTuple{
+							{Ordinal: 0, Members: []model.CellsetMember{{Name: "Sales"}}},
+						},
+					},
+				},
+				Cells: []model.CellsetCell{
+					{Ordinal: 0, Value: nil},
+				},
+			},
+			wantLen:  1,
+			wantKeys: []string{"DIM1", "Jan"},
+			wantValues: map[string]interface{}{
+				"DIM1": "Sales",
+				"Jan":  nil,
+			},
+		},
+		{
+			name: "sparse cells with missing ordinals produce nil",
+			resp: model.CellsetResponse{
+				Axes: []model.CellsetAxis{
+					{
+						Ordinal: 0,
+						Tuples: []model.CellsetTuple{
+							{Ordinal: 0, Members: []model.CellsetMember{{Name: "Jan"}}},
+							{Ordinal: 1, Members: []model.CellsetMember{{Name: "Feb"}}},
+						},
+					},
+					{
+						Ordinal: 1,
+						Tuples: []model.CellsetTuple{
+							{Ordinal: 0, Members: []model.CellsetMember{{Name: "Revenue"}}},
+						},
+					},
+				},
+				// Only ordinal 1 present; ordinal 0 is missing
+				Cells: []model.CellsetCell{
+					{Ordinal: 1, Value: 999.0},
+				},
+			},
+			wantLen:  1,
+			wantKeys: []string{"DIM1", "Jan", "Feb"},
+			wantValues: map[string]interface{}{
+				"DIM1": "Revenue",
+				"Jan":  nil,
+				"Feb":  999.0,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			records := cellsetToRecords(tt.resp)
+
+			if len(records) != tt.wantLen {
+				t.Fatalf("got %d records, want %d", len(records), tt.wantLen)
+			}
+
+			if tt.wantLen == 0 {
+				return
+			}
+
+			first := records[0]
+			for _, key := range tt.wantKeys {
+				if _, ok := first[key]; !ok {
+					t.Errorf("record missing key %q, got keys: %v", key, mapKeys(first))
+				}
+			}
+
+			for key, wantVal := range tt.wantValues {
+				gotVal, ok := first[key]
+				if !ok {
+					t.Errorf("record missing key %q", key)
+					continue
+				}
+				if wantVal == nil {
+					if gotVal != nil {
+						t.Errorf("key %q = %v, want nil", key, gotVal)
+					}
+					continue
+				}
+				// Compare as strings for simplicity (handles float formatting)
+				gotStr := fmt.Sprintf("%v", gotVal)
+				wantStr := fmt.Sprintf("%v", wantVal)
+				if gotStr != wantStr {
+					t.Errorf("key %q = %v, want %v", key, gotVal, wantVal)
+				}
+			}
+		})
+	}
+}
+
+func mapKeys(m map[string]interface{}) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	return keys
+}
+
+// ---------------------------------------------------------------------------
+// TestBuildCellsetRows — unit tests for the buildCellsetRows function
+// ---------------------------------------------------------------------------
+
+func TestBuildCellsetRows(t *testing.T) {
+	tests := []struct {
+		name        string
+		resp        model.CellsetResponse
+		wantHeaders []string
+		wantRows    [][]string
+		wantNil     bool
+	}{
+		{
+			name: "normal 2-axis data",
+			resp: model.CellsetResponse{
+				Axes: []model.CellsetAxis{
+					{Ordinal: 0, Tuples: []model.CellsetTuple{
+						{Ordinal: 0, Members: []model.CellsetMember{{Name: "Jan"}}},
+						{Ordinal: 1, Members: []model.CellsetMember{{Name: "Feb"}}},
+					}},
+					{Ordinal: 1, Tuples: []model.CellsetTuple{
+						{Ordinal: 0, Members: []model.CellsetMember{{Name: "Revenue"}}},
+						{Ordinal: 1, Members: []model.CellsetMember{{Name: "Cost"}}},
+					}},
+				},
+				Cells: []model.CellsetCell{
+					{Ordinal: 0, Value: 100.0},
+					{Ordinal: 1, Value: 200.0},
+					{Ordinal: 2, Value: 50.0},
+					{Ordinal: 3, Value: 80.0},
+				},
+			},
+			wantHeaders: []string{"DIM1", "Jan", "Feb"},
+			wantRows: [][]string{
+				{"Revenue", "100", "200"},
+				{"Cost", "50", "80"},
+			},
+		},
+		{
+			name: "multi-member column headers",
+			resp: model.CellsetResponse{
+				Axes: []model.CellsetAxis{
+					{Ordinal: 0, Tuples: []model.CellsetTuple{
+						{Ordinal: 0, Members: []model.CellsetMember{{Name: "Jan"}, {Name: "Actual"}}},
+					}},
+					{Ordinal: 1, Tuples: []model.CellsetTuple{
+						{Ordinal: 0, Members: []model.CellsetMember{{Name: "Revenue"}}},
+					}},
+				},
+				Cells: []model.CellsetCell{
+					{Ordinal: 0, Value: 100.0},
+				},
+			},
+			wantHeaders: []string{"DIM1", "Jan / Actual"},
+			wantRows:    [][]string{{"Revenue", "100"}},
+		},
+		{
+			name: "multi-member row headers",
+			resp: model.CellsetResponse{
+				Axes: []model.CellsetAxis{
+					{Ordinal: 0, Tuples: []model.CellsetTuple{
+						{Ordinal: 0, Members: []model.CellsetMember{{Name: "Q1"}}},
+					}},
+					{Ordinal: 1, Tuples: []model.CellsetTuple{
+						{Ordinal: 0, Members: []model.CellsetMember{{Name: "US"}, {Name: "Revenue"}}},
+					}},
+				},
+				Cells: []model.CellsetCell{
+					{Ordinal: 0, Value: 500.0},
+				},
+			},
+			wantHeaders: []string{"DIM1", "DIM2", "Q1"},
+			wantRows:    [][]string{{"US", "Revenue", "500"}},
+		},
+		{
+			name: "null cell values as empty strings",
+			resp: model.CellsetResponse{
+				Axes: []model.CellsetAxis{
+					{Ordinal: 0, Tuples: []model.CellsetTuple{
+						{Ordinal: 0, Members: []model.CellsetMember{{Name: "Jan"}}},
+					}},
+					{Ordinal: 1, Tuples: []model.CellsetTuple{
+						{Ordinal: 0, Members: []model.CellsetMember{{Name: "Sales"}}},
+					}},
+				},
+				Cells: []model.CellsetCell{
+					{Ordinal: 0, Value: nil},
+				},
+			},
+			wantHeaders: []string{"DIM1", "Jan"},
+			wantRows:    [][]string{{"Sales", ""}},
+		},
+		{
+			name: "fewer than 2 axes returns nil",
+			resp: model.CellsetResponse{
+				Axes:  []model.CellsetAxis{{Ordinal: 0}},
+				Cells: nil,
+			},
+			wantNil: true,
+		},
+		{
+			name: "0 column tuples returns nil",
+			resp: model.CellsetResponse{
+				Axes: []model.CellsetAxis{
+					{Ordinal: 0, Tuples: []model.CellsetTuple{}},
+					{Ordinal: 1, Tuples: []model.CellsetTuple{
+						{Ordinal: 0, Members: []model.CellsetMember{{Name: "Row1"}}},
+					}},
+				},
+				Cells: nil,
+			},
+			wantNil: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			headers, rows := buildCellsetRows(tt.resp)
+
+			if tt.wantNil {
+				if headers != nil || rows != nil {
+					t.Errorf("expected nil, got headers=%v rows=%v", headers, rows)
+				}
+				return
+			}
+
+			if len(headers) != len(tt.wantHeaders) {
+				t.Fatalf("headers length = %d, want %d", len(headers), len(tt.wantHeaders))
+			}
+			for i, h := range headers {
+				if h != tt.wantHeaders[i] {
+					t.Errorf("headers[%d] = %q, want %q", i, h, tt.wantHeaders[i])
+				}
+			}
+
+			if len(rows) != len(tt.wantRows) {
+				t.Fatalf("rows length = %d, want %d", len(rows), len(tt.wantRows))
+			}
+			for i, row := range rows {
+				if len(row) != len(tt.wantRows[i]) {
+					t.Fatalf("rows[%d] length = %d, want %d", i, len(row), len(tt.wantRows[i]))
+				}
+				for j, v := range row {
+					if v != tt.wantRows[i][j] {
+						t.Errorf("rows[%d][%d] = %q, want %q", i, j, v, tt.wantRows[i][j])
+					}
+				}
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestWriteCSV — unit tests for the writeCSV function
+// ---------------------------------------------------------------------------
+
+func TestWriteCSV(t *testing.T) {
+	resp := model.CellsetResponse{
+		Axes: []model.CellsetAxis{
+			{Ordinal: 0, Tuples: []model.CellsetTuple{
+				{Ordinal: 0, Members: []model.CellsetMember{{Name: "Jan"}}},
+				{Ordinal: 1, Members: []model.CellsetMember{{Name: "Feb"}}},
+			}},
+			{Ordinal: 1, Tuples: []model.CellsetTuple{
+				{Ordinal: 0, Members: []model.CellsetMember{{Name: "Revenue"}}},
+				{Ordinal: 1, Members: []model.CellsetMember{{Name: "Cost"}}},
+			}},
+		},
+		Cells: []model.CellsetCell{
+			{Ordinal: 0, Value: 1000.0},
+			{Ordinal: 1, Value: 2000.0},
+			{Ordinal: 2, Value: 500.0},
+			{Ordinal: 3, Value: 800.0},
+		},
+	}
+
+	t.Run("writes CSV with headers", func(t *testing.T) {
+		outFile := filepath.Join(t.TempDir(), "out.csv")
+
+		captured := captureAll(t, func() {
+			err := writeCSV(resp, outFile, false)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+
+		// Verify success message on stderr
+		if !strings.Contains(captured.Stderr, "Exported 2 rows") {
+			t.Errorf("stderr should contain export summary, got: %s", captured.Stderr)
+		}
+
+		// Read and parse CSV
+		f, err := os.Open(outFile)
+		if err != nil {
+			t.Fatalf("cannot open output file: %v", err)
+		}
+		defer f.Close()
+
+		records, err := csv.NewReader(f).ReadAll()
+		if err != nil {
+			t.Fatalf("cannot parse CSV: %v", err)
+		}
+
+		// 1 header + 2 data rows = 3 total
+		if len(records) != 3 {
+			t.Fatalf("expected 3 CSV records, got %d", len(records))
+		}
+
+		// Check header
+		wantHeader := []string{"DIM1", "Jan", "Feb"}
+		for i, h := range records[0] {
+			if h != wantHeader[i] {
+				t.Errorf("header[%d] = %q, want %q", i, h, wantHeader[i])
+			}
+		}
+
+		// Check data
+		if records[1][0] != "Revenue" || records[1][1] != "1000" || records[1][2] != "2000" {
+			t.Errorf("row 1 = %v, want [Revenue 1000 2000]", records[1])
+		}
+		if records[2][0] != "Cost" || records[2][1] != "500" || records[2][2] != "800" {
+			t.Errorf("row 2 = %v, want [Cost 500 800]", records[2])
+		}
+	})
+
+	t.Run("writes CSV without headers when noHeader is true", func(t *testing.T) {
+		outFile := filepath.Join(t.TempDir(), "out.csv")
+
+		captureAll(t, func() {
+			err := writeCSV(resp, outFile, true)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+
+		f, err := os.Open(outFile)
+		if err != nil {
+			t.Fatalf("cannot open output file: %v", err)
+		}
+		defer f.Close()
+
+		records, err := csv.NewReader(f).ReadAll()
+		if err != nil {
+			t.Fatalf("cannot parse CSV: %v", err)
+		}
+
+		// 2 data rows, no header
+		if len(records) != 2 {
+			t.Fatalf("expected 2 CSV records (no header), got %d", len(records))
+		}
+		if records[0][0] != "Revenue" {
+			t.Errorf("first row should be data, got: %v", records[0])
+		}
+	})
+
+	t.Run("empty cellset prints message and creates no file", func(t *testing.T) {
+		outFile := filepath.Join(t.TempDir(), "out.csv")
+		emptyResp := model.CellsetResponse{
+			Axes:  []model.CellsetAxis{{Ordinal: 0}},
+			Cells: nil,
+		}
+
+		captured := captureAll(t, func() {
+			err := writeCSV(emptyResp, outFile, false)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+
+		if !strings.Contains(captured.Stderr, "No data to export") {
+			t.Errorf("stderr should contain 'No data to export', got: %s", captured.Stderr)
+		}
+
+		if _, err := os.Stat(outFile); err == nil {
+			t.Error("file should not be created for empty cellset")
+		}
+	})
+
+	t.Run("returns error for invalid path", func(t *testing.T) {
+		badPath := filepath.Join(t.TempDir(), "nonexistent", "subdir", "out.csv")
+
+		captureAll(t, func() {
+			err := writeCSV(resp, badPath, false)
+			if err == nil {
+				t.Fatal("expected error for invalid path, got nil")
+			}
+			if !strings.Contains(err.Error(), "Cannot create file") {
+				t.Errorf("error should mention file creation, got: %s", err.Error())
+			}
+		})
+	})
+}
+
+// ===========================================================================
+// TestRunExport_JSONFile — integration tests for JSON file output
+// ===========================================================================
+
+func TestRunExport_JSONFile(t *testing.T) {
+	resetCmdFlags(t)
+	exportView = "Default"
+
+	outFile := filepath.Join(t.TempDir(), "export.json")
+	exportOut = outFile
+
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(cellsetResponseJSON())
+	})
+
+	captured := captureAll(t, func() {
+		err := runExport(exportCmd, []string{"Sales"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	// File should exist
+	data, err := os.ReadFile(outFile)
+	if err != nil {
+		t.Fatalf("cannot read output file: %v", err)
+	}
+
+	// Should be valid JSON array
+	var records []map[string]interface{}
+	if err := json.Unmarshal(data, &records); err != nil {
+		t.Fatalf("output file is not valid JSON array: %v\ncontents: %s", err, string(data))
+	}
+
+	// Should have 2 records (Revenue and Cost rows)
+	if len(records) != 2 {
+		t.Fatalf("expected 2 records, got %d", len(records))
+	}
+
+	// First record should be Revenue row
+	first := records[0]
+	if first["DIM1"] != "Revenue" {
+		t.Errorf("first record DIM1 = %v, want Revenue", first["DIM1"])
+	}
+	// JSON numbers unmarshal as float64
+	if first["Jan"] != 1000.0 {
+		t.Errorf("first record Jan = %v, want 1000", first["Jan"])
+	}
+	if first["Feb"] != 2000.0 {
+		t.Errorf("first record Feb = %v, want 2000", first["Feb"])
+	}
+
+	// Second record should be Cost row
+	second := records[1]
+	if second["DIM1"] != "Cost" {
+		t.Errorf("second record DIM1 = %v, want Cost", second["DIM1"])
+	}
+	if second["Jan"] != 500.0 {
+		t.Errorf("second record Jan = %v, want 500", second["Jan"])
+	}
+
+	// Stderr should contain success message
+	if !strings.Contains(captured.Stderr, "Wrote 2 records") {
+		t.Errorf("stderr should contain success message, got:\n%s", captured.Stderr)
+	}
+	if !strings.Contains(captured.Stderr, outFile) {
+		t.Errorf("stderr should contain file path, got:\n%s", captured.Stderr)
+	}
+
+	// Stdout should be empty (output goes to file, not stdout)
+	if strings.TrimSpace(captured.Stdout) != "" {
+		t.Errorf("stdout should be empty when writing to file, got:\n%s", captured.Stdout)
+	}
+}
+
+func TestRunExport_JSONFileInvalidPath(t *testing.T) {
+	resetCmdFlags(t)
+	exportView = "Default"
+	exportOut = "/nonexistent/dir/export.json"
+
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(cellsetResponseJSON())
+	})
+
+	captured := captureAll(t, func() {
+		err := runExport(exportCmd, []string{"Sales"})
+		if err != errSilent {
+			t.Fatalf("expected errSilent, got: %v", err)
+		}
+	})
+
+	if !strings.Contains(captured.Stderr, "Cannot write file") {
+		t.Errorf("stderr should contain 'Cannot write file', got:\n%s", captured.Stderr)
+	}
+}
+
+func TestRunExport_JSONFileOverwrite(t *testing.T) {
+	resetCmdFlags(t)
+	exportView = "Default"
+
+	outFile := filepath.Join(t.TempDir(), "export.json")
+	exportOut = outFile
+
+	// Write existing content to the file
+	os.WriteFile(outFile, []byte("old content"), 0644)
+
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(cellsetResponseJSON())
+	})
+
+	captureAll(t, func() {
+		err := runExport(exportCmd, []string{"Sales"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	// File should be overwritten with valid JSON
+	data, err := os.ReadFile(outFile)
+	if err != nil {
+		t.Fatalf("cannot read output file: %v", err)
+	}
+
+	var records []map[string]interface{}
+	if err := json.Unmarshal(data, &records); err != nil {
+		t.Fatalf("overwritten file is not valid JSON: %v", err)
+	}
+	if len(records) != 2 {
+		t.Errorf("expected 2 records after overwrite, got %d", len(records))
+	}
+}
+
+func TestRunExport_JSONFileEmptyCellset(t *testing.T) {
+	resetCmdFlags(t)
+	exportView = "Default"
+
+	outFile := filepath.Join(t.TempDir(), "empty.json")
+	exportOut = outFile
+
+	// Return a cellset with fewer than 2 axes
+	emptyResp := model.CellsetResponse{
+		Axes:  []model.CellsetAxis{{Ordinal: 0}},
+		Cells: nil,
+	}
+	emptyData, _ := json.Marshal(emptyResp)
+
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(emptyData)
+	})
+
+	captured := captureAll(t, func() {
+		err := runExport(exportCmd, []string{"Sales"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	data, err := os.ReadFile(outFile)
+	if err != nil {
+		t.Fatalf("cannot read output file: %v", err)
+	}
+
+	// Should be an empty JSON array
+	var records []map[string]interface{}
+	if err := json.Unmarshal(data, &records); err != nil {
+		t.Fatalf("output is not valid JSON: %v\ncontents: %s", err, string(data))
+	}
+	if len(records) != 0 {
+		t.Errorf("expected 0 records for empty cellset, got %d", len(records))
+	}
+
+	// Stderr should say 0 records
+	if !strings.Contains(captured.Stderr, "Wrote 0 records") {
+		t.Errorf("stderr should contain 'Wrote 0 records', got:\n%s", captured.Stderr)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Integration tests — CSV file export via runExport
+// ---------------------------------------------------------------------------
+
+func TestRunExport_CSVFile(t *testing.T) {
+	resetCmdFlags(t)
+	exportView = "Default"
+
+	outFile := filepath.Join(t.TempDir(), "report.csv")
+	exportOut = outFile
+
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(cellsetResponseJSON())
+	})
+
+	captured := captureAll(t, func() {
+		err := runExport(exportCmd, []string{"Sales"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	// Verify success message
+	if !strings.Contains(captured.Stderr, "Exported") {
+		t.Errorf("stderr should contain export message, got: %s", captured.Stderr)
+	}
+
+	// Nothing on stdout (file output, not screen)
+	if strings.TrimSpace(captured.Stdout) != "" {
+		t.Errorf("stdout should be empty for file output, got: %s", captured.Stdout)
+	}
+
+	// Read and verify CSV
+	f, err := os.Open(outFile)
+	if err != nil {
+		t.Fatalf("cannot open output file: %v", err)
+	}
+	defer f.Close()
+
+	records, err := csv.NewReader(f).ReadAll()
+	if err != nil {
+		t.Fatalf("cannot parse CSV: %v", err)
+	}
+
+	if len(records) != 3 { // 1 header + 2 data
+		t.Fatalf("expected 3 records, got %d", len(records))
+	}
+	if records[0][0] != "DIM1" {
+		t.Errorf("header[0] = %q, want DIM1", records[0][0])
+	}
+	if records[1][1] != "1000" {
+		t.Errorf("Revenue/Jan = %q, want 1000", records[1][1])
+	}
+}
+
+func TestRunExport_CSVNoHeader(t *testing.T) {
+	resetCmdFlags(t)
+	exportView = "Default"
+
+	outFile := filepath.Join(t.TempDir(), "report.csv")
+	exportOut = outFile
+	exportNoHeader = true
+
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(cellsetResponseJSON())
+	})
+
+	captureAll(t, func() {
+		err := runExport(exportCmd, []string{"Sales"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	f, err := os.Open(outFile)
+	if err != nil {
+		t.Fatalf("cannot open output file: %v", err)
+	}
+	defer f.Close()
+
+	records, err := csv.NewReader(f).ReadAll()
+	if err != nil {
+		t.Fatalf("cannot parse CSV: %v", err)
+	}
+
+	// 2 data rows only, no header
+	if len(records) != 2 {
+		t.Fatalf("expected 2 records (no header), got %d", len(records))
+	}
+	if records[0][0] != "Revenue" {
+		t.Errorf("first row should be data, got: %v", records[0])
+	}
+}
+
+func TestRunExport_CSVServerError(t *testing.T) {
+	resetCmdFlags(t)
+	exportView = "Default"
+
+	outFile := filepath.Join(t.TempDir(), "report.csv")
+	exportOut = outFile
+
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		w.Write([]byte(`View not found`))
+	})
+
+	captured := captureAll(t, func() {
+		err := runExport(exportCmd, []string{"Sales"})
+		if err != errSilent {
+			t.Fatalf("expected errSilent, got: %v", err)
+		}
+	})
+
+	if !strings.Contains(captured.Stderr, "Not found") {
+		t.Errorf("stderr should contain error, got: %s", captured.Stderr)
+	}
+
+	// File should not be created
+	if _, err := os.Stat(outFile); err == nil {
+		t.Error("CSV file should not be created on server error")
 	}
 }


### PR DESCRIPTION
## Summary

The v0.1.1 CSV and JSON export implementations were lost during the dev→main conflict resolution. This restores the full export functionality.

## Test plan

- [x] `go test ./...` passes
- [x] `-o report.csv` writes CSV file
- [x] `-o data.json` writes JSON file
- [x] `--no-header` excludes header in CSV