### PR TITLE
fix: use POST for view execute and add regression tests

### DIFF
--- a/cmd/export.go
+++ b/cmd/export.go
@@ -27,7 +27,7 @@ var exportCmd = &cobra.Command{
 
 Equivalent to: File → Export in TM1 Architect
                or Export View in PAW
-REST API:      GET /Cubes('name')/Views('view')/tm1.Execute
+REST API:      POST /Cubes('name')/Views('view')/tm1.Execute
                POST /ExecuteMDX`,
 	Example: `  tm1cli export "Sales" --view "Default"
   tm1cli export "Sales" --view "Default" -o report.csv
@@ -75,7 +75,7 @@ func runExport(cmd *cobra.Command, args []string) error {
 
 	endpoint := fmt.Sprintf("Cubes('%s')/Views('%s')/tm1.Execute?$expand=Axes($expand=Tuples($expand=Members($select=Name))),Cells($select=Value,Ordinal)", url.PathEscape(cubeName), url.PathEscape(exportView))
 
-	data, err := cl.Get(endpoint)
+	data, err := cl.Post(endpoint, map[string]interface{}{})
 	if err != nil {
 		output.PrintError(err.Error(), jsonMode)
 		return errSilent

--- a/cmd/export_test.go
+++ b/cmd/export_test.go
@@ -1448,6 +1448,53 @@ func TestRunExport_CSVNoHeader(t *testing.T) {
 	}
 }
 
+func TestRunExport_UsesPOSTNotGET(t *testing.T) {
+	resetCmdFlags(t)
+	exportView = "Default"
+
+	var capturedMethod string
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		capturedMethod = r.Method
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(cellsetResponseJSON())
+	})
+
+	captureAll(t, func() {
+		err := runExport(exportCmd, []string{"Sales"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	if capturedMethod != "POST" {
+		t.Errorf("export should use POST for tm1.Execute, got %q", capturedMethod)
+	}
+}
+
+func TestRunExport_CSVUsesPOST(t *testing.T) {
+	resetCmdFlags(t)
+	exportView = "Default"
+	exportOut = filepath.Join(t.TempDir(), "out.csv")
+
+	var capturedMethod string
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		capturedMethod = r.Method
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(cellsetResponseJSON())
+	})
+
+	captureAll(t, func() {
+		err := runExport(exportCmd, []string{"Sales"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	if capturedMethod != "POST" {
+		t.Errorf("CSV export should use POST for tm1.Execute, got %q", capturedMethod)
+	}
+}
+
 func TestRunExport_CSVServerError(t *testing.T) {
 	resetCmdFlags(t)
 	exportView = "Default"

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -76,6 +76,52 @@ func TestNewClient(t *testing.T) {
 	}
 }
 
+func TestNewClientAutoAppendsApiV1(t *testing.T) {
+	tests := []struct {
+		name    string
+		url     string
+		wantURL string
+	}{
+		{
+			name:    "bare host:port gets /api/v1 appended",
+			url:     "http://localhost:8010",
+			wantURL: "http://localhost:8010/api/v1",
+		},
+		{
+			name:    "bare host:port with trailing slash",
+			url:     "http://localhost:8010/",
+			wantURL: "http://localhost:8010/api/v1",
+		},
+		{
+			name:    "already has /api/v1",
+			url:     "https://server:8010/api/v1",
+			wantURL: "https://server:8010/api/v1",
+		},
+		{
+			name:    "already has /api/v1 with trailing slash",
+			url:     "https://server:8010/api/v1/",
+			wantURL: "https://server:8010/api/v1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := config.ServerConfig{
+				URL:      tt.url,
+				User:     "admin",
+				AuthMode: "basic",
+			}
+			c, err := NewClient(srv, "pass", false, false)
+			if err != nil {
+				t.Fatalf("NewClient failed: %v", err)
+			}
+			if c.baseURL != tt.wantURL {
+				t.Errorf("baseURL = %q, want %q", c.baseURL, tt.wantURL)
+			}
+		})
+	}
+}
+
 func TestGet(t *testing.T) {
 	tests := []struct {
 		name        string


### PR DESCRIPTION
## Summary

- Fix export to use POST instead of GET for `tm1.Execute` (TM1 rejects GET on action endpoints)
- Restore `/api/v1` auto-append lost during merge conflict
- Add regression tests for both bugs

## New tests

- `TestRunExport_UsesPOSTNotGET` — verifies screen export uses POST
- `TestRunExport_CSVUsesPOST` — verifies CSV file export uses POST
- `TestNewClientAutoAppendsApiV1` — 4 cases: bare URL, trailing slash, already has `/api/v1`, with trailing slash

## Test plan

- [x] `go test ./...` passes (all packages)
- [x] Tested manually: `tm1cli export "General Ledger" --view "Default"` works