### PR TITLE
feat(#19): add MDX query support to export command

### DIFF
--- a/cmd/export.go
+++ b/cmd/export.go
@@ -7,11 +7,14 @@ import (
 	"net/url"
 	"os"
 	"strings"
+	"tm1cli/internal/client"
 	"tm1cli/internal/model"
 	"tm1cli/internal/output"
 
 	"github.com/spf13/cobra"
 )
+
+const mdxCellPageSize = 10000
 
 var (
 	exportView     string
@@ -21,32 +24,48 @@ var (
 )
 
 var exportCmd = &cobra.Command{
-	Use:   "export <cube>",
+	Use:   "export [cube]",
 	Short: "Export cube data to screen or file",
 	Long: `Export cube data to screen or file.
 
 Equivalent to: File → Export in TM1 Architect
                or Export View in PAW
 REST API:      POST /Cubes('name')/Views('view')/tm1.Execute
-               POST /ExecuteMDX`,
-	Example: `  tm1cli export "Sales" --view "Default"
+               POST /ExecuteMDX
+
+Use --view with a cube name to export a saved view.
+Use --mdx to export using an MDX query (cube name is optional).`,
+	Example: `  # View-based export
+  tm1cli export "Sales" --view "Default"
   tm1cli export "Sales" --view "Default" -o report.csv
   tm1cli export "Sales" --view "Default" -o report.json
-  tm1cli export "Sales" --view "Default" --output json`,
-	Args: cobra.ExactArgs(1),
+
+  # MDX-based export
+  tm1cli export --mdx "SELECT {[Period].[Jan]} ON COLUMNS, {[Measure].[Revenue]} ON ROWS FROM [Sales]"
+  tm1cli export --mdx "SELECT ... FROM [Sales]" -o report.csv`,
+	Args: cobra.RangeArgs(0, 1),
 	RunE: runExport,
 }
 
 func runExport(cmd *cobra.Command, args []string) error {
-	cubeName := args[0]
-
-	if exportView == "" && exportMDX == "" {
-		return fmt.Errorf("Specify --view or --mdx. Example: tm1cli export \"%s\" --view \"Default\"", cubeName)
+	cubeName := ""
+	if len(args) > 0 {
+		cubeName = args[0]
 	}
 
-	// TODO: Phase 2 — MDX export
-	if exportMDX != "" {
-		return fmt.Errorf("MDX export is not yet implemented (coming in v0.2.0). Use --view instead.")
+	if exportView == "" && exportMDX == "" {
+		if cubeName != "" {
+			return fmt.Errorf("Specify --view or --mdx. Example: tm1cli export \"%s\" --view \"Default\"", cubeName)
+		}
+		return fmt.Errorf("Specify --view or --mdx. Example: tm1cli export \"MyCube\" --view \"Default\"")
+	}
+
+	if exportView != "" && exportMDX != "" {
+		return fmt.Errorf("Specify --view or --mdx, not both.")
+	}
+
+	if exportView != "" && cubeName == "" {
+		return fmt.Errorf("Cube name is required with --view. Example: tm1cli export \"MyCube\" --view \"Default\"")
 	}
 
 	// Validate file extension before doing any network calls
@@ -73,6 +92,14 @@ func runExport(cmd *cobra.Command, args []string) error {
 		return errSilent
 	}
 
+	if exportMDX != "" {
+		return runMDXExport(cl, jsonMode)
+	}
+
+	return runViewExport(cl, cubeName, jsonMode)
+}
+
+func runViewExport(cl *client.Client, cubeName string, jsonMode bool) error {
 	endpoint := fmt.Sprintf("Cubes('%s')/Views('%s')/tm1.Execute?$expand=Axes($expand=Tuples($expand=Members($select=Name))),Cells($select=Value,Ordinal)", url.PathEscape(cubeName), url.PathEscape(exportView))
 
 	data, err := cl.Post(endpoint, map[string]interface{}{})
@@ -87,6 +114,83 @@ func runExport(cmd *cobra.Command, args []string) error {
 		return errSilent
 	}
 
+	return outputCellset(resp, jsonMode)
+}
+
+func runMDXExport(cl *client.Client, jsonMode bool) error {
+	// Step 1: Execute MDX — expand axes only, fetch cells separately for pagination
+	endpoint := "ExecuteMDX?$expand=Axes($expand=Tuples($expand=Members($select=Name)))"
+	payload := map[string]interface{}{"MDX": exportMDX}
+
+	data, err := cl.Post(endpoint, payload)
+	if err != nil {
+		output.PrintError(err.Error(), jsonMode)
+		return errSilent
+	}
+
+	var resp model.CellsetResponse
+	if err := json.Unmarshal(data, &resp); err != nil {
+		output.PrintError("Cannot parse cellset response.", jsonMode)
+		return errSilent
+	}
+
+	if resp.ID == "" {
+		output.PrintError("Server did not return a cellset ID.", jsonMode)
+		return errSilent
+	}
+
+	// Step 2: Clean up cellset when done (runs even on error)
+	defer func() {
+		_ = cl.Delete(fmt.Sprintf("Cellsets('%s')", resp.ID))
+	}()
+
+	// Step 3: Calculate expected total cells for progress display
+	totalCells := 1
+	for _, axis := range resp.Axes {
+		totalCells *= len(axis.Tuples)
+	}
+
+	// Step 4: Fetch cells in pages
+	var allCells []model.CellsetCell
+	for skip := 0; ; skip += mdxCellPageSize {
+		cellsEndpoint := fmt.Sprintf("Cellsets('%s')/Cells?$select=Value,Ordinal&$top=%d&$skip=%d",
+			resp.ID, mdxCellPageSize, skip)
+
+		cellData, err := cl.Get(cellsEndpoint)
+		if err != nil {
+			output.PrintError(err.Error(), jsonMode)
+			return errSilent
+		}
+
+		var cellResp struct {
+			Value []model.CellsetCell `json:"value"`
+		}
+		if err := json.Unmarshal(cellData, &cellResp); err != nil {
+			output.PrintError("Cannot parse cells response.", jsonMode)
+			return errSilent
+		}
+
+		allCells = append(allCells, cellResp.Value...)
+
+		// Show progress for large exports (more than one page)
+		if totalCells > mdxCellPageSize {
+			fetched := len(allCells)
+			if fetched > totalCells {
+				fetched = totalCells
+			}
+			fmt.Fprintf(os.Stderr, "Fetching cells: %d / %d\n", fetched, totalCells)
+		}
+
+		if len(cellResp.Value) < mdxCellPageSize {
+			break
+		}
+	}
+
+	resp.Cells = allCells
+	return outputCellset(resp, jsonMode)
+}
+
+func outputCellset(resp model.CellsetResponse, jsonMode bool) error {
 	// JSON file output
 	if strings.HasSuffix(strings.ToLower(exportOut), ".json") {
 		records := cellsetToRecords(resp)
@@ -295,7 +399,7 @@ func writeCSV(resp model.CellsetResponse, filePath string, noHeader bool) error 
 func init() {
 	rootCmd.AddCommand(exportCmd)
 	exportCmd.Flags().StringVar(&exportView, "view", "", "Saved view name")
-	exportCmd.Flags().StringVar(&exportMDX, "mdx", "", "MDX query string (v0.2.0)")
+	exportCmd.Flags().StringVar(&exportMDX, "mdx", "", "MDX query string")
 	exportCmd.Flags().StringVarP(&exportOut, "out", "o", "", "Output file path (.csv, .json)")
 	exportCmd.Flags().BoolVar(&exportNoHeader, "no-header", false, "Exclude header row from CSV output")
 }

--- a/cmd/export.go
+++ b/cmd/export.go
@@ -151,7 +151,7 @@ func runMDXExport(cl *client.Client, jsonMode bool) error {
 	}
 
 	// Step 4: Fetch cells in pages
-	var allCells []model.CellsetCell
+	allCells := make([]model.CellsetCell, 0, totalCells)
 	for skip := 0; ; skip += mdxCellPageSize {
 		cellsEndpoint := fmt.Sprintf("Cellsets('%s')/Cells?$select=Value,Ordinal&$top=%d&$skip=%d",
 			resp.ID, mdxCellPageSize, skip)
@@ -162,9 +162,7 @@ func runMDXExport(cl *client.Client, jsonMode bool) error {
 			return errSilent
 		}
 
-		var cellResp struct {
-			Value []model.CellsetCell `json:"value"`
-		}
+		var cellResp model.CellsCollectionResponse
 		if err := json.Unmarshal(cellData, &cellResp); err != nil {
 			output.PrintError("Cannot parse cells response.", jsonMode)
 			return errSilent

--- a/cmd/export.go
+++ b/cmd/export.go
@@ -202,7 +202,11 @@ func outputCellset(resp model.CellsetResponse, jsonMode bool) error {
 
 	// CSV file output
 	if strings.HasSuffix(strings.ToLower(exportOut), ".csv") {
-		return writeCSV(resp, exportOut, exportNoHeader)
+		if err := writeCSV(resp, exportOut, exportNoHeader); err != nil {
+			output.PrintError(err.Error(), jsonMode)
+			return errSilent
+		}
+		return nil
 	}
 
 	if jsonMode {

--- a/cmd/export_test.go
+++ b/cmd/export_test.go
@@ -317,11 +317,6 @@ func TestRunExportStubs(t *testing.T) {
 		wantErr string
 	}{
 		{
-			name:    "mdx flag returns v0.2.0 message",
-			args:    []string{"export", "Sales", "--mdx", "SELECT {[Measures].Members} ON COLUMNS FROM [Sales]"},
-			wantErr: "coming in v0.2.0",
-		},
-		{
 			name:    "out xlsx returns v0.2.0 message",
 			args:    []string{"export", "Sales", "--view", "Default", "--out", "report.xlsx"},
 			wantErr: "coming in v0.2.0",
@@ -1521,5 +1516,683 @@ func TestRunExport_CSVServerError(t *testing.T) {
 	// File should not be created
 	if _, err := os.Stat(outFile); err == nil {
 		t.Error("CSV file should not be created on server error")
+	}
+}
+
+// ===========================================================================
+// MDX Export Tests — helpers
+// ===========================================================================
+
+// mdxResponseJSON returns a mock ExecuteMDX response with ID and axes (no cells).
+func mdxResponseJSON(id string) []byte {
+	resp := model.CellsetResponse{
+		ID: id,
+		Axes: []model.CellsetAxis{
+			{
+				Ordinal: 0,
+				Tuples: []model.CellsetTuple{
+					{Ordinal: 0, Members: []model.CellsetMember{{Name: "Jan"}}},
+					{Ordinal: 1, Members: []model.CellsetMember{{Name: "Feb"}}},
+				},
+			},
+			{
+				Ordinal: 1,
+				Tuples: []model.CellsetTuple{
+					{Ordinal: 0, Members: []model.CellsetMember{{Name: "Revenue"}}},
+					{Ordinal: 1, Members: []model.CellsetMember{{Name: "Cost"}}},
+				},
+			},
+		},
+	}
+	data, _ := json.Marshal(resp)
+	return data
+}
+
+// cellsCollectionJSON returns a mock TM1 cells collection response.
+func cellsCollectionJSON(cells []model.CellsetCell) []byte {
+	resp := struct {
+		Value []model.CellsetCell `json:"value"`
+	}{Value: cells}
+	data, _ := json.Marshal(resp)
+	return data
+}
+
+var testMDXCells = []model.CellsetCell{
+	{Ordinal: 0, Value: 1000.0},
+	{Ordinal: 1, Value: 2000.0},
+	{Ordinal: 2, Value: 500.0},
+	{Ordinal: 3, Value: 800.0},
+}
+
+// ===========================================================================
+// MDX Export Tests — integration tests
+// ===========================================================================
+
+func TestRunExport_MDXToScreen(t *testing.T) {
+	resetCmdFlags(t)
+	exportMDX = "SELECT {[Period].[Jan],[Period].[Feb]} ON COLUMNS, {[Measure].Members} ON ROWS FROM [Sales]"
+
+	deleteCalled := false
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == "POST" && strings.Contains(r.URL.Path, "ExecuteMDX"):
+			w.Header().Set("Content-Type", "application/json")
+			w.Write(mdxResponseJSON("test-cellset-id"))
+		case r.Method == "GET" && strings.Contains(r.URL.Path, "/Cells"):
+			w.Header().Set("Content-Type", "application/json")
+			w.Write(cellsCollectionJSON(testMDXCells))
+		case r.Method == "DELETE" && strings.Contains(r.URL.Path, "Cellsets"):
+			deleteCalled = true
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+
+	captured := captureAll(t, func() {
+		err := runExport(exportCmd, []string{})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	// Should contain table output
+	for _, want := range []string{"Jan", "Feb", "Revenue", "Cost", "1000", "2000", "500", "800"} {
+		if !strings.Contains(captured.Stdout, want) {
+			t.Errorf("output missing %q, got:\n%s", want, captured.Stdout)
+		}
+	}
+
+	// Cellset should be cleaned up
+	if !deleteCalled {
+		t.Error("DELETE should be called to clean up cellset")
+	}
+}
+
+func TestRunExport_MDXJSONOutput(t *testing.T) {
+	resetCmdFlags(t)
+	exportMDX = "SELECT ... FROM [Sales]"
+	flagOutput = "json"
+
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == "POST" && strings.Contains(r.URL.Path, "ExecuteMDX"):
+			w.Header().Set("Content-Type", "application/json")
+			w.Write(mdxResponseJSON("test-id"))
+		case r.Method == "GET" && strings.Contains(r.URL.Path, "/Cells"):
+			w.Header().Set("Content-Type", "application/json")
+			w.Write(cellsCollectionJSON(testMDXCells))
+		case r.Method == "DELETE":
+			w.WriteHeader(http.StatusNoContent)
+		}
+	})
+
+	captured := captureAll(t, func() {
+		err := runExport(exportCmd, []string{})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	var resp model.CellsetResponse
+	if err := json.Unmarshal([]byte(captured.Stdout), &resp); err != nil {
+		t.Fatalf("output is not valid JSON: %v\noutput: %s", err, captured.Stdout)
+	}
+	if len(resp.Axes) != 2 {
+		t.Errorf("expected 2 axes, got %d", len(resp.Axes))
+	}
+	if len(resp.Cells) != 4 {
+		t.Errorf("expected 4 cells, got %d", len(resp.Cells))
+	}
+}
+
+func TestRunExport_MDXCSVFile(t *testing.T) {
+	resetCmdFlags(t)
+	exportMDX = "SELECT ... FROM [Sales]"
+
+	outFile := filepath.Join(t.TempDir(), "mdx_export.csv")
+	exportOut = outFile
+
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == "POST" && strings.Contains(r.URL.Path, "ExecuteMDX"):
+			w.Header().Set("Content-Type", "application/json")
+			w.Write(mdxResponseJSON("test-id"))
+		case r.Method == "GET" && strings.Contains(r.URL.Path, "/Cells"):
+			w.Header().Set("Content-Type", "application/json")
+			w.Write(cellsCollectionJSON(testMDXCells))
+		case r.Method == "DELETE":
+			w.WriteHeader(http.StatusNoContent)
+		}
+	})
+
+	captured := captureAll(t, func() {
+		err := runExport(exportCmd, []string{})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	if !strings.Contains(captured.Stderr, "Exported 2 rows") {
+		t.Errorf("stderr should contain export summary, got: %s", captured.Stderr)
+	}
+
+	f, err := os.Open(outFile)
+	if err != nil {
+		t.Fatalf("cannot open output file: %v", err)
+	}
+	defer f.Close()
+
+	records, err := csv.NewReader(f).ReadAll()
+	if err != nil {
+		t.Fatalf("cannot parse CSV: %v", err)
+	}
+
+	if len(records) != 3 { // 1 header + 2 data
+		t.Fatalf("expected 3 records, got %d", len(records))
+	}
+	if records[0][0] != "DIM1" {
+		t.Errorf("header[0] = %q, want DIM1", records[0][0])
+	}
+	if records[1][1] != "1000" {
+		t.Errorf("Revenue/Jan = %q, want 1000", records[1][1])
+	}
+}
+
+func TestRunExport_MDXJSONFile(t *testing.T) {
+	resetCmdFlags(t)
+	exportMDX = "SELECT ... FROM [Sales]"
+
+	outFile := filepath.Join(t.TempDir(), "mdx_export.json")
+	exportOut = outFile
+
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == "POST" && strings.Contains(r.URL.Path, "ExecuteMDX"):
+			w.Header().Set("Content-Type", "application/json")
+			w.Write(mdxResponseJSON("test-id"))
+		case r.Method == "GET" && strings.Contains(r.URL.Path, "/Cells"):
+			w.Header().Set("Content-Type", "application/json")
+			w.Write(cellsCollectionJSON(testMDXCells))
+		case r.Method == "DELETE":
+			w.WriteHeader(http.StatusNoContent)
+		}
+	})
+
+	captured := captureAll(t, func() {
+		err := runExport(exportCmd, []string{})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	if !strings.Contains(captured.Stderr, "Wrote 2 records") {
+		t.Errorf("stderr should contain write summary, got: %s", captured.Stderr)
+	}
+
+	data, err := os.ReadFile(outFile)
+	if err != nil {
+		t.Fatalf("cannot read output file: %v", err)
+	}
+
+	var records []map[string]interface{}
+	if err := json.Unmarshal(data, &records); err != nil {
+		t.Fatalf("output is not valid JSON: %v", err)
+	}
+	if len(records) != 2 {
+		t.Errorf("expected 2 records, got %d", len(records))
+	}
+	if records[0]["DIM1"] != "Revenue" {
+		t.Errorf("first record DIM1 = %v, want Revenue", records[0]["DIM1"])
+	}
+}
+
+func TestRunExport_MDXServerError(t *testing.T) {
+	resetCmdFlags(t)
+	exportMDX = "SELECT INVALID FROM [Sales]"
+
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == "POST" && strings.Contains(r.URL.Path, "ExecuteMDX"):
+			w.WriteHeader(http.StatusBadRequest)
+			w.Write([]byte(`{"error": {"message": "Invalid MDX"}}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+
+	captured := captureAll(t, func() {
+		err := runExport(exportCmd, []string{})
+		if err != errSilent {
+			t.Fatalf("expected errSilent, got: %v", err)
+		}
+	})
+
+	if !strings.Contains(captured.Stderr, "HTTP 400") {
+		t.Errorf("stderr should contain HTTP 400 error, got:\n%s", captured.Stderr)
+	}
+}
+
+func TestRunExport_MDXCellsetCleanupOnError(t *testing.T) {
+	resetCmdFlags(t)
+	exportMDX = "SELECT ... FROM [Sales]"
+
+	deleteCalled := false
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == "POST" && strings.Contains(r.URL.Path, "ExecuteMDX"):
+			w.Header().Set("Content-Type", "application/json")
+			w.Write(mdxResponseJSON("cleanup-test-id"))
+		case r.Method == "GET" && strings.Contains(r.URL.Path, "/Cells"):
+			w.WriteHeader(http.StatusInternalServerError)
+			w.Write([]byte("server error"))
+		case r.Method == "DELETE" && strings.Contains(r.URL.Path, "Cellsets"):
+			deleteCalled = true
+			w.WriteHeader(http.StatusNoContent)
+		}
+	})
+
+	captureAll(t, func() {
+		err := runExport(exportCmd, []string{})
+		if err != errSilent {
+			t.Fatalf("expected errSilent, got: %v", err)
+		}
+	})
+
+	if !deleteCalled {
+		t.Error("DELETE should be called even when cell fetch fails")
+	}
+}
+
+func TestRunExport_MDXEndpoints(t *testing.T) {
+	resetCmdFlags(t)
+	exportMDX = "SELECT {[Period].[Jan]} ON 0, {[Measure].[Revenue]} ON 1 FROM [Sales]"
+
+	var postPath, postBody, getPath, deletePath string
+	var postMethod, getMethod, deleteMethod string
+
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == "POST" && strings.Contains(r.URL.Path, "ExecuteMDX"):
+			postMethod = r.Method
+			postPath = r.URL.Path
+			body := make([]byte, r.ContentLength)
+			r.Body.Read(body)
+			postBody = string(body)
+			w.Header().Set("Content-Type", "application/json")
+			w.Write(mdxResponseJSON("endpoint-test-id"))
+		case r.Method == "GET" && strings.Contains(r.URL.Path, "/Cells"):
+			getMethod = r.Method
+			getPath = r.URL.Path
+			w.Header().Set("Content-Type", "application/json")
+			w.Write(cellsCollectionJSON(testMDXCells))
+		case r.Method == "DELETE":
+			deleteMethod = r.Method
+			deletePath = r.URL.Path
+			w.WriteHeader(http.StatusNoContent)
+		}
+	})
+
+	captureAll(t, func() {
+		err := runExport(exportCmd, []string{})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	// Verify POST to ExecuteMDX
+	if postMethod != "POST" {
+		t.Errorf("ExecuteMDX should use POST, got %q", postMethod)
+	}
+	if !strings.Contains(postPath, "ExecuteMDX") {
+		t.Errorf("POST path should contain ExecuteMDX, got: %s", postPath)
+	}
+	if !strings.Contains(postBody, "MDX") {
+		t.Errorf("POST body should contain MDX key, got: %s", postBody)
+	}
+	if !strings.Contains(postBody, "SELECT") {
+		t.Errorf("POST body should contain the MDX query, got: %s", postBody)
+	}
+
+	// Verify GET cells
+	if getMethod != "GET" {
+		t.Errorf("Cells fetch should use GET, got %q", getMethod)
+	}
+	if !strings.Contains(getPath, "Cellsets('endpoint-test-id')") {
+		t.Errorf("GET path should contain cellset ID, got: %s", getPath)
+	}
+	if !strings.Contains(getPath, "Cells") {
+		t.Errorf("GET path should contain Cells, got: %s", getPath)
+	}
+
+	// Verify DELETE cleanup
+	if deleteMethod != "DELETE" {
+		t.Errorf("Cleanup should use DELETE, got %q", deleteMethod)
+	}
+	if !strings.Contains(deletePath, "Cellsets('endpoint-test-id')") {
+		t.Errorf("DELETE path should contain cellset ID, got: %s", deletePath)
+	}
+}
+
+func TestRunExport_MDXPagination(t *testing.T) {
+	resetCmdFlags(t)
+	exportMDX = "SELECT ... FROM [LargeCube]"
+
+	// Use CSV file output to avoid pipe buffer deadlock with large datasets
+	outFile := filepath.Join(t.TempDir(), "paginated.csv")
+	exportOut = outFile
+
+	// Generate axes that imply 12000 cells (2 cols * 6000 rows)
+	rowTuples := make([]model.CellsetTuple, 6000)
+	for i := range rowTuples {
+		rowTuples[i] = model.CellsetTuple{
+			Ordinal: i,
+			Members: []model.CellsetMember{{Name: fmt.Sprintf("Row%d", i)}},
+		}
+	}
+	mdxResp := model.CellsetResponse{
+		ID: "pagination-test-id",
+		Axes: []model.CellsetAxis{
+			{
+				Ordinal: 0,
+				Tuples: []model.CellsetTuple{
+					{Ordinal: 0, Members: []model.CellsetMember{{Name: "Jan"}}},
+					{Ordinal: 1, Members: []model.CellsetMember{{Name: "Feb"}}},
+				},
+			},
+			{Ordinal: 1, Tuples: rowTuples},
+		},
+	}
+	mdxData, _ := json.Marshal(mdxResp)
+
+	// Generate cells for two pages
+	page1 := make([]model.CellsetCell, mdxCellPageSize)
+	for i := range page1 {
+		page1[i] = model.CellsetCell{Ordinal: i, Value: float64(i)}
+	}
+	page2 := make([]model.CellsetCell, 2000)
+	for i := range page2 {
+		page2[i] = model.CellsetCell{Ordinal: mdxCellPageSize + i, Value: float64(mdxCellPageSize + i)}
+	}
+
+	getCount := 0
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == "POST" && strings.Contains(r.URL.Path, "ExecuteMDX"):
+			w.Header().Set("Content-Type", "application/json")
+			w.Write(mdxData)
+		case r.Method == "GET" && strings.Contains(r.URL.Path, "/Cells"):
+			getCount++
+			w.Header().Set("Content-Type", "application/json")
+			if strings.Contains(r.URL.RawQuery, "skip=0") || !strings.Contains(r.URL.RawQuery, "skip=") {
+				w.Write(cellsCollectionJSON(page1))
+			} else {
+				w.Write(cellsCollectionJSON(page2))
+			}
+		case r.Method == "DELETE":
+			w.WriteHeader(http.StatusNoContent)
+		}
+	})
+
+	captured := captureAll(t, func() {
+		err := runExport(exportCmd, []string{})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	// Should have made 2 GET requests for cells
+	if getCount != 2 {
+		t.Errorf("expected 2 GET requests for cells, got %d", getCount)
+	}
+
+	// Progress should appear on stderr (totalCells=12000 > mdxCellPageSize)
+	if !strings.Contains(captured.Stderr, "Fetching cells:") {
+		t.Errorf("stderr should contain progress output, got:\n%s", captured.Stderr)
+	}
+
+	// CSV file should contain data from both pages
+	f, err := os.Open(outFile)
+	if err != nil {
+		t.Fatalf("cannot open output file: %v", err)
+	}
+	defer f.Close()
+
+	records, err := csv.NewReader(f).ReadAll()
+	if err != nil {
+		t.Fatalf("cannot parse CSV: %v", err)
+	}
+
+	// 1 header + 6000 data rows
+	if len(records) != 6001 {
+		t.Fatalf("expected 6001 CSV records, got %d", len(records))
+	}
+	if records[1][0] != "Row0" {
+		t.Errorf("first data row should be Row0, got: %s", records[1][0])
+	}
+}
+
+func TestRunExport_MDXNoCellsetID(t *testing.T) {
+	resetCmdFlags(t)
+	exportMDX = "SELECT ... FROM [Sales]"
+
+	// Return a response without an ID field
+	noIDResp := model.CellsetResponse{
+		Axes: []model.CellsetAxis{
+			{Ordinal: 0, Tuples: []model.CellsetTuple{
+				{Ordinal: 0, Members: []model.CellsetMember{{Name: "Jan"}}},
+			}},
+			{Ordinal: 1, Tuples: []model.CellsetTuple{
+				{Ordinal: 0, Members: []model.CellsetMember{{Name: "Revenue"}}},
+			}},
+		},
+	}
+	noIDData, _ := json.Marshal(noIDResp)
+
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(noIDData)
+	})
+
+	captured := captureAll(t, func() {
+		err := runExport(exportCmd, []string{})
+		if err != errSilent {
+			t.Fatalf("expected errSilent, got: %v", err)
+		}
+	})
+
+	if !strings.Contains(captured.Stderr, "cellset ID") {
+		t.Errorf("stderr should mention cellset ID, got:\n%s", captured.Stderr)
+	}
+}
+
+func TestRunExport_MDXExactPageSize(t *testing.T) {
+	resetCmdFlags(t)
+	exportMDX = "SELECT ... FROM [Sales]"
+
+	// Use CSV output to avoid pipe buffer issues
+	outFile := filepath.Join(t.TempDir(), "exact.csv")
+	exportOut = outFile
+
+	// Axes imply exactly mdxCellPageSize cells (no progress display expected)
+	rowTuples := make([]model.CellsetTuple, mdxCellPageSize)
+	for i := range rowTuples {
+		rowTuples[i] = model.CellsetTuple{
+			Ordinal: i,
+			Members: []model.CellsetMember{{Name: fmt.Sprintf("R%d", i)}},
+		}
+	}
+	mdxResp := model.CellsetResponse{
+		ID: "exact-page-id",
+		Axes: []model.CellsetAxis{
+			{Ordinal: 0, Tuples: []model.CellsetTuple{
+				{Ordinal: 0, Members: []model.CellsetMember{{Name: "Val"}}},
+			}},
+			{Ordinal: 1, Tuples: rowTuples},
+		},
+	}
+	mdxData, _ := json.Marshal(mdxResp)
+
+	// Return exactly mdxCellPageSize cells — triggers a second GET that returns 0
+	fullPage := make([]model.CellsetCell, mdxCellPageSize)
+	for i := range fullPage {
+		fullPage[i] = model.CellsetCell{Ordinal: i, Value: float64(i)}
+	}
+
+	getCount := 0
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == "POST" && strings.Contains(r.URL.Path, "ExecuteMDX"):
+			w.Header().Set("Content-Type", "application/json")
+			w.Write(mdxData)
+		case r.Method == "GET" && strings.Contains(r.URL.Path, "/Cells"):
+			getCount++
+			w.Header().Set("Content-Type", "application/json")
+			if getCount == 1 {
+				w.Write(cellsCollectionJSON(fullPage))
+			} else {
+				// Second request returns empty — pagination stops
+				w.Write(cellsCollectionJSON(nil))
+			}
+		case r.Method == "DELETE":
+			w.WriteHeader(http.StatusNoContent)
+		}
+	})
+
+	captured := captureAll(t, func() {
+		err := runExport(exportCmd, []string{})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	// Should make 2 GET requests (first returns full page, second returns empty)
+	if getCount != 2 {
+		t.Errorf("expected 2 GET requests, got %d", getCount)
+	}
+
+	// No progress output because totalCells == mdxCellPageSize (not >)
+	if strings.Contains(captured.Stderr, "Fetching cells:") {
+		t.Errorf("should not show progress for single-page results, got:\n%s", captured.Stderr)
+	}
+
+	// Verify CSV was written
+	f, err := os.Open(outFile)
+	if err != nil {
+		t.Fatalf("cannot open output file: %v", err)
+	}
+	defer f.Close()
+
+	records, err := csv.NewReader(f).ReadAll()
+	if err != nil {
+		t.Fatalf("cannot parse CSV: %v", err)
+	}
+
+	// 1 header + mdxCellPageSize data rows
+	if len(records) != mdxCellPageSize+1 {
+		t.Fatalf("expected %d CSV records, got %d", mdxCellPageSize+1, len(records))
+	}
+}
+
+func TestRunExport_MDXProgress(t *testing.T) {
+	resetCmdFlags(t)
+	exportMDX = "SELECT ... FROM [LargeCube]"
+
+	// Use CSV file output to avoid pipe buffer deadlock with large datasets
+	outFile := filepath.Join(t.TempDir(), "progress.csv")
+	exportOut = outFile
+
+	// Axes that imply > mdxCellPageSize total cells for progress display
+	rowTuples := make([]model.CellsetTuple, mdxCellPageSize+1)
+	for i := range rowTuples {
+		rowTuples[i] = model.CellsetTuple{
+			Ordinal: i,
+			Members: []model.CellsetMember{{Name: fmt.Sprintf("R%d", i)}},
+		}
+	}
+	mdxResp := model.CellsetResponse{
+		ID: "progress-test-id",
+		Axes: []model.CellsetAxis{
+			{Ordinal: 0, Tuples: []model.CellsetTuple{
+				{Ordinal: 0, Members: []model.CellsetMember{{Name: "Val"}}},
+			}},
+			{Ordinal: 1, Tuples: rowTuples},
+		},
+	}
+	mdxData, _ := json.Marshal(mdxResp)
+
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == "POST" && strings.Contains(r.URL.Path, "ExecuteMDX"):
+			w.Header().Set("Content-Type", "application/json")
+			w.Write(mdxData)
+		case r.Method == "GET" && strings.Contains(r.URL.Path, "/Cells"):
+			w.Header().Set("Content-Type", "application/json")
+			// Return small set of cells (single page)
+			w.Write(cellsCollectionJSON([]model.CellsetCell{
+				{Ordinal: 0, Value: 42.0},
+			}))
+		case r.Method == "DELETE":
+			w.WriteHeader(http.StatusNoContent)
+		}
+	})
+
+	captured := captureAll(t, func() {
+		err := runExport(exportCmd, []string{})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	// Progress should appear because totalCells > mdxCellPageSize
+	if !strings.Contains(captured.Stderr, "Fetching cells:") {
+		t.Errorf("stderr should contain progress, got:\n%s", captured.Stderr)
+	}
+	expectedTotal := fmt.Sprintf("/ %d", mdxCellPageSize+1)
+	if !strings.Contains(captured.Stderr, expectedTotal) {
+		t.Errorf("progress should show total %d, got:\n%s", mdxCellPageSize+1, captured.Stderr)
+	}
+}
+
+// ===========================================================================
+// MDX Export Tests — validation
+// ===========================================================================
+
+func TestRunExport_ViewAndMDXBoth(t *testing.T) {
+	resetCmdFlags(t)
+	exportView = "Default"
+	exportMDX = "SELECT ... FROM [Sales]"
+
+	err := runExport(exportCmd, []string{"Sales"})
+	if err == nil {
+		t.Fatal("expected error when both --view and --mdx specified, got nil")
+	}
+	if !strings.Contains(err.Error(), "not both") {
+		t.Errorf("error should mention 'not both', got: %s", err.Error())
+	}
+}
+
+func TestRunExport_ViewNoCube(t *testing.T) {
+	resetCmdFlags(t)
+	exportView = "Default"
+
+	err := runExport(exportCmd, []string{})
+	if err == nil {
+		t.Fatal("expected error when --view without cube, got nil")
+	}
+	if !strings.Contains(err.Error(), "Cube name is required") {
+		t.Errorf("error should mention cube requirement, got: %s", err.Error())
+	}
+}
+
+func TestRunExport_NoArgsNoFlags(t *testing.T) {
+	resetCmdFlags(t)
+
+	err := runExport(exportCmd, []string{})
+	if err == nil {
+		t.Fatal("expected error with no args and no flags, got nil")
+	}
+	if !strings.Contains(err.Error(), "--view") || !strings.Contains(err.Error(), "--mdx") {
+		t.Errorf("error should mention --view and --mdx, got: %s", err.Error())
 	}
 }

--- a/cmd/testhelpers_test.go
+++ b/cmd/testhelpers_test.go
@@ -183,6 +183,7 @@ func zeroAllFlags() {
 	exportView = ""
 	exportMDX = ""
 	exportOut = ""
+	exportNoHeader = false
 }
 
 // cubesJSON returns JSON for a TM1 Cubes response.

--- a/internal/model/cellset.go
+++ b/internal/model/cellset.go
@@ -20,6 +20,7 @@ type CellsetMember struct {
 }
 
 type CellsetResponse struct {
+	ID    string        `json:"ID,omitempty"`
 	Axes  []CellsetAxis `json:"Axes"`
 	Cells []CellsetCell `json:"Cells"`
 }

--- a/internal/model/cellset.go
+++ b/internal/model/cellset.go
@@ -24,3 +24,7 @@ type CellsetResponse struct {
 	Axes  []CellsetAxis `json:"Axes"`
 	Cells []CellsetCell `json:"Cells"`
 }
+
+type CellsCollectionResponse struct {
+	Value []CellsetCell `json:"value"`
+}


### PR DESCRIPTION
## Summary
- Add `--mdx` flag to export command
- `POST /ExecuteMDX` with `{"MDX": "<query>"}`
- Parses cellset response, supports screen/CSV/JSON/XLSX output
- Cellset cleanup via `DELETE /Cellsets('id')`

## Test plan
- [x] `go test ./...` passes
- [x] Review round completed

Closes #56