### PR TITLE
feat(#19): implement MDX export support

### DIFF
--- a/cmd/export.go
+++ b/cmd/export.go
@@ -7,12 +7,15 @@ import (
 	"net/url"
 	"os"
 	"strings"
+	"tm1cli/internal/client"
 	"tm1cli/internal/model"
 	"tm1cli/internal/output"
 
 	"github.com/spf13/cobra"
 	"github.com/xuri/excelize/v2"
 )
+
+const mdxCellPageSize = 10000
 
 var (
 	exportView     string
@@ -30,25 +33,37 @@ Equivalent to: File → Export in TM1 Architect
                or Export View in PAW
 REST API:      POST /Cubes('name')/Views('view')/tm1.Execute
                POST /ExecuteMDX`,
-	Example: `  tm1cli export "Sales" --view "Default"
+	Example: `  # View-based export
+  tm1cli export "Sales" --view "Default"
   tm1cli export "Sales" --view "Default" -o report.csv
-  tm1cli export "Sales" --view "Default" -o report.json
   tm1cli export "Sales" --view "Default" -o report.xlsx
-  tm1cli export "Sales" --view "Default" --output json`,
-	Args: cobra.ExactArgs(1),
+
+  # MDX-based export
+  tm1cli export --mdx "SELECT {[Period].[Jan]} ON COLUMNS, {[Measure].[Revenue]} ON ROWS FROM [Sales]"
+  tm1cli export --mdx "SELECT ... FROM [Sales]" -o report.csv`,
+	Args: cobra.RangeArgs(0, 1),
 	RunE: runExport,
 }
 
 func runExport(cmd *cobra.Command, args []string) error {
-	cubeName := args[0]
-
-	if exportView == "" && exportMDX == "" {
-		return fmt.Errorf("Specify --view or --mdx. Example: tm1cli export \"%s\" --view \"Default\"", cubeName)
+	cubeName := ""
+	if len(args) > 0 {
+		cubeName = args[0]
 	}
 
-	// TODO: Phase 2 — MDX export
-	if exportMDX != "" {
-		return fmt.Errorf("MDX export is not yet implemented (coming in v0.2.0). Use --view instead.")
+	if exportView == "" && exportMDX == "" {
+		if cubeName != "" {
+			return fmt.Errorf("Specify --view or --mdx. Example: tm1cli export \"%s\" --view \"Default\"", cubeName)
+		}
+		return fmt.Errorf("Specify --view or --mdx. Example: tm1cli export \"MyCube\" --view \"Default\"")
+	}
+
+	if exportView != "" && exportMDX != "" {
+		return fmt.Errorf("Specify --view or --mdx, not both.")
+	}
+
+	if exportView != "" && cubeName == "" {
+		return fmt.Errorf("Cube name is required with --view. Example: tm1cli export \"MyCube\" --view \"Default\"")
 	}
 
 	// Validate file extension before doing any network calls
@@ -72,6 +87,14 @@ func runExport(cmd *cobra.Command, args []string) error {
 		return errSilent
 	}
 
+	if exportMDX != "" {
+		return runMDXExport(cl, jsonMode)
+	}
+
+	return runViewExport(cl, cubeName, jsonMode)
+}
+
+func runViewExport(cl *client.Client, cubeName string, jsonMode bool) error {
 	endpoint := fmt.Sprintf("Cubes('%s')/Views('%s')/tm1.Execute?$expand=Axes($expand=Tuples($expand=Members($select=Name))),Cells($select=Value,Ordinal)", url.PathEscape(cubeName), url.PathEscape(exportView))
 
 	data, err := cl.Post(endpoint, map[string]interface{}{})
@@ -86,6 +109,81 @@ func runExport(cmd *cobra.Command, args []string) error {
 		return errSilent
 	}
 
+	return outputCellset(resp, jsonMode)
+}
+
+func runMDXExport(cl *client.Client, jsonMode bool) error {
+	// Step 1: Execute MDX — expand axes only, fetch cells separately for pagination
+	endpoint := "ExecuteMDX?$expand=Axes($expand=Tuples($expand=Members($select=Name)))"
+	payload := map[string]interface{}{"MDX": exportMDX}
+
+	data, err := cl.Post(endpoint, payload)
+	if err != nil {
+		output.PrintError(err.Error(), jsonMode)
+		return errSilent
+	}
+
+	var resp model.CellsetResponse
+	if err := json.Unmarshal(data, &resp); err != nil {
+		output.PrintError("Cannot parse cellset response.", jsonMode)
+		return errSilent
+	}
+
+	if resp.ID == "" {
+		output.PrintError("Server did not return a cellset ID.", jsonMode)
+		return errSilent
+	}
+
+	// Step 2: Clean up cellset when done (runs even on error)
+	defer func() {
+		_ = cl.Delete(fmt.Sprintf("Cellsets('%s')", resp.ID))
+	}()
+
+	// Step 3: Calculate expected total cells for progress display
+	totalCells := 1
+	for _, axis := range resp.Axes {
+		totalCells *= len(axis.Tuples)
+	}
+
+	// Step 4: Fetch cells in pages
+	allCells := make([]model.CellsetCell, 0, totalCells)
+	for skip := 0; ; skip += mdxCellPageSize {
+		cellsEndpoint := fmt.Sprintf("Cellsets('%s')/Cells?$select=Value,Ordinal&$top=%d&$skip=%d",
+			resp.ID, mdxCellPageSize, skip)
+
+		cellData, err := cl.Get(cellsEndpoint)
+		if err != nil {
+			output.PrintError(err.Error(), jsonMode)
+			return errSilent
+		}
+
+		var cellResp model.CellsCollectionResponse
+		if err := json.Unmarshal(cellData, &cellResp); err != nil {
+			output.PrintError("Cannot parse cells response.", jsonMode)
+			return errSilent
+		}
+
+		allCells = append(allCells, cellResp.Value...)
+
+		// Show progress for large exports (more than one page)
+		if totalCells > mdxCellPageSize {
+			fetched := len(allCells)
+			if fetched > totalCells {
+				fetched = totalCells
+			}
+			fmt.Fprintf(os.Stderr, "Fetching cells: %d / %d\n", fetched, totalCells)
+		}
+
+		if len(cellResp.Value) < mdxCellPageSize {
+			break
+		}
+	}
+
+	resp.Cells = allCells
+	return outputCellset(resp, jsonMode)
+}
+
+func outputCellset(resp model.CellsetResponse, jsonMode bool) error {
 	// JSON file output
 	if strings.HasSuffix(strings.ToLower(exportOut), ".json") {
 		records := cellsetToRecords(resp)
@@ -388,7 +486,7 @@ func writeXLSX(resp model.CellsetResponse, filePath string, noHeader bool) error
 func init() {
 	rootCmd.AddCommand(exportCmd)
 	exportCmd.Flags().StringVar(&exportView, "view", "", "Saved view name")
-	exportCmd.Flags().StringVar(&exportMDX, "mdx", "", "MDX query string (v0.2.0)")
+	exportCmd.Flags().StringVar(&exportMDX, "mdx", "", "MDX query string")
 	exportCmd.Flags().StringVarP(&exportOut, "out", "o", "", "Output file path (.csv, .json, .xlsx)")
 	exportCmd.Flags().BoolVar(&exportNoHeader, "no-header", false, "Exclude header row from CSV/XLSX output")
 }

--- a/cmd/export_test.go
+++ b/cmd/export_test.go
@@ -319,11 +319,6 @@ func TestRunExportStubs(t *testing.T) {
 		wantErr string
 	}{
 		{
-			name:    "mdx flag returns v0.2.0 message",
-			args:    []string{"export", "Sales", "--mdx", "SELECT {[Measures].Members} ON COLUMNS FROM [Sales]"},
-			wantErr: "coming in v0.2.0",
-		},
-		{
 			name:    "out txt returns unsupported format error",
 			args:    []string{"export", "Sales", "--view", "Default", "--out", "report.txt"},
 			wantErr: "Unsupported file format",
@@ -1973,5 +1968,241 @@ func TestRunExport_XLSXNoHeader(t *testing.T) {
 	a1, _ := f.GetCellValue("Sheet1", "A1")
 	if a1 != "Revenue" {
 		t.Errorf("A1 = %q, want Revenue (first data row, no header)", a1)
+	}
+}
+
+// ===========================================================================
+// MDX Export Tests
+// ===========================================================================
+
+func mdxResponseJSON(id string) []byte {
+	resp := model.CellsetResponse{
+		ID: id,
+		Axes: []model.CellsetAxis{
+			{Ordinal: 0, Tuples: []model.CellsetTuple{
+				{Ordinal: 0, Members: []model.CellsetMember{{Name: "Jan"}}},
+				{Ordinal: 1, Members: []model.CellsetMember{{Name: "Feb"}}},
+			}},
+			{Ordinal: 1, Tuples: []model.CellsetTuple{
+				{Ordinal: 0, Members: []model.CellsetMember{{Name: "Revenue"}}},
+				{Ordinal: 1, Members: []model.CellsetMember{{Name: "Cost"}}},
+			}},
+		},
+	}
+	data, _ := json.Marshal(resp)
+	return data
+}
+
+func cellsCollectionJSON(cells []model.CellsetCell) []byte {
+	resp := struct {
+		Value []model.CellsetCell `json:"value"`
+	}{Value: cells}
+	data, _ := json.Marshal(resp)
+	return data
+}
+
+var testMDXCells = []model.CellsetCell{
+	{Ordinal: 0, Value: 1000.0},
+	{Ordinal: 1, Value: 2000.0},
+	{Ordinal: 2, Value: 500.0},
+	{Ordinal: 3, Value: 800.0},
+}
+
+func TestRunExport_MDXToScreen(t *testing.T) {
+	resetCmdFlags(t)
+	exportMDX = "SELECT {[Period].[Jan],[Period].[Feb]} ON COLUMNS, {[Measure].Members} ON ROWS FROM [Sales]"
+
+	deleteCalled := false
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == "POST" && strings.Contains(r.URL.Path, "ExecuteMDX"):
+			w.Header().Set("Content-Type", "application/json")
+			w.Write(mdxResponseJSON("test-cellset-id"))
+		case r.Method == "GET" && strings.Contains(r.URL.Path, "/Cells"):
+			w.Header().Set("Content-Type", "application/json")
+			w.Write(cellsCollectionJSON(testMDXCells))
+		case r.Method == "DELETE" && strings.Contains(r.URL.Path, "Cellsets"):
+			deleteCalled = true
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+
+	captured := captureAll(t, func() {
+		err := runExport(exportCmd, []string{})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	for _, want := range []string{"Jan", "Feb", "Revenue", "Cost", "1000", "2000", "500", "800"} {
+		if !strings.Contains(captured.Stdout, want) {
+			t.Errorf("output missing %q, got:\n%s", want, captured.Stdout)
+		}
+	}
+
+	if !deleteCalled {
+		t.Error("DELETE should be called to clean up cellset")
+	}
+}
+
+func TestRunExport_MDXCSVFile(t *testing.T) {
+	resetCmdFlags(t)
+	exportMDX = "SELECT ... FROM [Sales]"
+	outFile := filepath.Join(t.TempDir(), "mdx_export.csv")
+	exportOut = outFile
+
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == "POST" && strings.Contains(r.URL.Path, "ExecuteMDX"):
+			w.Header().Set("Content-Type", "application/json")
+			w.Write(mdxResponseJSON("test-id"))
+		case r.Method == "GET" && strings.Contains(r.URL.Path, "/Cells"):
+			w.Header().Set("Content-Type", "application/json")
+			w.Write(cellsCollectionJSON(testMDXCells))
+		case r.Method == "DELETE":
+			w.WriteHeader(http.StatusNoContent)
+		}
+	})
+
+	captured := captureAll(t, func() {
+		err := runExport(exportCmd, []string{})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	if !strings.Contains(captured.Stderr, "Exported 2 rows") {
+		t.Errorf("stderr should contain export summary, got: %s", captured.Stderr)
+	}
+
+	f, err := os.Open(outFile)
+	if err != nil {
+		t.Fatalf("cannot open output file: %v", err)
+	}
+	defer f.Close()
+
+	records, err := csv.NewReader(f).ReadAll()
+	if err != nil {
+		t.Fatalf("cannot parse CSV: %v", err)
+	}
+
+	if len(records) != 3 {
+		t.Fatalf("expected 3 records, got %d", len(records))
+	}
+	if records[1][1] != "1000" {
+		t.Errorf("Revenue/Jan = %q, want 1000", records[1][1])
+	}
+}
+
+func TestRunExport_MDXServerError(t *testing.T) {
+	resetCmdFlags(t)
+	exportMDX = "SELECT INVALID FROM [Sales]"
+
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte(`{"error": {"message": "Invalid MDX"}}`))
+	})
+
+	captured := captureAll(t, func() {
+		err := runExport(exportCmd, []string{})
+		if err != errSilent {
+			t.Fatalf("expected errSilent, got: %v", err)
+		}
+	})
+
+	if !strings.Contains(captured.Stderr, "HTTP 400") {
+		t.Errorf("stderr should contain HTTP 400 error, got:\n%s", captured.Stderr)
+	}
+}
+
+func TestRunExport_MDXCellsetCleanupOnError(t *testing.T) {
+	resetCmdFlags(t)
+	exportMDX = "SELECT ... FROM [Sales]"
+
+	deleteCalled := false
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == "POST" && strings.Contains(r.URL.Path, "ExecuteMDX"):
+			w.Header().Set("Content-Type", "application/json")
+			w.Write(mdxResponseJSON("cleanup-test-id"))
+		case r.Method == "GET" && strings.Contains(r.URL.Path, "/Cells"):
+			w.WriteHeader(http.StatusInternalServerError)
+			w.Write([]byte("server error"))
+		case r.Method == "DELETE" && strings.Contains(r.URL.Path, "Cellsets"):
+			deleteCalled = true
+			w.WriteHeader(http.StatusNoContent)
+		}
+	})
+
+	captureAll(t, func() {
+		runExport(exportCmd, []string{})
+	})
+
+	if !deleteCalled {
+		t.Error("DELETE should be called even when cell fetch fails")
+	}
+}
+
+func TestRunExport_MDXEndpointUsesPOST(t *testing.T) {
+	resetCmdFlags(t)
+	exportMDX = "SELECT {[Period].[Jan]} ON 0 FROM [Sales]"
+
+	var capturedMethod string
+	var capturedBody string
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.Contains(r.URL.Path, "ExecuteMDX"):
+			capturedMethod = r.Method
+			body := make([]byte, r.ContentLength)
+			r.Body.Read(body)
+			capturedBody = string(body)
+			w.Header().Set("Content-Type", "application/json")
+			w.Write(mdxResponseJSON("test-id"))
+		case r.Method == "GET" && strings.Contains(r.URL.Path, "/Cells"):
+			w.Header().Set("Content-Type", "application/json")
+			w.Write(cellsCollectionJSON(testMDXCells))
+		case r.Method == "DELETE":
+			w.WriteHeader(http.StatusNoContent)
+		}
+	})
+
+	captureAll(t, func() {
+		runExport(exportCmd, []string{})
+	})
+
+	if capturedMethod != "POST" {
+		t.Errorf("ExecuteMDX should use POST, got %q", capturedMethod)
+	}
+	if !strings.Contains(capturedBody, "MDX") {
+		t.Errorf("POST body should contain MDX key, got: %s", capturedBody)
+	}
+}
+
+func TestRunExport_ViewAndMDXBoth(t *testing.T) {
+	resetCmdFlags(t)
+	exportView = "Default"
+	exportMDX = "SELECT ... FROM [Sales]"
+
+	err := runExport(exportCmd, []string{"Sales"})
+	if err == nil {
+		t.Fatal("expected error when both --view and --mdx specified")
+	}
+	if !strings.Contains(err.Error(), "not both") {
+		t.Errorf("error should mention 'not both', got: %s", err.Error())
+	}
+}
+
+func TestRunExport_ViewNoCube(t *testing.T) {
+	resetCmdFlags(t)
+	exportView = "Default"
+
+	err := runExport(exportCmd, []string{})
+	if err == nil {
+		t.Fatal("expected error when --view without cube")
+	}
+	if !strings.Contains(err.Error(), "Cube name is required") {
+		t.Errorf("error should mention cube requirement, got: %s", err.Error())
 	}
 }


### PR DESCRIPTION
## Summary

- Implement `--mdx` flag for export command
- `POST /ExecuteMDX` with paginated cell fetching (10k chunks)
- Cellset cleanup via `DELETE /Cellsets('id')`
- Supports all output modes: screen, CSV, JSON, XLSX
- Cube name optional with `--mdx`, required with `--view`
- `--view` and `--mdx` mutually exclusive

## Test plan

- [x] `go test ./...` passes
- [x] 7 new MDX tests: screen, CSV, server error, cleanup on error, POST method, both flags, view without cube

Closes #56