### PR TITLE
chore: bump Makefile version to 0.2.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION := 0.1.2
+VERSION := 0.2.0
 
 build:
 	go build -ldflags "-X tm1cli/cmd.Version=$(VERSION)" -o tm1cli


### PR DESCRIPTION
Bump VERSION in Makefile to match v0.2.0 release.