### PR TITLE
feat(#54): add process dump and load commands

### DIFF
--- a/cmd/process.go
+++ b/cmd/process.go
@@ -335,8 +335,7 @@ func runProcessDump(cmd *cobra.Command, args []string) error {
 	}
 
 	if procDumpOut == "" {
-		out, _ := json.MarshalIndent(detail, "", "  ")
-		fmt.Println(string(out))
+		output.PrintJSON(detail)
 		return nil
 	}
 

--- a/cmd/process.go
+++ b/cmd/process.go
@@ -299,8 +299,9 @@ Without -o flag, prints JSON to stdout.`,
 func runProcessDump(cmd *cobra.Command, args []string) error {
 	processName := args[0]
 
+	var ext string
 	if procDumpOut != "" {
-		ext := strings.ToLower(filepath.Ext(procDumpOut))
+		ext = strings.ToLower(filepath.Ext(procDumpOut))
 		if ext != ".json" && ext != ".yaml" && ext != ".yml" {
 			return fmt.Errorf("Unsupported format %q. Use .json, .yaml, or .yml.", ext)
 		}
@@ -341,16 +342,10 @@ func runProcessDump(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	ext := strings.ToLower(filepath.Ext(procDumpOut))
 	switch ext {
 	case ".json":
-		out, err := json.MarshalIndent(detail, "", "  ")
-		if err != nil {
-			output.PrintError("Cannot serialize process definition.", false)
-			return errSilent
-		}
-		if err := os.WriteFile(procDumpOut, out, 0644); err != nil {
-			output.PrintError(fmt.Sprintf("Cannot write file: %s", err.Error()), false)
+		if err := writeJSONFile(procDumpOut, detail); err != nil {
+			output.PrintError(err.Error(), false)
 			return errSilent
 		}
 	case ".yaml", ".yml":

--- a/cmd/process.go
+++ b/cmd/process.go
@@ -319,7 +319,7 @@ func runProcessDump(cmd *cobra.Command, args []string) error {
 		return errSilent
 	}
 
-	endpoint := fmt.Sprintf("Processes('%s')?$select=Name,PrologProcedure,MetadataProcedure,DataProcedure,EpilogProcedure,Parameters,DataSource,Variables",
+	endpoint := fmt.Sprintf("Processes('%s')?$expand=Parameters,Variables&$select=Name,PrologProcedure,MetadataProcedure,DataProcedure,EpilogProcedure,DataSource",
 		url.PathEscape(processName))
 
 	data, err := cl.Get(endpoint)

--- a/cmd/process.go
+++ b/cmd/process.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"net/url"
 	"os"
-	"path/filepath"
 	"strings"
 	"time"
+	"tm1cli/internal/client"
 	"tm1cli/internal/model"
 	"tm1cli/internal/output"
 
@@ -282,13 +282,13 @@ var procDumpOut string
 var processDumpCmd = &cobra.Command{
 	Use:   "dump <name>",
 	Short: "Export a TI process definition to file",
-	Long: `Export a TI process definition to a JSON or YAML file.
+	Long: `Export a TI process definition to JSON or YAML file.
 
-Equivalent to: Right-click → Export in TM1 Architect
+Equivalent to: serializing a TI process for Git version control
 REST API:      GET /Processes('name')
 
-Format is detected from file extension (.json, .yaml, .yml).
-Without -o flag, prints JSON to stdout.`,
+The output file format is detected from the file extension.
+If no -o flag is given, JSON is printed to stdout.`,
 	Example: `  tm1cli process dump "LoadData" -o loaddata.yaml
   tm1cli process dump "LoadData" -o loaddata.json
   tm1cli process dump "LoadData"`,
@@ -299,11 +299,10 @@ Without -o flag, prints JSON to stdout.`,
 func runProcessDump(cmd *cobra.Command, args []string) error {
 	processName := args[0]
 
-	var ext string
 	if procDumpOut != "" {
-		ext = strings.ToLower(filepath.Ext(procDumpOut))
-		if ext != ".json" && ext != ".yaml" && ext != ".yml" {
-			return fmt.Errorf("Unsupported format %q. Use .json, .yaml, or .yml.", ext)
+		ext := strings.ToLower(procDumpOut)
+		if !strings.HasSuffix(ext, ".json") && !strings.HasSuffix(ext, ".yaml") && !strings.HasSuffix(ext, ".yml") {
+			return fmt.Errorf("Unsupported file format. Supported: .json, .yaml, .yml")
 		}
 	}
 
@@ -313,54 +312,58 @@ func runProcessDump(cmd *cobra.Command, args []string) error {
 		return errSilent
 	}
 
+	jsonMode := isJSONOutput(cfg)
 	cl, err := createClient(cfg)
 	if err != nil {
-		output.PrintError(err.Error(), false)
+		output.PrintError(err.Error(), jsonMode)
 		return errSilent
 	}
 
-	endpoint := fmt.Sprintf("Processes('%s')?$expand=Parameters,Variables", url.PathEscape(processName))
+	endpoint := fmt.Sprintf("Processes('%s')?$select=Name,PrologProcedure,MetadataProcedure,DataProcedure,EpilogProcedure,Parameters,DataSource,Variables",
+		url.PathEscape(processName))
+
 	data, err := cl.Get(endpoint)
 	if err != nil {
-		output.PrintError(err.Error(), false)
+		output.PrintError(err.Error(), jsonMode)
 		return errSilent
 	}
 
 	var detail model.ProcessDetail
 	if err := json.Unmarshal(data, &detail); err != nil {
-		output.PrintError("Cannot parse process definition from server response.", false)
+		output.PrintError("Cannot parse process response.", jsonMode)
 		return errSilent
 	}
 
 	if procDumpOut == "" {
-		out, err := json.MarshalIndent(detail, "", "  ")
-		if err != nil {
-			output.PrintError("Cannot serialize process definition.", false)
-			return errSilent
-		}
+		out, _ := json.MarshalIndent(detail, "", "  ")
 		fmt.Println(string(out))
 		return nil
 	}
 
-	switch ext {
-	case ".json":
-		if err := writeJSONFile(procDumpOut, detail); err != nil {
-			output.PrintError(err.Error(), false)
-			return errSilent
-		}
-	case ".yaml", ".yml":
+	ext := strings.ToLower(procDumpOut)
+	if strings.HasSuffix(ext, ".yaml") || strings.HasSuffix(ext, ".yml") {
 		out, err := yaml.Marshal(detail)
 		if err != nil {
-			output.PrintError("Cannot serialize process definition.", false)
+			output.PrintError(fmt.Sprintf("Cannot encode YAML: %s", err), jsonMode)
 			return errSilent
 		}
-		if err := os.WriteFile(procDumpOut, out, 0644); err != nil {
-			output.PrintError(fmt.Sprintf("Cannot write file: %s", err.Error()), false)
+		if err := os.WriteFile(procDumpOut, out, 0600); err != nil {
+			output.PrintError(fmt.Sprintf("Cannot write file: %s", err), jsonMode)
+			return errSilent
+		}
+	} else {
+		out, err := json.MarshalIndent(detail, "", "  ")
+		if err != nil {
+			output.PrintError(fmt.Sprintf("Cannot encode JSON: %s", err), jsonMode)
+			return errSilent
+		}
+		if err := os.WriteFile(procDumpOut, append(out, '\n'), 0600); err != nil {
+			output.PrintError(fmt.Sprintf("Cannot write file: %s", err), jsonMode)
 			return errSilent
 		}
 	}
 
-	fmt.Fprintf(os.Stderr, "Exported process '%s' to %s\n", processName, procDumpOut)
+	fmt.Fprintf(os.Stderr, "Wrote process '%s' to %s\n", processName, procDumpOut)
 	return nil
 }
 
@@ -374,38 +377,63 @@ var (
 
 var processLoadCmd = &cobra.Command{
 	Use:   "load <name>",
-	Short: "Import a TI process from file",
+	Short: "Import a TI process from a JSON or YAML file",
 	Long: `Import a TI process definition from a JSON or YAML file.
 
-Equivalent to: Import in TM1 Architect
-REST API:      PATCH /Processes('name') or POST /Processes
+Equivalent to: creating or updating a TI process via REST API
+REST API:      POST /Processes (create) or PATCH /Processes('name') (update)
 
-Format is detected from file extension (.json, .yaml, .yml).
-By default, tries to update an existing process (PATCH).
-If the process does not exist, creates it (POST).`,
+The file format is detected from the extension.
+The process name from the CLI argument overrides the name in the file.
+By default, an existing process is updated; a new process is created.`,
 	Example: `  tm1cli process load "LoadData" -f loaddata.yaml
-  tm1cli process load "LoadData" -f loaddata.json
-  tm1cli process load "NewProcess" -f process.yaml --create-only
-  tm1cli process load "LoadData" -f process.yaml --update-only`,
+  tm1cli process load "LoadData" -f loaddata.json --create-only
+  tm1cli process load "LoadData" -f loaddata.yaml --update-only`,
 	Args: cobra.ExactArgs(1),
 	RunE: runProcessLoad,
+}
+
+func processExists(cl *client.Client, name string) (bool, error) {
+	endpoint := fmt.Sprintf("Processes('%s')?$select=Name", url.PathEscape(name))
+	_, err := cl.Get(endpoint)
+	if err == nil {
+		return true, nil
+	}
+	if strings.HasPrefix(err.Error(), "Not found:") {
+		return false, nil
+	}
+	return false, err
 }
 
 func runProcessLoad(cmd *cobra.Command, args []string) error {
 	processName := args[0]
 
-	if procLoadFile == "" {
-		return fmt.Errorf("--file (-f) is required")
-	}
-
 	if procLoadCreateOnly && procLoadUpdateOnly {
-		return fmt.Errorf("--create-only and --update-only are mutually exclusive")
+		return fmt.Errorf("Cannot use --create-only and --update-only together.")
 	}
 
-	ext := strings.ToLower(filepath.Ext(procLoadFile))
-	if ext != ".json" && ext != ".yaml" && ext != ".yml" {
-		return fmt.Errorf("Unsupported format %q. Use .json, .yaml, or .yml.", ext)
+	ext := strings.ToLower(procLoadFile)
+	if !strings.HasSuffix(ext, ".json") && !strings.HasSuffix(ext, ".yaml") && !strings.HasSuffix(ext, ".yml") {
+		return fmt.Errorf("Unsupported file format. Supported: .json, .yaml, .yml")
 	}
+
+	fileData, err := os.ReadFile(procLoadFile)
+	if err != nil {
+		return fmt.Errorf("Cannot read file: %s", err)
+	}
+
+	var detail model.ProcessDetail
+	if strings.HasSuffix(ext, ".yaml") || strings.HasSuffix(ext, ".yml") {
+		if err := yaml.Unmarshal(fileData, &detail); err != nil {
+			return fmt.Errorf("Cannot parse YAML: %s", err)
+		}
+	} else {
+		if err := json.Unmarshal(fileData, &detail); err != nil {
+			return fmt.Errorf("Cannot parse JSON: %s", err)
+		}
+	}
+
+	detail.Name = processName
 
 	cfg, err := loadConfig()
 	if err != nil {
@@ -413,80 +441,54 @@ func runProcessLoad(cmd *cobra.Command, args []string) error {
 		return errSilent
 	}
 
+	jsonMode := isJSONOutput(cfg)
 	cl, err := createClient(cfg)
 	if err != nil {
-		output.PrintError(err.Error(), false)
+		output.PrintError(err.Error(), jsonMode)
 		return errSilent
 	}
 
-	fileData, err := os.ReadFile(procLoadFile)
+	exists, err := processExists(cl, processName)
 	if err != nil {
-		output.PrintError(fmt.Sprintf("Cannot read file: %s", err.Error()), false)
+		output.PrintError(err.Error(), jsonMode)
 		return errSilent
 	}
 
-	var detail model.ProcessDetail
-	switch ext {
-	case ".json":
-		if err := json.Unmarshal(fileData, &detail); err != nil {
-			output.PrintError("Cannot parse JSON file.", false)
-			return errSilent
-		}
-	case ".yaml", ".yml":
-		if err := yaml.Unmarshal(fileData, &detail); err != nil {
-			output.PrintError("Cannot parse YAML file.", false)
-			return errSilent
-		}
+	if procLoadCreateOnly && exists {
+		output.PrintError(fmt.Sprintf("Process '%s' already exists. Remove --create-only to update.", processName), jsonMode)
+		return errSilent
 	}
-
-	// CLI argument overrides the name stored in the file
-	detail.Name = processName
-
-	if procLoadCreateOnly {
-		_, err := cl.Post("Processes", detail)
-		if err != nil {
-			output.PrintError(err.Error(), false)
-			return errSilent
-		}
-		fmt.Printf("Process '%s' created successfully.\n", processName)
-		return nil
-	}
-
-	patchEndpoint := fmt.Sprintf("Processes('%s')", url.PathEscape(processName))
-
-	if procLoadUpdateOnly {
-		_, status, err := cl.Patch(patchEndpoint, detail)
-		if err != nil {
-			if status == 404 {
-				output.PrintError(fmt.Sprintf("Process '%s' not found. Cannot update.", processName), false)
-			} else {
-				output.PrintError(err.Error(), false)
-			}
-			return errSilent
-		}
-		fmt.Printf("Process '%s' updated successfully.\n", processName)
-		return nil
-	}
-
-	// Default: try PATCH, fall back to POST only on 404
-	_, status, patchErr := cl.Patch(patchEndpoint, detail)
-	if patchErr == nil {
-		fmt.Printf("Process '%s' updated successfully.\n", processName)
-		return nil
-	}
-
-	if status != 404 {
-		output.PrintError(patchErr.Error(), false)
+	if procLoadUpdateOnly && !exists {
+		output.PrintError(fmt.Sprintf("Process '%s' does not exist. Remove --update-only to create.", processName), jsonMode)
 		return errSilent
 	}
 
-	// Process not found — create it
-	_, postErr := cl.Post("Processes", detail)
-	if postErr != nil {
-		output.PrintError(postErr.Error(), false)
+	if exists {
+		endpoint := fmt.Sprintf("Processes('%s')", url.PathEscape(processName))
+		_, err = cl.Patch(endpoint, detail)
+	} else {
+		_, err = cl.Post("Processes", detail)
+	}
+
+	if err != nil {
+		output.PrintError(err.Error(), jsonMode)
 		return errSilent
 	}
-	fmt.Printf("Process '%s' created successfully.\n", processName)
+
+	action := "Updated"
+	if !exists {
+		action = "Created"
+	}
+
+	if jsonMode {
+		output.PrintJSON(map[string]string{
+			"process": processName,
+			"status":  strings.ToLower(action),
+			"message": fmt.Sprintf("%s process '%s'.", action, processName),
+		})
+	} else {
+		fmt.Printf("%s process '%s' from %s\n", action, processName, procLoadFile)
+	}
 	return nil
 }
 
@@ -509,6 +511,7 @@ func init() {
 	processDumpCmd.Flags().StringVarP(&procDumpOut, "out", "o", "", "Output file path (.json, .yaml, .yml)")
 
 	processLoadCmd.Flags().StringVarP(&procLoadFile, "file", "f", "", "Input file path (.json, .yaml, .yml)")
-	processLoadCmd.Flags().BoolVar(&procLoadCreateOnly, "create-only", false, "Only create new process, fail if exists")
-	processLoadCmd.Flags().BoolVar(&procLoadUpdateOnly, "update-only", false, "Only update existing process, fail if not found")
+	processLoadCmd.MarkFlagRequired("file")
+	processLoadCmd.Flags().BoolVar(&procLoadCreateOnly, "create-only", false, "Fail if process already exists")
+	processLoadCmd.Flags().BoolVar(&procLoadUpdateOnly, "update-only", false, "Fail if process does not exist")
 }

--- a/cmd/process.go
+++ b/cmd/process.go
@@ -4,12 +4,15 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/url"
+	"os"
+	"path/filepath"
 	"strings"
 	"time"
 	"tm1cli/internal/model"
 	"tm1cli/internal/output"
 
 	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
 )
 
 var processCmd = &cobra.Command{
@@ -272,6 +275,226 @@ func runProcessRun(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
+// --- process dump ---
+
+var procDumpOut string
+
+var processDumpCmd = &cobra.Command{
+	Use:   "dump <name>",
+	Short: "Export a TI process definition to file",
+	Long: `Export a TI process definition to a JSON or YAML file.
+
+Equivalent to: Right-click → Export in TM1 Architect
+REST API:      GET /Processes('name')
+
+Format is detected from file extension (.json, .yaml, .yml).
+Without -o flag, prints JSON to stdout.`,
+	Example: `  tm1cli process dump "LoadData" -o loaddata.yaml
+  tm1cli process dump "LoadData" -o loaddata.json
+  tm1cli process dump "LoadData"`,
+	Args: cobra.ExactArgs(1),
+	RunE: runProcessDump,
+}
+
+func runProcessDump(cmd *cobra.Command, args []string) error {
+	processName := args[0]
+
+	if procDumpOut != "" {
+		ext := strings.ToLower(filepath.Ext(procDumpOut))
+		if ext != ".json" && ext != ".yaml" && ext != ".yml" {
+			return fmt.Errorf("Unsupported format %q. Use .json, .yaml, or .yml.", ext)
+		}
+	}
+
+	cfg, err := loadConfig()
+	if err != nil {
+		output.PrintError(err.Error(), isJSONOutput(nil))
+		return errSilent
+	}
+
+	cl, err := createClient(cfg)
+	if err != nil {
+		output.PrintError(err.Error(), false)
+		return errSilent
+	}
+
+	endpoint := fmt.Sprintf("Processes('%s')?$expand=Parameters,Variables", url.PathEscape(processName))
+	data, err := cl.Get(endpoint)
+	if err != nil {
+		output.PrintError(err.Error(), false)
+		return errSilent
+	}
+
+	var detail model.ProcessDetail
+	if err := json.Unmarshal(data, &detail); err != nil {
+		output.PrintError("Cannot parse process definition from server response.", false)
+		return errSilent
+	}
+
+	if procDumpOut == "" {
+		out, err := json.MarshalIndent(detail, "", "  ")
+		if err != nil {
+			output.PrintError("Cannot serialize process definition.", false)
+			return errSilent
+		}
+		fmt.Println(string(out))
+		return nil
+	}
+
+	ext := strings.ToLower(filepath.Ext(procDumpOut))
+	switch ext {
+	case ".json":
+		out, err := json.MarshalIndent(detail, "", "  ")
+		if err != nil {
+			output.PrintError("Cannot serialize process definition.", false)
+			return errSilent
+		}
+		if err := os.WriteFile(procDumpOut, out, 0644); err != nil {
+			output.PrintError(fmt.Sprintf("Cannot write file: %s", err.Error()), false)
+			return errSilent
+		}
+	case ".yaml", ".yml":
+		out, err := yaml.Marshal(detail)
+		if err != nil {
+			output.PrintError("Cannot serialize process definition.", false)
+			return errSilent
+		}
+		if err := os.WriteFile(procDumpOut, out, 0644); err != nil {
+			output.PrintError(fmt.Sprintf("Cannot write file: %s", err.Error()), false)
+			return errSilent
+		}
+	}
+
+	fmt.Fprintf(os.Stderr, "Exported process '%s' to %s\n", processName, procDumpOut)
+	return nil
+}
+
+// --- process load ---
+
+var (
+	procLoadFile       string
+	procLoadCreateOnly bool
+	procLoadUpdateOnly bool
+)
+
+var processLoadCmd = &cobra.Command{
+	Use:   "load <name>",
+	Short: "Import a TI process from file",
+	Long: `Import a TI process definition from a JSON or YAML file.
+
+Equivalent to: Import in TM1 Architect
+REST API:      PATCH /Processes('name') or POST /Processes
+
+Format is detected from file extension (.json, .yaml, .yml).
+By default, tries to update an existing process (PATCH).
+If the process does not exist, creates it (POST).`,
+	Example: `  tm1cli process load "LoadData" -f loaddata.yaml
+  tm1cli process load "LoadData" -f loaddata.json
+  tm1cli process load "NewProcess" -f process.yaml --create-only
+  tm1cli process load "LoadData" -f process.yaml --update-only`,
+	Args: cobra.ExactArgs(1),
+	RunE: runProcessLoad,
+}
+
+func runProcessLoad(cmd *cobra.Command, args []string) error {
+	processName := args[0]
+
+	if procLoadFile == "" {
+		return fmt.Errorf("--file (-f) is required")
+	}
+
+	if procLoadCreateOnly && procLoadUpdateOnly {
+		return fmt.Errorf("--create-only and --update-only are mutually exclusive")
+	}
+
+	ext := strings.ToLower(filepath.Ext(procLoadFile))
+	if ext != ".json" && ext != ".yaml" && ext != ".yml" {
+		return fmt.Errorf("Unsupported format %q. Use .json, .yaml, or .yml.", ext)
+	}
+
+	cfg, err := loadConfig()
+	if err != nil {
+		output.PrintError(err.Error(), isJSONOutput(nil))
+		return errSilent
+	}
+
+	cl, err := createClient(cfg)
+	if err != nil {
+		output.PrintError(err.Error(), false)
+		return errSilent
+	}
+
+	fileData, err := os.ReadFile(procLoadFile)
+	if err != nil {
+		output.PrintError(fmt.Sprintf("Cannot read file: %s", err.Error()), false)
+		return errSilent
+	}
+
+	var detail model.ProcessDetail
+	switch ext {
+	case ".json":
+		if err := json.Unmarshal(fileData, &detail); err != nil {
+			output.PrintError("Cannot parse JSON file.", false)
+			return errSilent
+		}
+	case ".yaml", ".yml":
+		if err := yaml.Unmarshal(fileData, &detail); err != nil {
+			output.PrintError("Cannot parse YAML file.", false)
+			return errSilent
+		}
+	}
+
+	// CLI argument overrides the name stored in the file
+	detail.Name = processName
+
+	if procLoadCreateOnly {
+		_, err := cl.Post("Processes", detail)
+		if err != nil {
+			output.PrintError(err.Error(), false)
+			return errSilent
+		}
+		fmt.Printf("Process '%s' created successfully.\n", processName)
+		return nil
+	}
+
+	patchEndpoint := fmt.Sprintf("Processes('%s')", url.PathEscape(processName))
+
+	if procLoadUpdateOnly {
+		_, status, err := cl.Patch(patchEndpoint, detail)
+		if err != nil {
+			if status == 404 {
+				output.PrintError(fmt.Sprintf("Process '%s' not found. Cannot update.", processName), false)
+			} else {
+				output.PrintError(err.Error(), false)
+			}
+			return errSilent
+		}
+		fmt.Printf("Process '%s' updated successfully.\n", processName)
+		return nil
+	}
+
+	// Default: try PATCH, fall back to POST only on 404
+	_, status, patchErr := cl.Patch(patchEndpoint, detail)
+	if patchErr == nil {
+		fmt.Printf("Process '%s' updated successfully.\n", processName)
+		return nil
+	}
+
+	if status != 404 {
+		output.PrintError(patchErr.Error(), false)
+		return errSilent
+	}
+
+	// Process not found — create it
+	_, postErr := cl.Post("Processes", detail)
+	if postErr != nil {
+		output.PrintError(postErr.Error(), false)
+		return errSilent
+	}
+	fmt.Printf("Process '%s' created successfully.\n", processName)
+	return nil
+}
+
 func init() {
 	rootCmd.AddCommand(processCmd)
 	processCmd.AddCommand(processListCmd)
@@ -284,4 +507,13 @@ func init() {
 	processListCmd.Flags().BoolVar(&procListCount, "count", false, "Show count only")
 
 	processRunCmd.Flags().StringArrayVar(&procRunParams, "param", nil, "Process parameter as Key=Value (repeatable)")
+
+	processCmd.AddCommand(processDumpCmd)
+	processCmd.AddCommand(processLoadCmd)
+
+	processDumpCmd.Flags().StringVarP(&procDumpOut, "out", "o", "", "Output file path (.json, .yaml, .yml)")
+
+	processLoadCmd.Flags().StringVarP(&procLoadFile, "file", "f", "", "Input file path (.json, .yaml, .yml)")
+	processLoadCmd.Flags().BoolVar(&procLoadCreateOnly, "create-only", false, "Only create new process, fail if exists")
+	processLoadCmd.Flags().BoolVar(&procLoadUpdateOnly, "update-only", false, "Only update existing process, fail if not found")
 }

--- a/cmd/process.go
+++ b/cmd/process.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/url"
 	"os"
@@ -398,7 +399,7 @@ func processExists(cl *client.Client, name string) (bool, error) {
 	if err == nil {
 		return true, nil
 	}
-	if strings.HasPrefix(err.Error(), "Not found:") {
+	if errors.Is(err, client.ErrNotFound) {
 		return false, nil
 	}
 	return false, err

--- a/cmd/process_test.go
+++ b/cmd/process_test.go
@@ -967,29 +967,6 @@ func TestRunProcessList_FilterFallbackWarning(t *testing.T) {
 }
 
 // ============================================================
-// Helpers for dump/load tests
-// ============================================================
-
-func processDetailJSON() []byte {
-	return []byte(`{
-		"@odata.context": "...",
-		"Name": "LoadData",
-		"PrologProcedure": "#Region Prolog\nIF(1=1);\nEndIf;",
-		"MetadataProcedure": "",
-		"DataProcedure": "CellPutN(1, 'Sales', 'Jan', 'Actual');",
-		"EpilogProcedure": "",
-		"HasSecurityAccess": false,
-		"Parameters": [
-			{"Name": "pYear", "Prompt": "Year", "Value": "2024", "Type": "String"}
-		],
-		"DataSource": {
-			"Type": "None"
-		},
-		"Variables": []
-	}`)
-}
-
-// ============================================================
 // Integration tests — runProcessDump
 // ============================================================
 
@@ -997,9 +974,12 @@ func TestRunProcessDump_JSONStdout(t *testing.T) {
 	resetCmdFlags(t)
 
 	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		w.Write(processDetailJSON())
+		if r.Method == "GET" && strings.Contains(r.URL.Path, "Processes") {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write(processDetailJSON("LoadData"))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
 	})
 
 	captured := captureAll(t, func() {
@@ -1009,28 +989,27 @@ func TestRunProcessDump_JSONStdout(t *testing.T) {
 		}
 	})
 
-	if !json.Valid([]byte(captured.Stdout)) {
-		t.Fatalf("stdout is not valid JSON:\n%s", captured.Stdout)
+	var detail model.ProcessDetail
+	if err := json.Unmarshal([]byte(captured.Stdout), &detail); err != nil {
+		t.Fatalf("stdout is not valid JSON: %v\noutput: %s", err, captured.Stdout)
 	}
-	if !strings.Contains(captured.Stdout, "LoadData") {
-		t.Errorf("stdout missing 'LoadData':\n%s", captured.Stdout)
+	if detail.Name != "LoadData" {
+		t.Errorf("Name = %q, want 'LoadData'", detail.Name)
 	}
-	if !strings.Contains(captured.Stdout, "PrologProcedure") {
-		t.Errorf("stdout missing 'PrologProcedure':\n%s", captured.Stdout)
+	if detail.PrologProcedure != "# prolog code" {
+		t.Errorf("PrologProcedure = %q, want '# prolog code'", detail.PrologProcedure)
 	}
 }
 
 func TestRunProcessDump_JSONFile(t *testing.T) {
 	resetCmdFlags(t)
-
 	tmpDir := t.TempDir()
-	outFile := filepath.Join(tmpDir, "loaddata.json")
+	outFile := filepath.Join(tmpDir, "test.json")
 	procDumpOut = outFile
 
 	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		w.Write(processDetailJSON())
+		w.Write(processDetailJSON("LoadData"))
 	})
 
 	captureAll(t, func() {
@@ -1040,33 +1019,29 @@ func TestRunProcessDump_JSONFile(t *testing.T) {
 		}
 	})
 
-	fileData, err := os.ReadFile(outFile)
+	data, err := os.ReadFile(outFile)
 	if err != nil {
 		t.Fatalf("cannot read output file: %v", err)
 	}
-	if !json.Valid(fileData) {
-		t.Fatalf("file content is not valid JSON:\n%s", fileData)
-	}
+
 	var detail model.ProcessDetail
-	if err := json.Unmarshal(fileData, &detail); err != nil {
-		t.Fatalf("cannot parse file as ProcessDetail: %v", err)
+	if err := json.Unmarshal(data, &detail); err != nil {
+		t.Fatalf("file is not valid JSON: %v", err)
 	}
 	if detail.Name != "LoadData" {
-		t.Errorf("detail.Name = %q, want 'LoadData'", detail.Name)
+		t.Errorf("Name = %q, want 'LoadData'", detail.Name)
 	}
 }
 
 func TestRunProcessDump_YAMLFile(t *testing.T) {
 	resetCmdFlags(t)
-
 	tmpDir := t.TempDir()
-	outFile := filepath.Join(tmpDir, "loaddata.yaml")
+	outFile := filepath.Join(tmpDir, "test.yaml")
 	procDumpOut = outFile
 
 	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		w.Write(processDetailJSON())
+		w.Write(processDetailJSON("LoadData"))
 	})
 
 	captureAll(t, func() {
@@ -1076,20 +1051,22 @@ func TestRunProcessDump_YAMLFile(t *testing.T) {
 		}
 	})
 
-	fileData, err := os.ReadFile(outFile)
+	data, err := os.ReadFile(outFile)
 	if err != nil {
 		t.Fatalf("cannot read output file: %v", err)
 	}
+
 	var detail model.ProcessDetail
-	if err := yaml.Unmarshal(fileData, &detail); err != nil {
-		t.Fatalf("cannot parse file as YAML ProcessDetail: %v", err)
+	if err := yaml.Unmarshal(data, &detail); err != nil {
+		t.Fatalf("file is not valid YAML: %v", err)
 	}
 	if detail.Name != "LoadData" {
-		t.Errorf("detail.Name = %q, want 'LoadData'", detail.Name)
+		t.Errorf("Name = %q, want 'LoadData'", detail.Name)
 	}
-	// YAML tags use "prolog" not "PrologProcedure"
-	if !strings.Contains(string(fileData), "prolog:") {
-		t.Errorf("YAML output missing 'prolog:' key:\n%s", fileData)
+
+	yamlStr := string(data)
+	if !strings.Contains(yamlStr, "prolog:") {
+		t.Error("YAML should use 'prolog' key")
 	}
 }
 
@@ -1101,25 +1078,28 @@ func TestRunProcessDump_NotFound(t *testing.T) {
 		w.Write([]byte(`Not found`))
 	})
 
-	captureAll(t, func() {
+	captured := captureAll(t, func() {
 		err := runProcessDump(processDumpCmd, []string{"NonExistent"})
 		if err != errSilent {
 			t.Fatalf("expected errSilent, got: %v", err)
 		}
 	})
+
+	if !strings.Contains(captured.Stderr, "Not found") {
+		t.Errorf("stderr should contain 'Not found', got: %q", captured.Stderr)
+	}
 }
 
-func TestRunProcessDump_InvalidExtension(t *testing.T) {
+func TestRunProcessDump_UnsupportedExtension(t *testing.T) {
 	resetCmdFlags(t)
-	procDumpOut = "file.txt"
+	procDumpOut = "output.txt"
 
-	// No mock server — error should occur before any network call
 	err := runProcessDump(processDumpCmd, []string{"LoadData"})
 	if err == nil {
-		t.Fatal("expected error for unsupported format, got nil")
+		t.Fatal("expected error for unsupported extension")
 	}
-	if !strings.Contains(err.Error(), "Unsupported format") {
-		t.Errorf("error = %q, want it to mention 'Unsupported format'", err.Error())
+	if !strings.Contains(err.Error(), "Unsupported file format") {
+		t.Errorf("error = %q, want 'Unsupported file format'", err.Error())
 	}
 }
 
@@ -1127,351 +1107,339 @@ func TestRunProcessDump_InvalidExtension(t *testing.T) {
 // Integration tests — runProcessLoad
 // ============================================================
 
-func writeProcessJSONFile(t *testing.T, dir string, detail model.ProcessDetail) string {
-	t.Helper()
-	data, err := json.MarshalIndent(detail, "", "  ")
-	if err != nil {
-		t.Fatalf("cannot marshal detail: %v", err)
-	}
-	path := filepath.Join(dir, "process.json")
-	if err := os.WriteFile(path, data, 0644); err != nil {
-		t.Fatalf("cannot write file: %v", err)
-	}
-	return path
-}
-
-func writeProcessYAMLFile(t *testing.T, dir string, detail model.ProcessDetail) string {
-	t.Helper()
-	data, err := yaml.Marshal(detail)
-	if err != nil {
-		t.Fatalf("cannot marshal detail: %v", err)
-	}
-	path := filepath.Join(dir, "process.yaml")
-	if err := os.WriteFile(path, data, 0644); err != nil {
-		t.Fatalf("cannot write file: %v", err)
-	}
-	return path
-}
-
-func TestRunProcessLoad_PatchSuccess(t *testing.T) {
+func TestRunProcessLoad_CreateNew(t *testing.T) {
 	resetCmdFlags(t)
 
 	tmpDir := t.TempDir()
+	inFile := filepath.Join(tmpDir, "proc.json")
 	detail := model.ProcessDetail{
 		Name:            "LoadData",
-		PrologProcedure: "IF(1=1);",
+		PrologProcedure: "# code",
 		DataSource:      model.ProcessDataSource{Type: "None"},
 	}
-	procLoadFile = writeProcessJSONFile(t, tmpDir, detail)
+	data, _ := json.MarshalIndent(detail, "", "  ")
+	os.WriteFile(inFile, data, 0600)
+	procLoadFile = inFile
 
-	var capturedMethod string
+	var postBody string
 	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
-		capturedMethod = r.Method
-		w.WriteHeader(http.StatusNoContent)
-	})
-
-	captured := captureAll(t, func() {
-		err := runProcessLoad(processLoadCmd, []string{"LoadData"})
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-	})
-
-	if capturedMethod != "PATCH" {
-		t.Errorf("method = %q, want PATCH", capturedMethod)
-	}
-	if !strings.Contains(captured.Stdout, "updated successfully") {
-		t.Errorf("stdout missing success message:\n%s", captured.Stdout)
-	}
-}
-
-func TestRunProcessLoad_PatchFallbackToPost(t *testing.T) {
-	resetCmdFlags(t)
-
-	tmpDir := t.TempDir()
-	detail := model.ProcessDetail{
-		Name:       "NewProcess",
-		DataSource: model.ProcessDataSource{Type: "None"},
-	}
-	procLoadFile = writeProcessJSONFile(t, tmpDir, detail)
-
-	var capturedMethods []string
-	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
-		capturedMethods = append(capturedMethods, r.Method)
-		if r.Method == "PATCH" {
+		if r.Method == "GET" && strings.Contains(r.URL.Path, "Processes") {
 			w.WriteHeader(http.StatusNotFound)
 			w.Write([]byte(`Not found`))
 			return
 		}
-		// POST
-		w.WriteHeader(http.StatusCreated)
-	})
-
-	captured := captureAll(t, func() {
-		err := runProcessLoad(processLoadCmd, []string{"NewProcess"})
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-	})
-
-	if len(capturedMethods) < 2 {
-		t.Fatalf("expected at least 2 requests, got %d", len(capturedMethods))
-	}
-	if capturedMethods[0] != "PATCH" {
-		t.Errorf("first method = %q, want PATCH", capturedMethods[0])
-	}
-	if capturedMethods[1] != "POST" {
-		t.Errorf("second method = %q, want POST", capturedMethods[1])
-	}
-	if !strings.Contains(captured.Stdout, "created successfully") {
-		t.Errorf("stdout missing created message:\n%s", captured.Stdout)
-	}
-}
-
-func TestRunProcessLoad_CreateOnly(t *testing.T) {
-	resetCmdFlags(t)
-	procLoadCreateOnly = true
-
-	tmpDir := t.TempDir()
-	detail := model.ProcessDetail{
-		Name:       "NewProcess",
-		DataSource: model.ProcessDataSource{Type: "None"},
-	}
-	procLoadFile = writeProcessJSONFile(t, tmpDir, detail)
-
-	var capturedMethods []string
-	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
-		capturedMethods = append(capturedMethods, r.Method)
-		w.WriteHeader(http.StatusCreated)
-	})
-
-	captured := captureAll(t, func() {
-		err := runProcessLoad(processLoadCmd, []string{"NewProcess"})
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-	})
-
-	for _, m := range capturedMethods {
-		if m == "PATCH" {
-			t.Error("--create-only should not send PATCH request")
-		}
-	}
-	if len(capturedMethods) == 0 || capturedMethods[0] != "POST" {
-		t.Errorf("expected POST as first request, got: %v", capturedMethods)
-	}
-	if !strings.Contains(captured.Stdout, "created successfully") {
-		t.Errorf("stdout missing created message:\n%s", captured.Stdout)
-	}
-}
-
-func TestRunProcessLoad_UpdateOnly404(t *testing.T) {
-	resetCmdFlags(t)
-	procLoadUpdateOnly = true
-
-	tmpDir := t.TempDir()
-	detail := model.ProcessDetail{
-		Name:       "NonExistent",
-		DataSource: model.ProcessDataSource{Type: "None"},
-	}
-	procLoadFile = writeProcessJSONFile(t, tmpDir, detail)
-
-	var capturedMethods []string
-	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
-		capturedMethods = append(capturedMethods, r.Method)
-		w.WriteHeader(http.StatusNotFound)
-		w.Write([]byte(`Not found`))
-	})
-
-	captureAll(t, func() {
-		err := runProcessLoad(processLoadCmd, []string{"NonExistent"})
-		if err != errSilent {
-			t.Fatalf("expected errSilent, got: %v", err)
-		}
-	})
-
-	// Should not fall back to POST when --update-only is set
-	for _, m := range capturedMethods {
-		if m == "POST" {
-			t.Error("--update-only should not fall back to POST on 404")
-		}
-	}
-}
-
-func TestRunProcessLoad_YAMLFile(t *testing.T) {
-	resetCmdFlags(t)
-
-	tmpDir := t.TempDir()
-	detail := model.ProcessDetail{
-		Name:            "LoadData",
-		PrologProcedure: "IF(1=1);",
-		DataSource:      model.ProcessDataSource{Type: "None"},
-		Parameters:      []model.ProcessParamDef{{Name: "pYear", Type: "String"}},
-	}
-	procLoadFile = writeProcessYAMLFile(t, tmpDir, detail)
-
-	var capturedBody []byte
-	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
-		capturedBody, _ = io.ReadAll(r.Body)
-		w.WriteHeader(http.StatusNoContent)
-	})
-
-	captureAll(t, func() {
-		err := runProcessLoad(processLoadCmd, []string{"LoadData"})
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-	})
-
-	// PATCH body should be valid JSON containing the process fields
-	if !json.Valid(capturedBody) {
-		t.Fatalf("PATCH body is not valid JSON:\n%s", capturedBody)
-	}
-	if !strings.Contains(string(capturedBody), "LoadData") {
-		t.Errorf("PATCH body missing 'LoadData':\n%s", capturedBody)
-	}
-}
-
-func TestRunProcessLoad_MissingFileFlag(t *testing.T) {
-	resetCmdFlags(t)
-	// procLoadFile intentionally left empty
-
-	err := runProcessLoad(processLoadCmd, []string{"LoadData"})
-	if err == nil {
-		t.Fatal("expected error for missing --file, got nil")
-	}
-	if !strings.Contains(err.Error(), "--file") && !strings.Contains(err.Error(), "-f") {
-		t.Errorf("error = %q, want it to mention --file or -f", err.Error())
-	}
-}
-
-func TestRunProcessLoad_CreateOnlyUpdateOnlyMutuallyExclusive(t *testing.T) {
-	resetCmdFlags(t)
-	procLoadCreateOnly = true
-	procLoadUpdateOnly = true
-	procLoadFile = "some.json" // won't be read; error should occur first
-
-	err := runProcessLoad(processLoadCmd, []string{"LoadData"})
-	if err == nil {
-		t.Fatal("expected error for mutually exclusive flags, got nil")
-	}
-	if !strings.Contains(err.Error(), "mutually exclusive") {
-		t.Errorf("error = %q, want it to mention 'mutually exclusive'", err.Error())
-	}
-}
-
-func TestRunProcessLoad_FileNotFound(t *testing.T) {
-	resetCmdFlags(t)
-	procLoadFile = "/nonexistent/path/process.json"
-
-	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
-		// Should not be reached
-		t.Error("no network call should be made when file is missing")
-		w.WriteHeader(http.StatusOK)
-	})
-
-	captureAll(t, func() {
-		err := runProcessLoad(processLoadCmd, []string{"LoadData"})
-		if err != errSilent {
-			t.Fatalf("expected errSilent, got: %v", err)
-		}
-	})
-}
-
-func TestRunProcessLoad_NonNotFoundErrorNoFallback(t *testing.T) {
-	resetCmdFlags(t)
-
-	tmpDir := t.TempDir()
-	detail := model.ProcessDetail{
-		Name:       "LoadData",
-		DataSource: model.ProcessDataSource{Type: "None"},
-	}
-	procLoadFile = writeProcessJSONFile(t, tmpDir, detail)
-
-	var capturedMethods []string
-	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
-		capturedMethods = append(capturedMethods, r.Method)
-		// Return 500 for PATCH — should NOT fall back to POST
-		w.WriteHeader(http.StatusInternalServerError)
-		w.Write([]byte(`Internal Server Error`))
-	})
-
-	captureAll(t, func() {
-		err := runProcessLoad(processLoadCmd, []string{"LoadData"})
-		if err != errSilent {
-			t.Fatalf("expected errSilent, got: %v", err)
-		}
-	})
-
-	for _, m := range capturedMethods {
-		if m == "POST" {
-			t.Error("500 error should not fall back to POST")
-		}
-	}
-}
-
-func TestProcessDumpLoadRoundtrip(t *testing.T) {
-	resetCmdFlags(t)
-
-	tmpDir := t.TempDir()
-	outFile := filepath.Join(tmpDir, "roundtrip.json")
-	procDumpOut = outFile
-
-	// Step 1: dump to file
-	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
-		if r.Method == "GET" {
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusOK)
-			w.Write(processDetailJSON())
+		if r.Method == "POST" && strings.Contains(r.URL.Path, "Processes") {
+			body, _ := io.ReadAll(r.Body)
+			postBody = string(body)
+			w.WriteHeader(http.StatusCreated)
 			return
 		}
-		t.Errorf("unexpected method %s in dump phase", r.Method)
+		w.WriteHeader(http.StatusNotFound)
 	})
 
-	captureAll(t, func() {
-		if err := runProcessDump(processDumpCmd, []string{"LoadData"}); err != nil {
-			t.Fatalf("dump failed: %v", err)
+	captured := captureAll(t, func() {
+		err := runProcessLoad(processLoadCmd, []string{"LoadData"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
 		}
 	})
 
-	// Reset flags for load phase
-	zeroAllFlags()
-	procLoadFile = outFile
+	if !strings.Contains(captured.Stdout, "Created") {
+		t.Errorf("output should contain 'Created', got: %q", captured.Stdout)
+	}
+	if !strings.Contains(postBody, "LoadData") {
+		t.Errorf("POST body should contain 'LoadData', got: %s", postBody)
+	}
+}
 
-	// Step 2: load from file, capture the PATCH body
-	var capturedBody []byte
+func TestRunProcessLoad_UpdateExisting(t *testing.T) {
+	resetCmdFlags(t)
+
+	tmpDir := t.TempDir()
+	inFile := filepath.Join(tmpDir, "proc.json")
+	detail := model.ProcessDetail{
+		Name:            "LoadData",
+		PrologProcedure: "# updated code",
+		DataSource:      model.ProcessDataSource{Type: "None"},
+	}
+	data, _ := json.MarshalIndent(detail, "", "  ")
+	os.WriteFile(inFile, data, 0600)
+	procLoadFile = inFile
+
+	var patchBody string
 	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "GET" && strings.Contains(r.URL.Path, "Processes") {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write(processDetailJSON("LoadData"))
+			return
+		}
 		if r.Method == "PATCH" {
-			capturedBody, _ = io.ReadAll(r.Body)
+			body, _ := io.ReadAll(r.Body)
+			patchBody = string(body)
 			w.WriteHeader(http.StatusNoContent)
 			return
 		}
-		t.Errorf("unexpected method %s in load phase", r.Method)
+		w.WriteHeader(http.StatusNotFound)
 	})
 
-	captureAll(t, func() {
-		if err := runProcessLoad(processLoadCmd, []string{"LoadData"}); err != nil {
-			t.Fatalf("load failed: %v", err)
+	captured := captureAll(t, func() {
+		err := runProcessLoad(processLoadCmd, []string{"LoadData"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
 		}
 	})
 
-	// The PATCH body should be valid JSON and match the original detail
-	if !json.Valid(capturedBody) {
-		t.Fatalf("PATCH body is not valid JSON:\n%s", capturedBody)
+	if !strings.Contains(captured.Stdout, "Updated") {
+		t.Errorf("output should contain 'Updated', got: %q", captured.Stdout)
 	}
+	if !strings.Contains(patchBody, "# updated code") {
+		t.Errorf("PATCH body should contain '# updated code', got: %s", patchBody)
+	}
+}
 
-	var loaded model.ProcessDetail
-	if err := json.Unmarshal(capturedBody, &loaded); err != nil {
-		t.Fatalf("cannot parse PATCH body: %v", err)
+func TestRunProcessLoad_CreateOnly_Exists(t *testing.T) {
+	resetCmdFlags(t)
+	procLoadCreateOnly = true
+
+	tmpDir := t.TempDir()
+	inFile := filepath.Join(tmpDir, "proc.json")
+	detail := model.ProcessDetail{Name: "LoadData", DataSource: model.ProcessDataSource{Type: "None"}}
+	data, _ := json.Marshal(detail)
+	os.WriteFile(inFile, data, 0600)
+	procLoadFile = inFile
+
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "GET" && strings.Contains(r.URL.Path, "Processes") {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write(processDetailJSON("LoadData"))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	})
+
+	captured := captureAll(t, func() {
+		err := runProcessLoad(processLoadCmd, []string{"LoadData"})
+		if err != errSilent {
+			t.Fatalf("expected errSilent, got: %v", err)
+		}
+	})
+
+	if !strings.Contains(captured.Stderr, "already exists") {
+		t.Errorf("stderr should contain 'already exists', got: %q", captured.Stderr)
 	}
-	if loaded.Name != "LoadData" {
-		t.Errorf("loaded.Name = %q, want 'LoadData'", loaded.Name)
+}
+
+func TestRunProcessLoad_UpdateOnly_NotFound(t *testing.T) {
+	resetCmdFlags(t)
+	procLoadUpdateOnly = true
+
+	tmpDir := t.TempDir()
+	inFile := filepath.Join(tmpDir, "proc.json")
+	detail := model.ProcessDetail{Name: "LoadData", DataSource: model.ProcessDataSource{Type: "None"}}
+	data, _ := json.Marshal(detail)
+	os.WriteFile(inFile, data, 0600)
+	procLoadFile = inFile
+
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "GET" {
+			w.WriteHeader(http.StatusNotFound)
+			w.Write([]byte(`Not found`))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	})
+
+	captured := captureAll(t, func() {
+		err := runProcessLoad(processLoadCmd, []string{"LoadData"})
+		if err != errSilent {
+			t.Fatalf("expected errSilent, got: %v", err)
+		}
+	})
+
+	if !strings.Contains(captured.Stderr, "does not exist") {
+		t.Errorf("stderr should contain 'does not exist', got: %q", captured.Stderr)
 	}
-	if loaded.PrologProcedure != "#Region Prolog\nIF(1=1);\nEndIf;" {
-		t.Errorf("loaded.PrologProcedure = %q, want original value", loaded.PrologProcedure)
+}
+
+func TestRunProcessLoad_MutualExclusive(t *testing.T) {
+	resetCmdFlags(t)
+	procLoadCreateOnly = true
+	procLoadUpdateOnly = true
+	procLoadFile = "dummy.json"
+
+	err := runProcessLoad(processLoadCmd, []string{"LoadData"})
+	if err == nil {
+		t.Fatal("expected error for mutual exclusive flags")
 	}
-	if len(loaded.Parameters) != 1 || loaded.Parameters[0].Name != "pYear" {
-		t.Errorf("loaded.Parameters = %+v, want one param 'pYear'", loaded.Parameters)
+	if !strings.Contains(err.Error(), "Cannot use --create-only and --update-only together") {
+		t.Errorf("error = %q, want mutual exclusivity error", err.Error())
+	}
+}
+
+func TestRunProcessLoad_UnsupportedExtension(t *testing.T) {
+	resetCmdFlags(t)
+	procLoadFile = "data.txt"
+
+	err := runProcessLoad(processLoadCmd, []string{"LoadData"})
+	if err == nil {
+		t.Fatal("expected error for unsupported extension")
+	}
+	if !strings.Contains(err.Error(), "Unsupported file format") {
+		t.Errorf("error = %q, want 'Unsupported file format'", err.Error())
+	}
+}
+
+func TestRunProcessLoad_NameOverride(t *testing.T) {
+	resetCmdFlags(t)
+
+	tmpDir := t.TempDir()
+	inFile := filepath.Join(tmpDir, "proc.json")
+	detail := model.ProcessDetail{
+		Name:       "OldName",
+		DataSource: model.ProcessDataSource{Type: "None"},
+	}
+	data, _ := json.Marshal(detail)
+	os.WriteFile(inFile, data, 0600)
+	procLoadFile = inFile
+
+	var postBody string
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "GET" {
+			w.WriteHeader(http.StatusNotFound)
+			w.Write([]byte(`Not found`))
+			return
+		}
+		if r.Method == "POST" {
+			body, _ := io.ReadAll(r.Body)
+			postBody = string(body)
+			w.WriteHeader(http.StatusCreated)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	})
+
+	captureAll(t, func() {
+		err := runProcessLoad(processLoadCmd, []string{"NewName"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	// POST body should have "NewName", not "OldName"
+	if strings.Contains(postBody, "OldName") {
+		t.Error("POST body should NOT contain 'OldName'")
+	}
+	if !strings.Contains(postBody, "NewName") {
+		t.Errorf("POST body should contain 'NewName', got: %s", postBody)
+	}
+}
+
+func TestRunProcessLoad_JSONOutput(t *testing.T) {
+	resetCmdFlags(t)
+	flagOutput = "json"
+
+	tmpDir := t.TempDir()
+	inFile := filepath.Join(tmpDir, "proc.json")
+	detail := model.ProcessDetail{Name: "LoadData", DataSource: model.ProcessDataSource{Type: "None"}}
+	data, _ := json.Marshal(detail)
+	os.WriteFile(inFile, data, 0600)
+	procLoadFile = inFile
+
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "GET" {
+			w.WriteHeader(http.StatusNotFound)
+			w.Write([]byte(`Not found`))
+			return
+		}
+		if r.Method == "POST" {
+			w.WriteHeader(http.StatusCreated)
+			return
+		}
+	})
+
+	captured := captureAll(t, func() {
+		err := runProcessLoad(processLoadCmd, []string{"LoadData"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	var result map[string]string
+	if err := json.Unmarshal([]byte(captured.Stdout), &result); err != nil {
+		t.Fatalf("output is not valid JSON: %v\noutput: %s", err, captured.Stdout)
+	}
+	if result["status"] != "created" {
+		t.Errorf("status = %q, want 'created'", result["status"])
+	}
+	if result["process"] != "LoadData" {
+		t.Errorf("process = %q, want 'LoadData'", result["process"])
+	}
+}
+
+// ============================================================
+// processExists tests
+// ============================================================
+
+func TestProcessExists_True(t *testing.T) {
+	resetCmdFlags(t)
+
+	ts := setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"Name":"LoadData"}`))
+	})
+
+	cfg, _ := loadConfig()
+	cl, _ := createClient(cfg)
+	_ = ts
+
+	exists, err := processExists(cl, "LoadData")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !exists {
+		t.Error("expected process to exist")
+	}
+}
+
+func TestProcessExists_False(t *testing.T) {
+	resetCmdFlags(t)
+
+	ts := setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		w.Write([]byte(`Not found`))
+	})
+	_ = ts
+
+	cfg, _ := loadConfig()
+	cl, _ := createClient(cfg)
+
+	exists, err := processExists(cl, "NonExistent")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if exists {
+		t.Error("expected process to not exist")
+	}
+}
+
+func TestProcessExists_Error(t *testing.T) {
+	resetCmdFlags(t)
+
+	ts := setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte(`Server error`))
+	})
+	_ = ts
+
+	cfg, _ := loadConfig()
+	cl, _ := createClient(cfg)
+
+	exists, err := processExists(cl, "Broken")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if exists {
+		t.Error("expected exists=false on error")
 	}
 }
 

--- a/cmd/process_test.go
+++ b/cmd/process_test.go
@@ -1118,7 +1118,9 @@ func TestRunProcessLoad_CreateNew(t *testing.T) {
 		DataSource:      model.ProcessDataSource{Type: "None"},
 	}
 	data, _ := json.MarshalIndent(detail, "", "  ")
-	os.WriteFile(inFile, data, 0600)
+	if err := os.WriteFile(inFile, data, 0600); err != nil {
+		t.Fatalf("test setup: cannot write fixture: %v", err)
+	}
 	procLoadFile = inFile
 
 	var postBody string
@@ -1163,7 +1165,9 @@ func TestRunProcessLoad_UpdateExisting(t *testing.T) {
 		DataSource:      model.ProcessDataSource{Type: "None"},
 	}
 	data, _ := json.MarshalIndent(detail, "", "  ")
-	os.WriteFile(inFile, data, 0600)
+	if err := os.WriteFile(inFile, data, 0600); err != nil {
+		t.Fatalf("test setup: cannot write fixture: %v", err)
+	}
 	procLoadFile = inFile
 
 	var patchBody string
@@ -1205,7 +1209,9 @@ func TestRunProcessLoad_CreateOnly_Exists(t *testing.T) {
 	inFile := filepath.Join(tmpDir, "proc.json")
 	detail := model.ProcessDetail{Name: "LoadData", DataSource: model.ProcessDataSource{Type: "None"}}
 	data, _ := json.Marshal(detail)
-	os.WriteFile(inFile, data, 0600)
+	if err := os.WriteFile(inFile, data, 0600); err != nil {
+		t.Fatalf("test setup: cannot write fixture: %v", err)
+	}
 	procLoadFile = inFile
 
 	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
@@ -1237,7 +1243,9 @@ func TestRunProcessLoad_UpdateOnly_NotFound(t *testing.T) {
 	inFile := filepath.Join(tmpDir, "proc.json")
 	detail := model.ProcessDetail{Name: "LoadData", DataSource: model.ProcessDataSource{Type: "None"}}
 	data, _ := json.Marshal(detail)
-	os.WriteFile(inFile, data, 0600)
+	if err := os.WriteFile(inFile, data, 0600); err != nil {
+		t.Fatalf("test setup: cannot write fixture: %v", err)
+	}
 	procLoadFile = inFile
 
 	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
@@ -1299,7 +1307,9 @@ func TestRunProcessLoad_NameOverride(t *testing.T) {
 		DataSource: model.ProcessDataSource{Type: "None"},
 	}
 	data, _ := json.Marshal(detail)
-	os.WriteFile(inFile, data, 0600)
+	if err := os.WriteFile(inFile, data, 0600); err != nil {
+		t.Fatalf("test setup: cannot write fixture: %v", err)
+	}
 	procLoadFile = inFile
 
 	var postBody string
@@ -1342,7 +1352,9 @@ func TestRunProcessLoad_JSONOutput(t *testing.T) {
 	inFile := filepath.Join(tmpDir, "proc.json")
 	detail := model.ProcessDetail{Name: "LoadData", DataSource: model.ProcessDataSource{Type: "None"}}
 	data, _ := json.Marshal(detail)
-	os.WriteFile(inFile, data, 0600)
+	if err := os.WriteFile(inFile, data, 0600); err != nil {
+		t.Fatalf("test setup: cannot write fixture: %v", err)
+	}
 	procLoadFile = inFile
 
 	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {

--- a/cmd/process_test.go
+++ b/cmd/process_test.go
@@ -6,9 +6,13 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"tm1cli/internal/model"
+
+	"gopkg.in/yaml.v3"
 )
 
 // --- filterSystemProcesses tests ---
@@ -961,3 +965,513 @@ func TestRunProcessList_FilterFallbackWarning(t *testing.T) {
 		t.Error("output should NOT contain 'RunReport' (doesn't match 'load' filter)")
 	}
 }
+
+// ============================================================
+// Helpers for dump/load tests
+// ============================================================
+
+func processDetailJSON() []byte {
+	return []byte(`{
+		"@odata.context": "...",
+		"Name": "LoadData",
+		"PrologProcedure": "#Region Prolog\nIF(1=1);\nEndIf;",
+		"MetadataProcedure": "",
+		"DataProcedure": "CellPutN(1, 'Sales', 'Jan', 'Actual');",
+		"EpilogProcedure": "",
+		"HasSecurityAccess": false,
+		"Parameters": [
+			{"Name": "pYear", "Prompt": "Year", "Value": "2024", "Type": "String"}
+		],
+		"DataSource": {
+			"Type": "None"
+		},
+		"Variables": []
+	}`)
+}
+
+// ============================================================
+// Integration tests — runProcessDump
+// ============================================================
+
+func TestRunProcessDump_JSONStdout(t *testing.T) {
+	resetCmdFlags(t)
+
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write(processDetailJSON())
+	})
+
+	captured := captureAll(t, func() {
+		err := runProcessDump(processDumpCmd, []string{"LoadData"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	if !json.Valid([]byte(captured.Stdout)) {
+		t.Fatalf("stdout is not valid JSON:\n%s", captured.Stdout)
+	}
+	if !strings.Contains(captured.Stdout, "LoadData") {
+		t.Errorf("stdout missing 'LoadData':\n%s", captured.Stdout)
+	}
+	if !strings.Contains(captured.Stdout, "PrologProcedure") {
+		t.Errorf("stdout missing 'PrologProcedure':\n%s", captured.Stdout)
+	}
+}
+
+func TestRunProcessDump_JSONFile(t *testing.T) {
+	resetCmdFlags(t)
+
+	tmpDir := t.TempDir()
+	outFile := filepath.Join(tmpDir, "loaddata.json")
+	procDumpOut = outFile
+
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write(processDetailJSON())
+	})
+
+	captureAll(t, func() {
+		err := runProcessDump(processDumpCmd, []string{"LoadData"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	fileData, err := os.ReadFile(outFile)
+	if err != nil {
+		t.Fatalf("cannot read output file: %v", err)
+	}
+	if !json.Valid(fileData) {
+		t.Fatalf("file content is not valid JSON:\n%s", fileData)
+	}
+	var detail model.ProcessDetail
+	if err := json.Unmarshal(fileData, &detail); err != nil {
+		t.Fatalf("cannot parse file as ProcessDetail: %v", err)
+	}
+	if detail.Name != "LoadData" {
+		t.Errorf("detail.Name = %q, want 'LoadData'", detail.Name)
+	}
+}
+
+func TestRunProcessDump_YAMLFile(t *testing.T) {
+	resetCmdFlags(t)
+
+	tmpDir := t.TempDir()
+	outFile := filepath.Join(tmpDir, "loaddata.yaml")
+	procDumpOut = outFile
+
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write(processDetailJSON())
+	})
+
+	captureAll(t, func() {
+		err := runProcessDump(processDumpCmd, []string{"LoadData"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	fileData, err := os.ReadFile(outFile)
+	if err != nil {
+		t.Fatalf("cannot read output file: %v", err)
+	}
+	var detail model.ProcessDetail
+	if err := yaml.Unmarshal(fileData, &detail); err != nil {
+		t.Fatalf("cannot parse file as YAML ProcessDetail: %v", err)
+	}
+	if detail.Name != "LoadData" {
+		t.Errorf("detail.Name = %q, want 'LoadData'", detail.Name)
+	}
+	// YAML tags use "prolog" not "PrologProcedure"
+	if !strings.Contains(string(fileData), "prolog:") {
+		t.Errorf("YAML output missing 'prolog:' key:\n%s", fileData)
+	}
+}
+
+func TestRunProcessDump_NotFound(t *testing.T) {
+	resetCmdFlags(t)
+
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		w.Write([]byte(`Not found`))
+	})
+
+	captureAll(t, func() {
+		err := runProcessDump(processDumpCmd, []string{"NonExistent"})
+		if err != errSilent {
+			t.Fatalf("expected errSilent, got: %v", err)
+		}
+	})
+}
+
+func TestRunProcessDump_InvalidExtension(t *testing.T) {
+	resetCmdFlags(t)
+	procDumpOut = "file.txt"
+
+	// No mock server — error should occur before any network call
+	err := runProcessDump(processDumpCmd, []string{"LoadData"})
+	if err == nil {
+		t.Fatal("expected error for unsupported format, got nil")
+	}
+	if !strings.Contains(err.Error(), "Unsupported format") {
+		t.Errorf("error = %q, want it to mention 'Unsupported format'", err.Error())
+	}
+}
+
+// ============================================================
+// Integration tests — runProcessLoad
+// ============================================================
+
+func writeProcessJSONFile(t *testing.T, dir string, detail model.ProcessDetail) string {
+	t.Helper()
+	data, err := json.MarshalIndent(detail, "", "  ")
+	if err != nil {
+		t.Fatalf("cannot marshal detail: %v", err)
+	}
+	path := filepath.Join(dir, "process.json")
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		t.Fatalf("cannot write file: %v", err)
+	}
+	return path
+}
+
+func writeProcessYAMLFile(t *testing.T, dir string, detail model.ProcessDetail) string {
+	t.Helper()
+	data, err := yaml.Marshal(detail)
+	if err != nil {
+		t.Fatalf("cannot marshal detail: %v", err)
+	}
+	path := filepath.Join(dir, "process.yaml")
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		t.Fatalf("cannot write file: %v", err)
+	}
+	return path
+}
+
+func TestRunProcessLoad_PatchSuccess(t *testing.T) {
+	resetCmdFlags(t)
+
+	tmpDir := t.TempDir()
+	detail := model.ProcessDetail{
+		Name:            "LoadData",
+		PrologProcedure: "IF(1=1);",
+		DataSource:      model.ProcessDataSource{Type: "None"},
+	}
+	procLoadFile = writeProcessJSONFile(t, tmpDir, detail)
+
+	var capturedMethod string
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		capturedMethod = r.Method
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	captured := captureAll(t, func() {
+		err := runProcessLoad(processLoadCmd, []string{"LoadData"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	if capturedMethod != "PATCH" {
+		t.Errorf("method = %q, want PATCH", capturedMethod)
+	}
+	if !strings.Contains(captured.Stdout, "updated successfully") {
+		t.Errorf("stdout missing success message:\n%s", captured.Stdout)
+	}
+}
+
+func TestRunProcessLoad_PatchFallbackToPost(t *testing.T) {
+	resetCmdFlags(t)
+
+	tmpDir := t.TempDir()
+	detail := model.ProcessDetail{
+		Name:       "NewProcess",
+		DataSource: model.ProcessDataSource{Type: "None"},
+	}
+	procLoadFile = writeProcessJSONFile(t, tmpDir, detail)
+
+	var capturedMethods []string
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		capturedMethods = append(capturedMethods, r.Method)
+		if r.Method == "PATCH" {
+			w.WriteHeader(http.StatusNotFound)
+			w.Write([]byte(`Not found`))
+			return
+		}
+		// POST
+		w.WriteHeader(http.StatusCreated)
+	})
+
+	captured := captureAll(t, func() {
+		err := runProcessLoad(processLoadCmd, []string{"NewProcess"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	if len(capturedMethods) < 2 {
+		t.Fatalf("expected at least 2 requests, got %d", len(capturedMethods))
+	}
+	if capturedMethods[0] != "PATCH" {
+		t.Errorf("first method = %q, want PATCH", capturedMethods[0])
+	}
+	if capturedMethods[1] != "POST" {
+		t.Errorf("second method = %q, want POST", capturedMethods[1])
+	}
+	if !strings.Contains(captured.Stdout, "created successfully") {
+		t.Errorf("stdout missing created message:\n%s", captured.Stdout)
+	}
+}
+
+func TestRunProcessLoad_CreateOnly(t *testing.T) {
+	resetCmdFlags(t)
+	procLoadCreateOnly = true
+
+	tmpDir := t.TempDir()
+	detail := model.ProcessDetail{
+		Name:       "NewProcess",
+		DataSource: model.ProcessDataSource{Type: "None"},
+	}
+	procLoadFile = writeProcessJSONFile(t, tmpDir, detail)
+
+	var capturedMethods []string
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		capturedMethods = append(capturedMethods, r.Method)
+		w.WriteHeader(http.StatusCreated)
+	})
+
+	captured := captureAll(t, func() {
+		err := runProcessLoad(processLoadCmd, []string{"NewProcess"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	for _, m := range capturedMethods {
+		if m == "PATCH" {
+			t.Error("--create-only should not send PATCH request")
+		}
+	}
+	if len(capturedMethods) == 0 || capturedMethods[0] != "POST" {
+		t.Errorf("expected POST as first request, got: %v", capturedMethods)
+	}
+	if !strings.Contains(captured.Stdout, "created successfully") {
+		t.Errorf("stdout missing created message:\n%s", captured.Stdout)
+	}
+}
+
+func TestRunProcessLoad_UpdateOnly404(t *testing.T) {
+	resetCmdFlags(t)
+	procLoadUpdateOnly = true
+
+	tmpDir := t.TempDir()
+	detail := model.ProcessDetail{
+		Name:       "NonExistent",
+		DataSource: model.ProcessDataSource{Type: "None"},
+	}
+	procLoadFile = writeProcessJSONFile(t, tmpDir, detail)
+
+	var capturedMethods []string
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		capturedMethods = append(capturedMethods, r.Method)
+		w.WriteHeader(http.StatusNotFound)
+		w.Write([]byte(`Not found`))
+	})
+
+	captureAll(t, func() {
+		err := runProcessLoad(processLoadCmd, []string{"NonExistent"})
+		if err != errSilent {
+			t.Fatalf("expected errSilent, got: %v", err)
+		}
+	})
+
+	// Should not fall back to POST when --update-only is set
+	for _, m := range capturedMethods {
+		if m == "POST" {
+			t.Error("--update-only should not fall back to POST on 404")
+		}
+	}
+}
+
+func TestRunProcessLoad_YAMLFile(t *testing.T) {
+	resetCmdFlags(t)
+
+	tmpDir := t.TempDir()
+	detail := model.ProcessDetail{
+		Name:            "LoadData",
+		PrologProcedure: "IF(1=1);",
+		DataSource:      model.ProcessDataSource{Type: "None"},
+		Parameters:      []model.ProcessParamDef{{Name: "pYear", Type: "String"}},
+	}
+	procLoadFile = writeProcessYAMLFile(t, tmpDir, detail)
+
+	var capturedBody []byte
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		capturedBody, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	captureAll(t, func() {
+		err := runProcessLoad(processLoadCmd, []string{"LoadData"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	// PATCH body should be valid JSON containing the process fields
+	if !json.Valid(capturedBody) {
+		t.Fatalf("PATCH body is not valid JSON:\n%s", capturedBody)
+	}
+	if !strings.Contains(string(capturedBody), "LoadData") {
+		t.Errorf("PATCH body missing 'LoadData':\n%s", capturedBody)
+	}
+}
+
+func TestRunProcessLoad_MissingFileFlag(t *testing.T) {
+	resetCmdFlags(t)
+	// procLoadFile intentionally left empty
+
+	err := runProcessLoad(processLoadCmd, []string{"LoadData"})
+	if err == nil {
+		t.Fatal("expected error for missing --file, got nil")
+	}
+	if !strings.Contains(err.Error(), "--file") && !strings.Contains(err.Error(), "-f") {
+		t.Errorf("error = %q, want it to mention --file or -f", err.Error())
+	}
+}
+
+func TestRunProcessLoad_CreateOnlyUpdateOnlyMutuallyExclusive(t *testing.T) {
+	resetCmdFlags(t)
+	procLoadCreateOnly = true
+	procLoadUpdateOnly = true
+	procLoadFile = "some.json" // won't be read; error should occur first
+
+	err := runProcessLoad(processLoadCmd, []string{"LoadData"})
+	if err == nil {
+		t.Fatal("expected error for mutually exclusive flags, got nil")
+	}
+	if !strings.Contains(err.Error(), "mutually exclusive") {
+		t.Errorf("error = %q, want it to mention 'mutually exclusive'", err.Error())
+	}
+}
+
+func TestRunProcessLoad_FileNotFound(t *testing.T) {
+	resetCmdFlags(t)
+	procLoadFile = "/nonexistent/path/process.json"
+
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		// Should not be reached
+		t.Error("no network call should be made when file is missing")
+		w.WriteHeader(http.StatusOK)
+	})
+
+	captureAll(t, func() {
+		err := runProcessLoad(processLoadCmd, []string{"LoadData"})
+		if err != errSilent {
+			t.Fatalf("expected errSilent, got: %v", err)
+		}
+	})
+}
+
+func TestRunProcessLoad_NonNotFoundErrorNoFallback(t *testing.T) {
+	resetCmdFlags(t)
+
+	tmpDir := t.TempDir()
+	detail := model.ProcessDetail{
+		Name:       "LoadData",
+		DataSource: model.ProcessDataSource{Type: "None"},
+	}
+	procLoadFile = writeProcessJSONFile(t, tmpDir, detail)
+
+	var capturedMethods []string
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		capturedMethods = append(capturedMethods, r.Method)
+		// Return 500 for PATCH — should NOT fall back to POST
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte(`Internal Server Error`))
+	})
+
+	captureAll(t, func() {
+		err := runProcessLoad(processLoadCmd, []string{"LoadData"})
+		if err != errSilent {
+			t.Fatalf("expected errSilent, got: %v", err)
+		}
+	})
+
+	for _, m := range capturedMethods {
+		if m == "POST" {
+			t.Error("500 error should not fall back to POST")
+		}
+	}
+}
+
+func TestProcessDumpLoadRoundtrip(t *testing.T) {
+	resetCmdFlags(t)
+
+	tmpDir := t.TempDir()
+	outFile := filepath.Join(tmpDir, "roundtrip.json")
+	procDumpOut = outFile
+
+	// Step 1: dump to file
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "GET" {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			w.Write(processDetailJSON())
+			return
+		}
+		t.Errorf("unexpected method %s in dump phase", r.Method)
+	})
+
+	captureAll(t, func() {
+		if err := runProcessDump(processDumpCmd, []string{"LoadData"}); err != nil {
+			t.Fatalf("dump failed: %v", err)
+		}
+	})
+
+	// Reset flags for load phase
+	zeroAllFlags()
+	procLoadFile = outFile
+
+	// Step 2: load from file, capture the PATCH body
+	var capturedBody []byte
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "PATCH" {
+			capturedBody, _ = io.ReadAll(r.Body)
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		t.Errorf("unexpected method %s in load phase", r.Method)
+	})
+
+	captureAll(t, func() {
+		if err := runProcessLoad(processLoadCmd, []string{"LoadData"}); err != nil {
+			t.Fatalf("load failed: %v", err)
+		}
+	})
+
+	// The PATCH body should be valid JSON and match the original detail
+	if !json.Valid(capturedBody) {
+		t.Fatalf("PATCH body is not valid JSON:\n%s", capturedBody)
+	}
+
+	var loaded model.ProcessDetail
+	if err := json.Unmarshal(capturedBody, &loaded); err != nil {
+		t.Fatalf("cannot parse PATCH body: %v", err)
+	}
+	if loaded.Name != "LoadData" {
+		t.Errorf("loaded.Name = %q, want 'LoadData'", loaded.Name)
+	}
+	if loaded.PrologProcedure != "#Region Prolog\nIF(1=1);\nEndIf;" {
+		t.Errorf("loaded.PrologProcedure = %q, want original value", loaded.PrologProcedure)
+	}
+	if len(loaded.Parameters) != 1 || loaded.Parameters[0].Name != "pYear" {
+		t.Errorf("loaded.Parameters = %+v, want one param 'pYear'", loaded.Parameters)
+	}
+}
+

--- a/cmd/testhelpers_test.go
+++ b/cmd/testhelpers_test.go
@@ -183,6 +183,10 @@ func zeroAllFlags() {
 	procListShowSystem = false
 	procListCount = false
 	procRunParams = nil
+	procDumpOut = ""
+	procLoadFile = ""
+	procLoadCreateOnly = false
+	procLoadUpdateOnly = false
 	exportView = ""
 	exportMDX = ""
 	exportOut = ""

--- a/cmd/testhelpers_test.go
+++ b/cmd/testhelpers_test.go
@@ -298,6 +298,24 @@ func processesJSON(procs ...string) []byte {
 	return data
 }
 
+// processDetailJSON returns JSON for a TM1 process detail response.
+func processDetailJSON(name string) []byte {
+	detail := model.ProcessDetail{
+		Name:              name,
+		PrologProcedure:   "# prolog code",
+		MetadataProcedure: "",
+		DataProcedure:     "CellPutN(1, 'Cube', 'e1', 'e2');",
+		EpilogProcedure:   "",
+		Parameters: []model.ProcessParamDef{
+			{Name: "pYear", Prompt: "Year", Value: float64(2024), Type: "Numeric"},
+		},
+		DataSource: model.ProcessDataSource{Type: "None"},
+		Variables:  []model.ProcessVariable{},
+	}
+	data, _ := json.Marshal(detail)
+	return data
+}
+
 // activeUserJSON returns JSON for a TM1 ActiveUser response.
 func activeUserJSON(name string) []byte {
 	data, _ := json.Marshal(model.ActiveUser{Name: name})

--- a/go.mod
+++ b/go.mod
@@ -20,4 +20,5 @@ require (
 	golang.org/x/net v0.50.0 // indirect
 	golang.org/x/sys v0.42.0 // indirect
 	golang.org/x/text v0.34.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/spf13/cobra v1.10.2
 	github.com/xuri/excelize/v2 v2.10.1
 	golang.org/x/term v0.41.0
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -20,5 +21,4 @@ require (
 	golang.org/x/net v0.50.0 // indirect
 	golang.org/x/sys v0.42.0 // indirect
 	golang.org/x/text v0.34.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -37,6 +37,7 @@ golang.org/x/term v0.41.0 h1:QCgPso/Q3RTJx2Th4bDLqML4W6iJiaXFq2/ftQF13YU=
 golang.org/x/term v0.41.0/go.mod h1:3pfBgksrReYfZ5lvYM0kSO0LIkAl4Yl2bXOkKP7Ec2A=
 golang.org/x/text v0.34.0 h1:oL/Qq0Kdaqxa1KbNeMKwQq0reLCCaFtqu2eNuSeNHbk=
 golang.org/x/text v0.34.0/go.mod h1:homfLqTYRFyVYemLBFl5GgL/DWEiH5wcsQ5gSh1yziA=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -154,21 +154,22 @@ func (c *Client) Delete(endpoint string) error {
 	return err
 }
 
-func (c *Client) Patch(endpoint string, payload interface{}) ([]byte, int, error) {
+func (c *Client) Patch(endpoint string, payload interface{}) ([]byte, error) {
 	url := c.baseURL + "/" + strings.TrimLeft(endpoint, "/")
 	var bodyReader io.Reader
 	if payload != nil {
 		data, err := json.Marshal(payload)
 		if err != nil {
-			return nil, 0, fmt.Errorf("cannot marshal request body: %w", err)
+			return nil, fmt.Errorf("cannot marshal request body: %w", err)
 		}
 		bodyReader = bytes.NewReader(data)
 	}
 	req, err := http.NewRequest("PATCH", url, bodyReader)
 	if err != nil {
-		return nil, 0, fmt.Errorf("cannot create request: %w", err)
+		return nil, fmt.Errorf("cannot create request: %w", err)
 	}
-	return c.do(req)
+	body, _, err := c.do(req)
+	return body, err
 }
 
 func (c *Client) wrapError(err error) error {

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -15,6 +16,9 @@ import (
 	"time"
 	"tm1cli/internal/config"
 )
+
+// ErrNotFound is returned when the TM1 server responds with HTTP 404.
+var ErrNotFound = errors.New("not found")
 
 type Client struct {
 	httpClient *http.Client
@@ -185,7 +189,7 @@ func (c *Client) httpError(status int, body []byte, endpoint string) error {
 	case 401:
 		return fmt.Errorf("Authentication failed. Check credentials.")
 	case 404:
-		return fmt.Errorf("Not found: %s", endpoint)
+		return fmt.Errorf("Not found: %s: %w", endpoint, ErrNotFound)
 	default:
 		short := string(body)
 		if len(short) > 200 {

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -126,7 +126,7 @@ func (c *Client) Get(endpoint string) ([]byte, error) {
 	return body, err
 }
 
-func (c *Client) Post(endpoint string, payload interface{}) ([]byte, error) {
+func (c *Client) doWithPayload(method, endpoint string, payload interface{}) ([]byte, error) {
 	url := c.baseURL + "/" + strings.TrimLeft(endpoint, "/")
 	var bodyReader io.Reader
 	if payload != nil {
@@ -136,12 +136,20 @@ func (c *Client) Post(endpoint string, payload interface{}) ([]byte, error) {
 		}
 		bodyReader = bytes.NewReader(data)
 	}
-	req, err := http.NewRequest("POST", url, bodyReader)
+	req, err := http.NewRequest(method, url, bodyReader)
 	if err != nil {
 		return nil, fmt.Errorf("cannot create request: %w", err)
 	}
 	body, _, err := c.do(req)
 	return body, err
+}
+
+func (c *Client) Post(endpoint string, payload interface{}) ([]byte, error) {
+	return c.doWithPayload("POST", endpoint, payload)
+}
+
+func (c *Client) Patch(endpoint string, payload interface{}) ([]byte, error) {
+	return c.doWithPayload("PATCH", endpoint, payload)
 }
 
 func (c *Client) Delete(endpoint string) error {
@@ -152,24 +160,6 @@ func (c *Client) Delete(endpoint string) error {
 	}
 	_, _, err = c.do(req)
 	return err
-}
-
-func (c *Client) Patch(endpoint string, payload interface{}) ([]byte, error) {
-	url := c.baseURL + "/" + strings.TrimLeft(endpoint, "/")
-	var bodyReader io.Reader
-	if payload != nil {
-		data, err := json.Marshal(payload)
-		if err != nil {
-			return nil, fmt.Errorf("cannot marshal request body: %w", err)
-		}
-		bodyReader = bytes.NewReader(data)
-	}
-	req, err := http.NewRequest("PATCH", url, bodyReader)
-	if err != nil {
-		return nil, fmt.Errorf("cannot create request: %w", err)
-	}
-	body, _, err := c.do(req)
-	return body, err
 }
 
 func (c *Client) wrapError(err error) error {

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -154,6 +154,23 @@ func (c *Client) Delete(endpoint string) error {
 	return err
 }
 
+func (c *Client) Patch(endpoint string, payload interface{}) ([]byte, int, error) {
+	url := c.baseURL + "/" + strings.TrimLeft(endpoint, "/")
+	var bodyReader io.Reader
+	if payload != nil {
+		data, err := json.Marshal(payload)
+		if err != nil {
+			return nil, 0, fmt.Errorf("cannot marshal request body: %w", err)
+		}
+		bodyReader = bytes.NewReader(data)
+	}
+	req, err := http.NewRequest("PATCH", url, bodyReader)
+	if err != nil {
+		return nil, 0, fmt.Errorf("cannot create request: %w", err)
+	}
+	return c.do(req)
+}
+
 func (c *Client) wrapError(err error) error {
 	if err == nil {
 		return nil

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -3,6 +3,7 @@ package client
 import (
 	"bytes"
 	"encoding/base64"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -322,6 +323,127 @@ func TestDelete(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 	})
+}
+
+func TestPatch(t *testing.T) {
+	payload := map[string]string{"Name": "TestProcess"}
+
+	tests := []struct {
+		name        string
+		handler     http.HandlerFunc
+		wantStatus  int
+		wantBody    string
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name: "successful PATCH returns body",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				w.Write([]byte(`{"Name":"TestProcess"}`))
+			},
+			wantStatus: http.StatusOK,
+			wantBody:   `{"Name":"TestProcess"}`,
+		},
+		{
+			name: "successful PATCH no content",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusNoContent)
+			},
+			wantStatus: http.StatusNoContent,
+			wantBody:   "",
+		},
+		{
+			name: "404 returns not found",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusNotFound)
+				w.Write([]byte(`Not found`))
+			},
+			wantStatus:  http.StatusNotFound,
+			wantErr:     true,
+			errContains: "Not found",
+		},
+		{
+			name: "500 returns server error",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusInternalServerError)
+				w.Write([]byte(`Internal Server Error`))
+			},
+			wantStatus:  http.StatusInternalServerError,
+			wantErr:     true,
+			errContains: "HTTP 500",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ts := newTestServer(tt.handler)
+			defer ts.Close()
+
+			c := newTestClient(t, ts.URL)
+			body, status, err := c.Patch("Processes('test')", payload)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				if tt.errContains != "" && !strings.Contains(err.Error(), tt.errContains) {
+					t.Errorf("error = %q, want it to contain %q", err.Error(), tt.errContains)
+				}
+				if status != tt.wantStatus {
+					t.Errorf("status = %d, want %d", status, tt.wantStatus)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if status != tt.wantStatus {
+				t.Errorf("status = %d, want %d", status, tt.wantStatus)
+			}
+			if string(body) != tt.wantBody {
+				t.Errorf("body = %q, want %q", string(body), tt.wantBody)
+			}
+		})
+	}
+}
+
+func TestPatchSendsCorrectMethod(t *testing.T) {
+	var capturedMethod string
+	ts := newTestServer(func(w http.ResponseWriter, r *http.Request) {
+		capturedMethod = r.Method
+		w.WriteHeader(http.StatusNoContent)
+	})
+	defer ts.Close()
+
+	c := newTestClient(t, ts.URL)
+	_, _, _ = c.Patch("Processes('test')", nil)
+
+	if capturedMethod != "PATCH" {
+		t.Errorf("method = %q, want PATCH", capturedMethod)
+	}
+}
+
+func TestPatchSendsBody(t *testing.T) {
+	var capturedBody string
+	ts := newTestServer(func(w http.ResponseWriter, r *http.Request) {
+		bodyBytes, _ := io.ReadAll(r.Body)
+		capturedBody = string(bodyBytes)
+		w.WriteHeader(http.StatusNoContent)
+	})
+	defer ts.Close()
+
+	c := newTestClient(t, ts.URL)
+	payload := map[string]string{"Name": "MyProcess"}
+	_, _, _ = c.Patch("Processes('test')", payload)
+
+	if !strings.Contains(capturedBody, "MyProcess") {
+		t.Errorf("request body = %q, want it to contain 'MyProcess'", capturedBody)
+	}
+	if !strings.Contains(capturedBody, "Name") {
+		t.Errorf("request body = %q, want it to contain 'Name'", capturedBody)
+	}
 }
 
 func TestSetAuth(t *testing.T) {

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -326,51 +326,45 @@ func TestDelete(t *testing.T) {
 }
 
 func TestPatch(t *testing.T) {
-	payload := map[string]string{"Name": "TestProcess"}
-
 	tests := []struct {
 		name        string
+		payload     interface{}
 		handler     http.HandlerFunc
-		wantStatus  int
-		wantBody    string
 		wantErr     bool
 		errContains string
+		wantBody    string
 	}{
 		{
-			name: "successful PATCH returns body",
+			name:    "successful PATCH with body",
+			payload: map[string]interface{}{"Name": "TestProcess"},
 			handler: func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusOK)
-				w.Write([]byte(`{"Name":"TestProcess"}`))
-			},
-			wantStatus: http.StatusOK,
-			wantBody:   `{"Name":"TestProcess"}`,
-		},
-		{
-			name: "successful PATCH no content",
-			handler: func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != "PATCH" {
+					t.Errorf("method = %q, want PATCH", r.Method)
+				}
+				if r.Header.Get("Content-Type") != "application/json" {
+					t.Errorf("Content-Type = %q, want application/json", r.Header.Get("Content-Type"))
+				}
 				w.WriteHeader(http.StatusNoContent)
 			},
-			wantStatus: http.StatusNoContent,
-			wantBody:   "",
+			wantBody: "",
 		},
 		{
-			name: "404 returns not found",
+			name:    "PATCH 404 returns not found",
+			payload: map[string]interface{}{"Name": "Missing"},
 			handler: func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(http.StatusNotFound)
 				w.Write([]byte(`Not found`))
 			},
-			wantStatus:  http.StatusNotFound,
 			wantErr:     true,
 			errContains: "Not found",
 		},
 		{
-			name: "500 returns server error",
+			name:    "PATCH 500 returns HTTP error",
+			payload: map[string]interface{}{"Name": "Broken"},
 			handler: func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(http.StatusInternalServerError)
-				w.Write([]byte(`Internal Server Error`))
+				w.Write([]byte(`Server error`))
 			},
-			wantStatus:  http.StatusInternalServerError,
 			wantErr:     true,
 			errContains: "HTTP 500",
 		},
@@ -382,7 +376,7 @@ func TestPatch(t *testing.T) {
 			defer ts.Close()
 
 			c := newTestClient(t, ts.URL)
-			body, status, err := c.Patch("Processes('test')", payload)
+			body, err := c.Patch("Processes('test')", tt.payload)
 
 			if tt.wantErr {
 				if err == nil {
@@ -391,16 +385,10 @@ func TestPatch(t *testing.T) {
 				if tt.errContains != "" && !strings.Contains(err.Error(), tt.errContains) {
 					t.Errorf("error = %q, want it to contain %q", err.Error(), tt.errContains)
 				}
-				if status != tt.wantStatus {
-					t.Errorf("status = %d, want %d", status, tt.wantStatus)
-				}
 				return
 			}
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
-			}
-			if status != tt.wantStatus {
-				t.Errorf("status = %d, want %d", status, tt.wantStatus)
 			}
 			if string(body) != tt.wantBody {
 				t.Errorf("body = %q, want %q", string(body), tt.wantBody)
@@ -418,7 +406,7 @@ func TestPatchSendsCorrectMethod(t *testing.T) {
 	defer ts.Close()
 
 	c := newTestClient(t, ts.URL)
-	_, _, _ = c.Patch("Processes('test')", nil)
+	_, _ = c.Patch("Processes('test')", nil)
 
 	if capturedMethod != "PATCH" {
 		t.Errorf("method = %q, want PATCH", capturedMethod)
@@ -436,7 +424,7 @@ func TestPatchSendsBody(t *testing.T) {
 
 	c := newTestClient(t, ts.URL)
 	payload := map[string]string{"Name": "MyProcess"}
-	_, _, _ = c.Patch("Processes('test')", payload)
+	_, _ = c.Patch("Processes('test')", payload)
 
 	if !strings.Contains(capturedBody, "MyProcess") {
 		t.Errorf("request body = %q, want it to contain 'MyProcess'", capturedBody)

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -3,7 +3,6 @@ package client
 import (
 	"bytes"
 	"encoding/base64"
-	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -394,43 +393,6 @@ func TestPatch(t *testing.T) {
 				t.Errorf("body = %q, want %q", string(body), tt.wantBody)
 			}
 		})
-	}
-}
-
-func TestPatchSendsCorrectMethod(t *testing.T) {
-	var capturedMethod string
-	ts := newTestServer(func(w http.ResponseWriter, r *http.Request) {
-		capturedMethod = r.Method
-		w.WriteHeader(http.StatusNoContent)
-	})
-	defer ts.Close()
-
-	c := newTestClient(t, ts.URL)
-	_, _ = c.Patch("Processes('test')", nil)
-
-	if capturedMethod != "PATCH" {
-		t.Errorf("method = %q, want PATCH", capturedMethod)
-	}
-}
-
-func TestPatchSendsBody(t *testing.T) {
-	var capturedBody string
-	ts := newTestServer(func(w http.ResponseWriter, r *http.Request) {
-		bodyBytes, _ := io.ReadAll(r.Body)
-		capturedBody = string(bodyBytes)
-		w.WriteHeader(http.StatusNoContent)
-	})
-	defer ts.Close()
-
-	c := newTestClient(t, ts.URL)
-	payload := map[string]string{"Name": "MyProcess"}
-	_, _ = c.Patch("Processes('test')", payload)
-
-	if !strings.Contains(capturedBody, "MyProcess") {
-		t.Errorf("request body = %q, want it to contain 'MyProcess'", capturedBody)
-	}
-	if !strings.Contains(capturedBody, "Name") {
-		t.Errorf("request body = %q, want it to contain 'Name'", capturedBody)
 	}
 }
 

--- a/internal/model/process_detail.go
+++ b/internal/model/process_detail.go
@@ -13,6 +13,9 @@ type ProcessDetail struct {
 }
 
 // ProcessParamDef represents a TI process parameter definition.
+// Note: Value is interface{} because TM1 returns string or numeric values.
+// YAML roundtrip may decode numeric values as int instead of float64;
+// this is benign because json.Marshal produces identical wire format for both.
 type ProcessParamDef struct {
 	Name   string      `json:"Name" yaml:"name"`
 	Prompt string      `json:"Prompt" yaml:"prompt"`

--- a/internal/model/process_detail.go
+++ b/internal/model/process_detail.go
@@ -1,0 +1,39 @@
+package model
+
+type ProcessDetail struct {
+	Name              string            `json:"Name" yaml:"name"`
+	PrologProcedure   string            `json:"PrologProcedure" yaml:"prolog"`
+	MetadataProcedure string            `json:"MetadataProcedure" yaml:"metadata"`
+	DataProcedure     string            `json:"DataProcedure" yaml:"data"`
+	EpilogProcedure   string            `json:"EpilogProcedure" yaml:"epilog"`
+	Parameters        []ProcessParamDef `json:"Parameters" yaml:"parameters"`
+	DataSource        ProcessDataSource `json:"DataSource" yaml:"datasource"`
+	Variables         []ProcessVariable `json:"Variables" yaml:"variables"`
+}
+
+type ProcessParamDef struct {
+	Name   string      `json:"Name" yaml:"name"`
+	Prompt string      `json:"Prompt" yaml:"prompt"`
+	Value  interface{} `json:"Value" yaml:"value"`
+	Type   string      `json:"Type" yaml:"type"`
+}
+
+type ProcessDataSource struct {
+	Type                    string `json:"Type" yaml:"type"`
+	DataSourceNameForServer string `json:"dataSourceNameForServer,omitempty" yaml:"dataSourceNameForServer,omitempty"`
+	DataSourceNameForClient string `json:"dataSourceNameForClient,omitempty" yaml:"dataSourceNameForClient,omitempty"`
+	ASCIIDecimalSeparator   string `json:"asciiDecimalSeparator,omitempty" yaml:"asciiDecimalSeparator,omitempty"`
+	ASCIIDelimiterChar      string `json:"asciiDelimiterChar,omitempty" yaml:"asciiDelimiterChar,omitempty"`
+	ASCIIDelimiterType      string `json:"asciiDelimiterType,omitempty" yaml:"asciiDelimiterType,omitempty"`
+	ASCIIHeaderRecords      int    `json:"asciiHeaderRecords,omitempty" yaml:"asciiHeaderRecords,omitempty"`
+	ASCIIQuoteCharacter     string `json:"asciiQuoteCharacter,omitempty" yaml:"asciiQuoteCharacter,omitempty"`
+	ASCIIThousandSeparator  string `json:"asciiThousandSeparator,omitempty" yaml:"asciiThousandSeparator,omitempty"`
+}
+
+type ProcessVariable struct {
+	Name      string `json:"Name" yaml:"name"`
+	Type      string `json:"Type" yaml:"type"`
+	Position  int    `json:"Position" yaml:"position"`
+	StartByte int    `json:"StartByte" yaml:"startByte"`
+	EndByte   int    `json:"EndByte" yaml:"endByte"`
+}

--- a/internal/model/process_detail.go
+++ b/internal/model/process_detail.go
@@ -26,7 +26,7 @@ type ProcessDataSource struct {
 	AsciiDecimalSeparator   string `json:"asciiDecimalSeparator,omitempty" yaml:"ascii_decimal_separator,omitempty"`
 	AsciiDelimiterChar      string `json:"asciiDelimiterChar,omitempty" yaml:"ascii_delimiter_char,omitempty"`
 	AsciiDelimiterType      string `json:"asciiDelimiterType,omitempty" yaml:"ascii_delimiter_type,omitempty"`
-	AsciiHeaderRecords      int    `json:"asciiHeaderRecords,omitempty" yaml:"ascii_header_records,omitempty"`
+	AsciiHeaderRecords      *int   `json:"asciiHeaderRecords,omitempty" yaml:"ascii_header_records,omitempty"`
 	AsciiQuoteCharacter     string `json:"asciiQuoteCharacter,omitempty" yaml:"ascii_quote_character,omitempty"`
 	AsciiThousandSeparator  string `json:"asciiThousandSeparator,omitempty" yaml:"ascii_thousand_separator,omitempty"`
 	DataSourceNameForClient string `json:"dataSourceNameForClient,omitempty" yaml:"data_source_name_for_client,omitempty"`

--- a/internal/model/process_detail.go
+++ b/internal/model/process_detail.go
@@ -1,5 +1,6 @@
 package model
 
+// ProcessDetail represents a full TI process definition for serialization.
 type ProcessDetail struct {
 	Name              string            `json:"Name" yaml:"name"`
 	PrologProcedure   string            `json:"PrologProcedure" yaml:"prolog"`
@@ -11,6 +12,7 @@ type ProcessDetail struct {
 	Variables         []ProcessVariable `json:"Variables" yaml:"variables"`
 }
 
+// ProcessParamDef represents a TI process parameter definition.
 type ProcessParamDef struct {
 	Name   string      `json:"Name" yaml:"name"`
 	Prompt string      `json:"Prompt" yaml:"prompt"`
@@ -18,22 +20,23 @@ type ProcessParamDef struct {
 	Type   string      `json:"Type" yaml:"type"`
 }
 
+// ProcessDataSource represents a TI process data source configuration.
 type ProcessDataSource struct {
 	Type                    string `json:"Type" yaml:"type"`
-	DataSourceNameForServer string `json:"dataSourceNameForServer,omitempty" yaml:"dataSourceNameForServer,omitempty"`
-	DataSourceNameForClient string `json:"dataSourceNameForClient,omitempty" yaml:"dataSourceNameForClient,omitempty"`
-	ASCIIDecimalSeparator   string `json:"asciiDecimalSeparator,omitempty" yaml:"asciiDecimalSeparator,omitempty"`
-	ASCIIDelimiterChar      string `json:"asciiDelimiterChar,omitempty" yaml:"asciiDelimiterChar,omitempty"`
-	ASCIIDelimiterType      string `json:"asciiDelimiterType,omitempty" yaml:"asciiDelimiterType,omitempty"`
-	ASCIIHeaderRecords      int    `json:"asciiHeaderRecords,omitempty" yaml:"asciiHeaderRecords,omitempty"`
-	ASCIIQuoteCharacter     string `json:"asciiQuoteCharacter,omitempty" yaml:"asciiQuoteCharacter,omitempty"`
-	ASCIIThousandSeparator  string `json:"asciiThousandSeparator,omitempty" yaml:"asciiThousandSeparator,omitempty"`
+	AsciiDecimalSeparator   string `json:"asciiDecimalSeparator,omitempty" yaml:"ascii_decimal_separator,omitempty"`
+	AsciiDelimiterChar      string `json:"asciiDelimiterChar,omitempty" yaml:"ascii_delimiter_char,omitempty"`
+	AsciiDelimiterType      string `json:"asciiDelimiterType,omitempty" yaml:"ascii_delimiter_type,omitempty"`
+	AsciiHeaderRecords      int    `json:"asciiHeaderRecords,omitempty" yaml:"ascii_header_records,omitempty"`
+	AsciiQuoteCharacter     string `json:"asciiQuoteCharacter,omitempty" yaml:"ascii_quote_character,omitempty"`
+	AsciiThousandSeparator  string `json:"asciiThousandSeparator,omitempty" yaml:"ascii_thousand_separator,omitempty"`
+	DataSourceNameForClient string `json:"dataSourceNameForClient,omitempty" yaml:"data_source_name_for_client,omitempty"`
+	DataSourceNameForServer string `json:"dataSourceNameForServer,omitempty" yaml:"data_source_name_for_server,omitempty"`
 }
 
+// ProcessVariable represents a TI process variable definition.
 type ProcessVariable struct {
 	Name      string `json:"Name" yaml:"name"`
 	Type      string `json:"Type" yaml:"type"`
-	Position  int    `json:"Position" yaml:"position"`
-	StartByte int    `json:"StartByte" yaml:"startByte"`
-	EndByte   int    `json:"EndByte" yaml:"endByte"`
+	StartByte int    `json:"StartByte" yaml:"start_byte"`
+	EndByte   int    `json:"EndByte" yaml:"end_byte"`
 }

--- a/internal/model/process_detail_test.go
+++ b/internal/model/process_detail_test.go
@@ -8,6 +8,8 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+func intPtr(v int) *int { return &v }
+
 func sampleProcessDetail() ProcessDetail {
 	return ProcessDetail{
 		Name:              "LoadData",
@@ -24,7 +26,7 @@ func sampleProcessDetail() ProcessDetail {
 			AsciiDecimalSeparator:   ".",
 			AsciiDelimiterChar:      ",",
 			AsciiDelimiterType:      "Character",
-			AsciiHeaderRecords:      1,
+			AsciiHeaderRecords:      intPtr(1),
 			DataSourceNameForServer: "/data/input.csv",
 		},
 		Variables: []ProcessVariable{
@@ -231,7 +233,7 @@ func TestProcessDataSourceJSON_Omitempty(t *testing.T) {
 		ds := ProcessDataSource{
 			Type:               "ASCII",
 			AsciiDelimiterChar: ",",
-			AsciiHeaderRecords: 1,
+			AsciiHeaderRecords: intPtr(1),
 		}
 		data, err := json.Marshal(ds)
 		if err != nil {

--- a/internal/model/process_detail_test.go
+++ b/internal/model/process_detail_test.go
@@ -1,0 +1,210 @@
+package model
+
+import (
+	"encoding/json"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestProcessDetailJSON(t *testing.T) {
+	original := ProcessDetail{
+		Name:            "LoadData",
+		PrologProcedure: "#Region Prolog\nIF(1=1);\nEndIf;",
+		DataProcedure:   "CellPutN(1, 'Sales', 'Jan', 'Actual');",
+		Parameters: []ProcessParamDef{
+			{Name: "pYear", Prompt: "Year", Value: "2024", Type: "String"},
+		},
+		DataSource: ProcessDataSource{
+			Type:                    "ASCII",
+			DataSourceNameForServer: "/data/file.csv",
+			ASCIIDelimiterChar:      ",",
+			ASCIIHeaderRecords:      1,
+		},
+		Variables: []ProcessVariable{
+			{Name: "vYear", Type: "String", Position: 1, StartByte: 0, EndByte: 4},
+		},
+	}
+
+	data, err := json.Marshal(original)
+	if err != nil {
+		t.Fatalf("Marshal error: %v", err)
+	}
+
+	var got ProcessDetail
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("Unmarshal error: %v", err)
+	}
+
+	if got.Name != original.Name {
+		t.Errorf("Name = %q, want %q", got.Name, original.Name)
+	}
+	if got.PrologProcedure != original.PrologProcedure {
+		t.Errorf("PrologProcedure = %q, want %q", got.PrologProcedure, original.PrologProcedure)
+	}
+	if got.DataProcedure != original.DataProcedure {
+		t.Errorf("DataProcedure = %q, want %q", got.DataProcedure, original.DataProcedure)
+	}
+	if len(got.Parameters) != 1 {
+		t.Fatalf("Parameters count = %d, want 1", len(got.Parameters))
+	}
+	if got.Parameters[0].Name != "pYear" {
+		t.Errorf("Parameters[0].Name = %q, want %q", got.Parameters[0].Name, "pYear")
+	}
+	if got.DataSource.Type != "ASCII" {
+		t.Errorf("DataSource.Type = %q, want %q", got.DataSource.Type, "ASCII")
+	}
+	if got.DataSource.ASCIIHeaderRecords != 1 {
+		t.Errorf("DataSource.ASCIIHeaderRecords = %d, want 1", got.DataSource.ASCIIHeaderRecords)
+	}
+	if len(got.Variables) != 1 {
+		t.Fatalf("Variables count = %d, want 1", len(got.Variables))
+	}
+	if got.Variables[0].Name != "vYear" {
+		t.Errorf("Variables[0].Name = %q, want %q", got.Variables[0].Name, "vYear")
+	}
+}
+
+func TestProcessDetailYAML(t *testing.T) {
+	original := ProcessDetail{
+		Name:            "LoadData",
+		PrologProcedure: "#Region Prolog\nIF(1=1);\nEndIf;",
+		DataProcedure:   "CellPutN(1, 'Sales', 'Jan', 'Actual');",
+		Parameters: []ProcessParamDef{
+			{Name: "pYear", Prompt: "Year", Value: "2024", Type: "String"},
+		},
+		DataSource: ProcessDataSource{
+			Type:               "None",
+			ASCIIDelimiterChar: ",",
+		},
+		Variables: []ProcessVariable{
+			{Name: "vYear", Type: "String", Position: 1, StartByte: 0, EndByte: 4},
+		},
+	}
+
+	data, err := yaml.Marshal(original)
+	if err != nil {
+		t.Fatalf("yaml.Marshal error: %v", err)
+	}
+
+	var got ProcessDetail
+	if err := yaml.Unmarshal(data, &got); err != nil {
+		t.Fatalf("yaml.Unmarshal error: %v", err)
+	}
+
+	if got.Name != original.Name {
+		t.Errorf("Name = %q, want %q", got.Name, original.Name)
+	}
+	if got.PrologProcedure != original.PrologProcedure {
+		t.Errorf("PrologProcedure = %q, want %q", got.PrologProcedure, original.PrologProcedure)
+	}
+	if len(got.Parameters) != 1 {
+		t.Fatalf("Parameters count = %d, want 1", len(got.Parameters))
+	}
+	if got.Parameters[0].Name != "pYear" {
+		t.Errorf("Parameters[0].Name = %q, want %q", got.Parameters[0].Name, "pYear")
+	}
+	if got.DataSource.Type != "None" {
+		t.Errorf("DataSource.Type = %q, want %q", got.DataSource.Type, "None")
+	}
+	if len(got.Variables) != 1 {
+		t.Fatalf("Variables count = %d, want 1", len(got.Variables))
+	}
+}
+
+func TestProcessDetailJSONStripsOData(t *testing.T) {
+	raw := `{
+		"@odata.context": "some-context-url",
+		"Name": "LoadData",
+		"PrologProcedure": "IF(1=1);",
+		"MetadataProcedure": "",
+		"DataProcedure": "",
+		"EpilogProcedure": "",
+		"HasSecurityAccess": false,
+		"UIData": "<some-xml/>",
+		"Parameters": [],
+		"DataSource": {"Type": "None"},
+		"Variables": []
+	}`
+
+	var got ProcessDetail
+	if err := json.Unmarshal([]byte(raw), &got); err != nil {
+		t.Fatalf("Unmarshal error: %v", err)
+	}
+
+	if got.Name != "LoadData" {
+		t.Errorf("Name = %q, want %q", got.Name, "LoadData")
+	}
+	if got.PrologProcedure != "IF(1=1);" {
+		t.Errorf("PrologProcedure = %q, want %q", got.PrologProcedure, "IF(1=1);")
+	}
+	if got.DataSource.Type != "None" {
+		t.Errorf("DataSource.Type = %q, want %q", got.DataSource.Type, "None")
+	}
+	// OData fields should be silently ignored
+	if len(got.Parameters) != 0 {
+		t.Errorf("Parameters count = %d, want 0", len(got.Parameters))
+	}
+	if len(got.Variables) != 0 {
+		t.Errorf("Variables count = %d, want 0", len(got.Variables))
+	}
+}
+
+func TestProcessParamDefValueTypes(t *testing.T) {
+	tests := []struct {
+		name      string
+		jsonInput string
+		wantValue interface{}
+	}{
+		{
+			name:      "string value preserved",
+			jsonInput: `{"Name":"pYear","Prompt":"Year","Value":"2024","Type":"String"}`,
+			wantValue: "2024",
+		},
+		{
+			name:      "numeric value preserved",
+			jsonInput: `{"Name":"pCount","Prompt":"Count","Value":100,"Type":"Numeric"}`,
+			wantValue: float64(100),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var p ProcessParamDef
+			if err := json.Unmarshal([]byte(tt.jsonInput), &p); err != nil {
+				t.Fatalf("Unmarshal error: %v", err)
+			}
+
+			// Round-trip through JSON
+			data, err := json.Marshal(p)
+			if err != nil {
+				t.Fatalf("Marshal error: %v", err)
+			}
+
+			var got ProcessParamDef
+			if err := json.Unmarshal(data, &got); err != nil {
+				t.Fatalf("Second Unmarshal error: %v", err)
+			}
+
+			// JSON numbers unmarshal as float64 for interface{}
+			switch v := tt.wantValue.(type) {
+			case string:
+				s, ok := got.Value.(string)
+				if !ok {
+					t.Fatalf("Value type = %T, want string", got.Value)
+				}
+				if s != v {
+					t.Errorf("Value = %q, want %q", s, v)
+				}
+			case float64:
+				f, ok := got.Value.(float64)
+				if !ok {
+					t.Fatalf("Value type = %T, want float64", got.Value)
+				}
+				if f != v {
+					t.Errorf("Value = %v, want %v", f, v)
+				}
+			}
+		})
+	}
+}

--- a/internal/model/process_detail_test.go
+++ b/internal/model/process_detail_test.go
@@ -246,6 +246,29 @@ func TestProcessDataSourceJSON_Omitempty(t *testing.T) {
 			t.Error("should include asciiHeaderRecords")
 		}
 	})
+
+	t.Run("zero AsciiHeaderRecords preserved with pointer type", func(t *testing.T) {
+		ds := ProcessDataSource{
+			Type:               "ASCII",
+			AsciiDelimiterChar: ",",
+			AsciiHeaderRecords: intPtr(0),
+		}
+		data, err := json.Marshal(ds)
+		if err != nil {
+			t.Fatalf("Marshal error: %v", err)
+		}
+		if !strings.Contains(string(data), `"asciiHeaderRecords":0`) {
+			t.Errorf("zero AsciiHeaderRecords should be present in JSON, got: %s", data)
+		}
+
+		var got ProcessDataSource
+		if err := json.Unmarshal(data, &got); err != nil {
+			t.Fatalf("Unmarshal error: %v", err)
+		}
+		if got.AsciiHeaderRecords == nil || *got.AsciiHeaderRecords != 0 {
+			t.Errorf("AsciiHeaderRecords roundtrip failed, got: %v", got.AsciiHeaderRecords)
+		}
+	})
 }
 
 func TestProcessVariableJSON(t *testing.T) {

--- a/internal/model/process_detail_test.go
+++ b/internal/model/process_detail_test.go
@@ -2,29 +2,40 @@ package model
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"gopkg.in/yaml.v3"
 )
 
-func TestProcessDetailJSON(t *testing.T) {
-	original := ProcessDetail{
-		Name:            "LoadData",
-		PrologProcedure: "#Region Prolog\nIF(1=1);\nEndIf;",
-		DataProcedure:   "CellPutN(1, 'Sales', 'Jan', 'Actual');",
+func sampleProcessDetail() ProcessDetail {
+	return ProcessDetail{
+		Name:              "LoadData",
+		PrologProcedure:   "IF(1=1);\nASCIIOutput('/tmp/test.csv', 'hello');\nENDIF;",
+		MetadataProcedure: "",
+		DataProcedure:     "CellPutN(Value, 'Cube', 'e1', 'e2');",
+		EpilogProcedure:   "",
 		Parameters: []ProcessParamDef{
-			{Name: "pYear", Prompt: "Year", Value: "2024", Type: "String"},
+			{Name: "pSource", Prompt: "Source file", Value: "data.csv", Type: "String"},
+			{Name: "pYear", Prompt: "Year", Value: float64(2024), Type: "Numeric"},
 		},
 		DataSource: ProcessDataSource{
 			Type:                    "ASCII",
-			DataSourceNameForServer: "/data/file.csv",
-			ASCIIDelimiterChar:      ",",
-			ASCIIHeaderRecords:      1,
+			AsciiDecimalSeparator:   ".",
+			AsciiDelimiterChar:      ",",
+			AsciiDelimiterType:      "Character",
+			AsciiHeaderRecords:      1,
+			DataSourceNameForServer: "/data/input.csv",
 		},
 		Variables: []ProcessVariable{
-			{Name: "vYear", Type: "String", Position: 1, StartByte: 0, EndByte: 4},
+			{Name: "V1", Type: "String", StartByte: 1, EndByte: 20},
+			{Name: "V2", Type: "Numeric", StartByte: 21, EndByte: 30},
 		},
 	}
+}
+
+func TestProcessDetailJSON(t *testing.T) {
+	original := sampleProcessDetail()
 
 	data, err := json.Marshal(original)
 	if err != nil {
@@ -40,171 +51,213 @@ func TestProcessDetailJSON(t *testing.T) {
 		t.Errorf("Name = %q, want %q", got.Name, original.Name)
 	}
 	if got.PrologProcedure != original.PrologProcedure {
-		t.Errorf("PrologProcedure = %q, want %q", got.PrologProcedure, original.PrologProcedure)
+		t.Errorf("PrologProcedure mismatch")
 	}
 	if got.DataProcedure != original.DataProcedure {
-		t.Errorf("DataProcedure = %q, want %q", got.DataProcedure, original.DataProcedure)
+		t.Errorf("DataProcedure mismatch")
 	}
-	if len(got.Parameters) != 1 {
-		t.Fatalf("Parameters count = %d, want 1", len(got.Parameters))
+	if len(got.Parameters) != 2 {
+		t.Fatalf("Parameters count = %d, want 2", len(got.Parameters))
 	}
-	if got.Parameters[0].Name != "pYear" {
-		t.Errorf("Parameters[0].Name = %q, want %q", got.Parameters[0].Name, "pYear")
+	if got.Parameters[0].Name != "pSource" {
+		t.Errorf("Parameters[0].Name = %q, want %q", got.Parameters[0].Name, "pSource")
 	}
 	if got.DataSource.Type != "ASCII" {
 		t.Errorf("DataSource.Type = %q, want %q", got.DataSource.Type, "ASCII")
 	}
-	if got.DataSource.ASCIIHeaderRecords != 1 {
-		t.Errorf("DataSource.ASCIIHeaderRecords = %d, want 1", got.DataSource.ASCIIHeaderRecords)
+	if len(got.Variables) != 2 {
+		t.Fatalf("Variables count = %d, want 2", len(got.Variables))
 	}
-	if len(got.Variables) != 1 {
-		t.Fatalf("Variables count = %d, want 1", len(got.Variables))
-	}
-	if got.Variables[0].Name != "vYear" {
-		t.Errorf("Variables[0].Name = %q, want %q", got.Variables[0].Name, "vYear")
+	if got.Variables[0].Name != "V1" {
+		t.Errorf("Variables[0].Name = %q, want %q", got.Variables[0].Name, "V1")
 	}
 }
 
 func TestProcessDetailYAML(t *testing.T) {
-	original := ProcessDetail{
-		Name:            "LoadData",
-		PrologProcedure: "#Region Prolog\nIF(1=1);\nEndIf;",
-		DataProcedure:   "CellPutN(1, 'Sales', 'Jan', 'Actual');",
-		Parameters: []ProcessParamDef{
-			{Name: "pYear", Prompt: "Year", Value: "2024", Type: "String"},
-		},
-		DataSource: ProcessDataSource{
-			Type:               "None",
-			ASCIIDelimiterChar: ",",
-		},
-		Variables: []ProcessVariable{
-			{Name: "vYear", Type: "String", Position: 1, StartByte: 0, EndByte: 4},
-		},
-	}
+	original := sampleProcessDetail()
 
 	data, err := yaml.Marshal(original)
 	if err != nil {
-		t.Fatalf("yaml.Marshal error: %v", err)
+		t.Fatalf("Marshal error: %v", err)
+	}
+
+	yamlStr := string(data)
+	// Verify YAML uses snake_case keys
+	if !strings.Contains(yamlStr, "prolog:") {
+		t.Error("YAML should use 'prolog' key (not 'PrologProcedure')")
+	}
+	if !strings.Contains(yamlStr, "datasource:") {
+		t.Error("YAML should use 'datasource' key")
+	}
+	if !strings.Contains(yamlStr, "start_byte:") {
+		t.Error("YAML should use 'start_byte' key")
 	}
 
 	var got ProcessDetail
 	if err := yaml.Unmarshal(data, &got); err != nil {
-		t.Fatalf("yaml.Unmarshal error: %v", err)
+		t.Fatalf("Unmarshal error: %v", err)
 	}
 
 	if got.Name != original.Name {
 		t.Errorf("Name = %q, want %q", got.Name, original.Name)
 	}
 	if got.PrologProcedure != original.PrologProcedure {
-		t.Errorf("PrologProcedure = %q, want %q", got.PrologProcedure, original.PrologProcedure)
+		t.Errorf("PrologProcedure mismatch")
 	}
-	if len(got.Parameters) != 1 {
-		t.Fatalf("Parameters count = %d, want 1", len(got.Parameters))
+	if len(got.Parameters) != 2 {
+		t.Fatalf("Parameters count = %d, want 2", len(got.Parameters))
 	}
-	if got.Parameters[0].Name != "pYear" {
-		t.Errorf("Parameters[0].Name = %q, want %q", got.Parameters[0].Name, "pYear")
-	}
-	if got.DataSource.Type != "None" {
-		t.Errorf("DataSource.Type = %q, want %q", got.DataSource.Type, "None")
-	}
-	if len(got.Variables) != 1 {
-		t.Fatalf("Variables count = %d, want 1", len(got.Variables))
+	if got.DataSource.Type != "ASCII" {
+		t.Errorf("DataSource.Type = %q, want %q", got.DataSource.Type, "ASCII")
 	}
 }
 
-func TestProcessDetailJSONStripsOData(t *testing.T) {
-	raw := `{
-		"@odata.context": "some-context-url",
+func TestProcessDetailJSON_EmptyProcedures(t *testing.T) {
+	original := ProcessDetail{
+		Name:              "EmptyProcs",
+		PrologProcedure:   "",
+		MetadataProcedure: "",
+		DataProcedure:     "",
+		EpilogProcedure:   "",
+		DataSource:        ProcessDataSource{Type: "None"},
+	}
+
+	data, err := json.Marshal(original)
+	if err != nil {
+		t.Fatalf("Marshal error: %v", err)
+	}
+
+	jsonStr := string(data)
+	// Empty strings must NOT be omitted
+	if !strings.Contains(jsonStr, `"PrologProcedure":""`) {
+		t.Errorf("PrologProcedure should be present as empty string in JSON")
+	}
+	if !strings.Contains(jsonStr, `"MetadataProcedure":""`) {
+		t.Errorf("MetadataProcedure should be present as empty string in JSON")
+	}
+
+	var got ProcessDetail
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("Unmarshal error: %v", err)
+	}
+	if got.PrologProcedure != "" {
+		t.Errorf("PrologProcedure = %q, want empty", got.PrologProcedure)
+	}
+}
+
+func TestProcessDetailJSON_StripOData(t *testing.T) {
+	input := `{
+		"@odata.context": "$metadata#Processes/$entity",
+		"@odata.etag": "W/\"abc123\"",
 		"Name": "LoadData",
-		"PrologProcedure": "IF(1=1);",
+		"PrologProcedure": "# prolog",
 		"MetadataProcedure": "",
 		"DataProcedure": "",
 		"EpilogProcedure": "",
-		"HasSecurityAccess": false,
-		"UIData": "<some-xml/>",
 		"Parameters": [],
 		"DataSource": {"Type": "None"},
-		"Variables": []
+		"Variables": [],
+		"Attributes": {"Caption": "Load Data"}
 	}`
 
 	var got ProcessDetail
-	if err := json.Unmarshal([]byte(raw), &got); err != nil {
+	if err := json.Unmarshal([]byte(input), &got); err != nil {
 		t.Fatalf("Unmarshal error: %v", err)
 	}
 
 	if got.Name != "LoadData" {
-		t.Errorf("Name = %q, want %q", got.Name, "LoadData")
+		t.Errorf("Name = %q, want 'LoadData'", got.Name)
 	}
-	if got.PrologProcedure != "IF(1=1);" {
-		t.Errorf("PrologProcedure = %q, want %q", got.PrologProcedure, "IF(1=1);")
+	if got.PrologProcedure != "# prolog" {
+		t.Errorf("PrologProcedure = %q, want '# prolog'", got.PrologProcedure)
 	}
 	if got.DataSource.Type != "None" {
-		t.Errorf("DataSource.Type = %q, want %q", got.DataSource.Type, "None")
-	}
-	// OData fields should be silently ignored
-	if len(got.Parameters) != 0 {
-		t.Errorf("Parameters count = %d, want 0", len(got.Parameters))
-	}
-	if len(got.Variables) != 0 {
-		t.Errorf("Variables count = %d, want 0", len(got.Variables))
+		t.Errorf("DataSource.Type = %q, want 'None'", got.DataSource.Type)
 	}
 }
 
-func TestProcessParamDefValueTypes(t *testing.T) {
+func TestProcessParamDefJSON(t *testing.T) {
 	tests := []struct {
 		name      string
-		jsonInput string
+		param     ProcessParamDef
 		wantValue interface{}
 	}{
 		{
-			name:      "string value preserved",
-			jsonInput: `{"Name":"pYear","Prompt":"Year","Value":"2024","Type":"String"}`,
-			wantValue: "2024",
+			name:      "string value",
+			param:     ProcessParamDef{Name: "pSource", Prompt: "File", Value: "data.csv", Type: "String"},
+			wantValue: "data.csv",
 		},
 		{
-			name:      "numeric value preserved",
-			jsonInput: `{"Name":"pCount","Prompt":"Count","Value":100,"Type":"Numeric"}`,
-			wantValue: float64(100),
+			name:      "numeric value",
+			param:     ProcessParamDef{Name: "pYear", Prompt: "Year", Value: float64(2024), Type: "Numeric"},
+			wantValue: float64(2024),
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			var p ProcessParamDef
-			if err := json.Unmarshal([]byte(tt.jsonInput), &p); err != nil {
-				t.Fatalf("Unmarshal error: %v", err)
-			}
-
-			// Round-trip through JSON
-			data, err := json.Marshal(p)
+			data, err := json.Marshal(tt.param)
 			if err != nil {
 				t.Fatalf("Marshal error: %v", err)
 			}
-
 			var got ProcessParamDef
 			if err := json.Unmarshal(data, &got); err != nil {
-				t.Fatalf("Second Unmarshal error: %v", err)
+				t.Fatalf("Unmarshal error: %v", err)
 			}
-
-			// JSON numbers unmarshal as float64 for interface{}
-			switch v := tt.wantValue.(type) {
-			case string:
-				s, ok := got.Value.(string)
-				if !ok {
-					t.Fatalf("Value type = %T, want string", got.Value)
-				}
-				if s != v {
-					t.Errorf("Value = %q, want %q", s, v)
-				}
-			case float64:
-				f, ok := got.Value.(float64)
-				if !ok {
-					t.Fatalf("Value type = %T, want float64", got.Value)
-				}
-				if f != v {
-					t.Errorf("Value = %v, want %v", f, v)
-				}
+			if got.Name != tt.param.Name {
+				t.Errorf("Name = %q, want %q", got.Name, tt.param.Name)
+			}
+			if got.Value != tt.wantValue {
+				t.Errorf("Value = %v (%T), want %v (%T)", got.Value, got.Value, tt.wantValue, tt.wantValue)
 			}
 		})
+	}
+}
+
+func TestProcessDataSourceJSON_Omitempty(t *testing.T) {
+	t.Run("None type omits optional fields", func(t *testing.T) {
+		ds := ProcessDataSource{Type: "None"}
+		data, err := json.Marshal(ds)
+		if err != nil {
+			t.Fatalf("Marshal error: %v", err)
+		}
+		want := `{"Type":"None"}`
+		if string(data) != want {
+			t.Errorf("Marshal = %s, want %s", data, want)
+		}
+	})
+
+	t.Run("ASCII type includes populated fields", func(t *testing.T) {
+		ds := ProcessDataSource{
+			Type:               "ASCII",
+			AsciiDelimiterChar: ",",
+			AsciiHeaderRecords: 1,
+		}
+		data, err := json.Marshal(ds)
+		if err != nil {
+			t.Fatalf("Marshal error: %v", err)
+		}
+		if !strings.Contains(string(data), `"asciiDelimiterChar":","`) {
+			t.Error("should include asciiDelimiterChar")
+		}
+		if !strings.Contains(string(data), `"asciiHeaderRecords":1`) {
+			t.Error("should include asciiHeaderRecords")
+		}
+	})
+}
+
+func TestProcessVariableJSON(t *testing.T) {
+	v := ProcessVariable{Name: "V1", Type: "String", StartByte: 1, EndByte: 20}
+	data, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("Marshal error: %v", err)
+	}
+
+	var got ProcessVariable
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("Unmarshal error: %v", err)
+	}
+	if got != v {
+		t.Errorf("Round-trip = %+v, want %+v", got, v)
 	}
 }


### PR DESCRIPTION
## Summary

- Add `process dump <name>` command to export TI process definitions to JSON or YAML files
- Add `process load <name>` command to import TI process definitions from JSON/YAML files with create/update upsert logic
- Add `Patch` HTTP method to client with `doWithPayload` helper to deduplicate Post/Patch
- Add `ErrNotFound` sentinel error for type-safe 404 detection
- Add `ProcessDetail`, `ProcessParamDef`, `ProcessDataSource`, `ProcessVariable` model types
- Add `gopkg.in/yaml.v3` dependency

Closes #54

## Highlights

- **dump**: `GET /Processes('name')` with `$select` for relevant fields, strips OData metadata naturally via struct unmarshaling, outputs JSON or YAML based on file extension (or JSON to stdout)
- **load**: Reads JSON/YAML, checks process existence via lightweight GET, then PATCH (update) or POST (create). Supports `--create-only` and `--update-only` flags for explicit behavior
- **Roundtrip safe**: `AsciiHeaderRecords` uses `*int` to preserve zero values through `omitempty`; empty procedure strings (prolog, metadata, etc.) are never omitted
- **CLI arg overrides file Name**: Supports clone/rename workflows

## Test plan

- [x] `process dump LoadData` prints JSON to stdout
- [x] `process dump LoadData -o loaddata.json` writes JSON file (0600 perms)
- [x] `process dump LoadData -o loaddata.yaml` writes YAML file with snake_case keys
- [x] `process dump NonExistent` returns error
- [x] `process dump LoadData -o file.txt` rejects unsupported extension before network call
- [x] `process load LoadData -f proc.json` creates new process (POST) when not found
- [x] `process load LoadData -f proc.json` updates existing process (PATCH) when found
- [x] `--create-only` fails if process already exists
- [x] `--update-only` fails if process does not exist
- [x] `--create-only --update-only` rejects as mutually exclusive
- [x] CLI name overrides file Name field
- [x] `--output json` produces structured JSON response
- [x] `AsciiHeaderRecords: 0` survives JSON roundtrip (pointer type test)
- [x] OData metadata (@odata.context, @odata.etag) stripped during deserialization
- [x] All 576 tests pass across 6 packages