### PR TITLE
feat(#23): document and test shell completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,18 @@ tm1cli export "Sales" --view "Default" -o data.csv --no-header  # CSV without he
 --version         Print version
 ```
 
+### Shell Completion
+
+Generate a completion script for your shell. Run
+`tm1cli completion <shell> --help` for the install steps.
+
+```bash
+tm1cli completion bash       # bash
+tm1cli completion zsh        # zsh
+tm1cli completion fish       # fish
+tm1cli completion powershell # PowerShell
+```
+
 ## Auth Modes
 
 | Mode | TM1 Security Mode | Usage |
@@ -211,9 +223,10 @@ tm1cli export "Sales" --view "Default" -o data.csv --no-header  # CSV without he
 
 - [x] v0.1.0 — Config, cubes, dims, members, process list/run, export view → table
 - [x] v0.1.1 — Export view → CSV/JSON file
-- [ ] v0.2.0 — MDX export, XLSX output, config edit, CAM auth testing
-- [ ] v0.3.0 — tab completion, advanced features
-- [ ] v0.4.0 — OS keychain password storage
+- [x] v0.1.2 — Bug fixes for export and URL handling
+- [x] v0.2.0 — MDX export, XLSX output, config edit, views, subsets, diagnostics
+- [x] v0.3.0 — Process dump/load, watch mode
+- [ ] v0.4.0 — OS keychain password storage, tab completion, consolidated member indentation, cellset parsing
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ tm1cli completion powershell # PowerShell
 - [x] v0.1.2 — Bug fixes for export and URL handling
 - [x] v0.2.0 — MDX export, XLSX output, config edit, views, subsets, diagnostics
 - [x] v0.3.0 — Process dump/load, watch mode
-- [ ] v0.4.0 — OS keychain password storage, tab completion, consolidated member indentation, cellset parsing
+- [ ] v0.4.0 — OS keychain password storage, consolidated member indentation, cellset parsing
 
 ## License
 

--- a/cmd/completion_test.go
+++ b/cmd/completion_test.go
@@ -31,9 +31,6 @@ func TestCompletionGenerators(t *testing.T) {
 				t.Fatalf("generator returned error: %v", err)
 			}
 			out := buf.String()
-			if out == "" {
-				t.Fatalf("expected non-empty completion output")
-			}
 			if !strings.Contains(out, tt.contains) {
 				t.Errorf("expected output to contain %q; first 300 chars:\n%s", tt.contains, firstN(out, 300))
 			}

--- a/cmd/completion_test.go
+++ b/cmd/completion_test.go
@@ -1,0 +1,69 @@
+package cmd
+
+import (
+	"bytes"
+	"io"
+	"strings"
+	"testing"
+)
+
+// TestCompletionGenerators verifies that each cobra-built-in completion
+// generator produces a non-empty, shell-specific script for tm1cli's rootCmd.
+// These are the same generators the default `completion <shell>` subcommands
+// invoke under the hood — testing them directly avoids cobra's one-shot writer
+// capture in InitDefaultCompletionCmd, which makes the subcommand path hard
+// to test repeatedly within a single test binary.
+func TestCompletionGenerators(t *testing.T) {
+	tests := []struct {
+		name     string
+		gen      func(io.Writer) error
+		contains string
+	}{
+		{"bash", func(w io.Writer) error { return rootCmd.GenBashCompletionV2(w, true) }, "# bash completion V2 for tm1cli"},
+		{"zsh", rootCmd.GenZshCompletion, "#compdef tm1cli"},
+		{"fish", func(w io.Writer) error { return rootCmd.GenFishCompletion(w, true) }, "# fish completion for tm1cli"},
+		{"powershell", rootCmd.GenPowerShellCompletionWithDesc, "Register-ArgumentCompleter"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			if err := tt.gen(&buf); err != nil {
+				t.Fatalf("generator returned error: %v", err)
+			}
+			out := buf.String()
+			if out == "" {
+				t.Fatalf("expected non-empty completion output")
+			}
+			if !strings.Contains(out, tt.contains) {
+				t.Errorf("expected output to contain %q; first 300 chars:\n%s", tt.contains, firstN(out, 300))
+			}
+		})
+	}
+}
+
+// TestCompletionCommandRegistered verifies cobra's default completion command
+// tree is reachable from rootCmd. This catches accidental
+// `rootCmd.CompletionOptions.DisableDefaultCmd = true` regressions and ensures
+// every documented shell subcommand exists.
+func TestCompletionCommandRegistered(t *testing.T) {
+	rootCmd.InitDefaultCompletionCmd()
+
+	completionSub, _, err := rootCmd.Find([]string{"completion"})
+	if err != nil || completionSub.Name() != "completion" {
+		t.Fatalf("completion command not registered on rootCmd: %v", err)
+	}
+
+	for _, shell := range []string{"bash", "zsh", "fish", "powershell"} {
+		sub, _, err := completionSub.Find([]string{shell})
+		if err != nil || sub.Name() != shell {
+			t.Errorf("completion %s subcommand not found: %v", shell, err)
+		}
+	}
+}
+
+func firstN(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n]
+}


### PR DESCRIPTION
## Summary

Closes #23.

Cobra v1.10.2 already auto-registers `tm1cli completion bash/zsh/fish/powershell` with shell-specific install instructions in each `--help`, so the feature requested in #23 has actually been present in every release. This PR closes the documentation/test gap rather than adding a redundant custom command.

- **`cmd/completion_test.go`** — `TestCompletionGenerators` (4 subtests, one per shell) calls cobra's generators directly and asserts the output contains a shell-specific marker. `TestCompletionCommandRegistered` calls `rootCmd.InitDefaultCompletionCmd()` and verifies the `completion` subcommand and all four shell leaves are reachable. The doc comment explains why the tests bypass `rootCmd.Execute()` (cobra v1.10.2 captures `out := c.OutOrStdout()` once at init time in `InitDefaultCompletionCmd`, making per-test writer redirection unreliable).
- **`README.md`** — added a `### Shell Completion` subsection under Usage pointing users at `tm1cli completion <shell> --help` for install steps; refreshed the roadmap to reflect what has actually shipped (v0.1.2/v0.2.0/v0.3.0 marked done; tab completion removed from the v0.4.0 pending list since this PR documents/tests the existing capability).

No new Go source code is added — replacing cobra's default would have been pure churn for no functional difference.

## Test plan

- [x] `go test ./...` — all 625 tests pass (6 new completion tests + 619 existing)
- [x] `go vet ./...` — clean
- [x] `go build ./...` — clean
- [x] Manual: `tm1cli completion --help` lists `bash`, `zsh`, `fish`, `powershell`
- [x] Manual: `tm1cli completion bash | head` emits a valid bash V2 script
- [x] Manual: `tm1cli completion zsh | head` emits `#compdef tm1cli`
- [ ] Reviewer to spot-check the README rendering on GitHub
