### PR TITLE
feat(#24): indent consolidated element children in dims members

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,10 +166,13 @@ tm1cli cubes --output json          # JSON output
 
 ```bash
 tm1cli dims                                # list dimensions
-tm1cli dims members Period                 # list elements
+tm1cli dims members Period                 # list elements (indented tree by default)
+tm1cli dims members Period --flat          # flat list, no indentation
 tm1cli dims members Region --hierarchy "Alternate Region"
-tm1cli dims members Account --filter "Rev"
+tm1cli dims members Account --filter "Rev" # --filter forces a flat list
 ```
+
+Children of consolidated elements are indented two spaces per level. Use `--flat` for a single-level list. Indentation is disabled automatically with `--filter`, `--count`, and `--output json`.
 
 ### Processes
 

--- a/cmd/dims.go
+++ b/cmd/dims.go
@@ -197,8 +197,10 @@ list. Indentation is disabled automatically with --filter, --count, and
 Tree mode fetches the full hierarchy so indentation stays intact. For
 dimensions over 5000 elements, tree view is gated behind --all; use
 --flat for a faster listing or --all to acknowledge the fetch cost.
-Hierarchies with extreme diamond expansion (over 50000 render rows)
-are rejected unconditionally — use --flat to inspect them.`,
+If the server doesn't support /Elements/$count the command falls back
+to flat output with a warning. Hierarchies with extreme diamond
+expansion (over 50000 render rows) are rejected unconditionally — use
+--flat to inspect them.`,
 	Example: `  tm1cli dims members Period
   tm1cli dims members Period --flat
   tm1cli dims members Region --hierarchy "Alternate Region"
@@ -236,18 +238,20 @@ func runDimsMembers(cmd *cobra.Command, args []string) error {
 	if treeMode && !membersAll {
 		countEndpoint := fmt.Sprintf("Dimensions('%s')/Hierarchies('%s')/Elements/$count", url.PathEscape(dimName), url.PathEscape(hierarchy))
 		data, err := cl.Get(countEndpoint)
-		if err != nil {
-			output.PrintError(err.Error(), jsonMode)
-			return errSilent
-		}
-		n, parseErr := strconv.Atoi(strings.TrimSpace(string(data)))
-		if parseErr != nil {
-			output.PrintError("cannot verify dimension size (unexpected server response); re-run with --flat or --all.", jsonMode)
-			return errSilent
-		}
-		if n > treeElementGate {
-			output.PrintError(fmt.Sprintf("dimension has %d elements. Tree view requires --all for dimensions over %d; use --flat for a faster listing.", n, treeElementGate), jsonMode)
-			return errSilent
+		switch {
+		case err != nil:
+			output.PrintWarning("cannot verify dimension size; falling back to flat output (use --all for full tree view).")
+			treeMode = false
+		default:
+			n, parseErr := strconv.Atoi(strings.TrimSpace(string(data)))
+			switch {
+			case parseErr != nil:
+				output.PrintWarning("cannot verify dimension size (unexpected server response); falling back to flat output (use --all for full tree view).")
+				treeMode = false
+			case n > treeElementGate:
+				output.PrintError(fmt.Sprintf("dimension has %d elements. Tree view requires --all for dimensions over %d; use --flat for a faster listing.", n, treeElementGate), jsonMode)
+				return errSilent
+			}
 		}
 	}
 

--- a/cmd/dims.go
+++ b/cmd/dims.go
@@ -195,12 +195,12 @@ list. Indentation is disabled automatically with --filter, --count, and
 --output json.
 
 Tree mode fetches the full hierarchy so indentation stays intact. For
-dimensions over 5000 elements, tree view is gated behind --all; use
---flat for a faster listing or --all to acknowledge the fetch cost.
-If the server doesn't support /Elements/$count the command falls back
-to flat output with a warning. Hierarchies with extreme diamond
-expansion (over 50000 render rows) are rejected unconditionally — use
---flat to inspect them.`,
+dimensions over 5000 elements the command falls back to flat output
+with a warning, keeping the pre-PR contract of the default invocation;
+pass --all to get the full indented tree. If the server doesn't support
+/Elements/$count the command falls back to flat output the same way.
+Hierarchies with extreme diamond expansion (over 50000 render rows)
+are rejected unconditionally — use --flat to inspect them.`,
 	Example: `  tm1cli dims members Period
   tm1cli dims members Period --flat
   tm1cli dims members Region --hierarchy "Alternate Region"
@@ -249,8 +249,8 @@ func runDimsMembers(cmd *cobra.Command, args []string) error {
 				output.PrintWarning(preflightFallbackMessage("cannot verify dimension size (unexpected server response)", limit))
 				treeMode = false
 			case n > treeElementGate:
-				output.PrintError(fmt.Sprintf("dimension has %d elements. Tree view requires --all for dimensions over %d; use --flat for a faster listing.", n, treeElementGate), jsonMode)
-				return errSilent
+				output.PrintWarning(preflightFallbackMessage(fmt.Sprintf("dimension has %d elements (over %d)", n, treeElementGate), limit))
+				treeMode = false
 			}
 		}
 	}

--- a/cmd/dims.go
+++ b/cmd/dims.go
@@ -240,13 +240,13 @@ func runDimsMembers(cmd *cobra.Command, args []string) error {
 		data, err := cl.Get(countEndpoint)
 		switch {
 		case err != nil:
-			output.PrintWarning("cannot verify dimension size; falling back to flat output (use --all for full tree view).")
+			output.PrintWarning(preflightFallbackMessage("cannot verify dimension size", limit))
 			treeMode = false
 		default:
 			n, parseErr := strconv.Atoi(strings.TrimSpace(string(data)))
 			switch {
 			case parseErr != nil:
-				output.PrintWarning("cannot verify dimension size (unexpected server response); falling back to flat output (use --all for full tree view).")
+				output.PrintWarning(preflightFallbackMessage("cannot verify dimension size (unexpected server response)", limit))
 				treeMode = false
 			case n > treeElementGate:
 				output.PrintError(fmt.Sprintf("dimension has %d elements. Tree view requires --all for dimensions over %d; use --flat for a faster listing.", n, treeElementGate), jsonMode)
@@ -300,6 +300,16 @@ func runDimsMembers(cmd *cobra.Command, args []string) error {
 	}
 
 	return displayMembers(elements, len(elements), limit, jsonMode, treeMode)
+}
+
+// preflightFallbackMessage composes the stderr warning printed when the
+// $count preflight cannot be satisfied. The warning must surface the row
+// limit explicitly so users don't silently consume truncated results.
+func preflightFallbackMessage(reason string, limit int) string {
+	if limit > 0 {
+		return fmt.Sprintf("%s; falling back to flat output (limited to %d rows; use --all for the full dimension).", reason, limit)
+	}
+	return fmt.Sprintf("%s; falling back to flat output (use --all for the full dimension).", reason)
 }
 
 func filterElementsByName(elements []model.Element, filter string) []model.Element {

--- a/cmd/dims.go
+++ b/cmd/dims.go
@@ -165,6 +165,18 @@ var (
 	membersFlat      bool
 )
 
+// treeElementGate is the server-side element count above which `dims members`
+// refuses to render a tree unless --all is passed. Keeps the default
+// invocation fast on huge dimensions.
+//
+// treeRenderCeiling is an absolute cap on materialised tree nodes to guard
+// against layered-diamond hierarchies whose expanded render size is far
+// larger than the unique element count reported by $count.
+const (
+	treeElementGate   = 5000
+	treeRenderCeiling = 50000
+)
+
 var dimsMembersCmd = &cobra.Command{
 	Use:   "members <dimension>",
 	Short: "List elements (members) of a dimension",
@@ -184,7 +196,9 @@ list. Indentation is disabled automatically with --filter, --count, and
 
 Tree mode fetches the full hierarchy so indentation stays intact. For
 dimensions over 5000 elements, tree view is gated behind --all; use
---flat for a faster listing or --all to acknowledge the fetch cost.`,
+--flat for a faster listing or --all to acknowledge the fetch cost.
+Hierarchies with extreme diamond expansion (over 50000 render rows)
+are rejected unconditionally — use --flat to inspect them.`,
 	Example: `  tm1cli dims members Period
   tm1cli dims members Period --flat
   tm1cli dims members Region --hierarchy "Alternate Region"
@@ -221,11 +235,19 @@ func runDimsMembers(cmd *cobra.Command, args []string) error {
 
 	if treeMode && !membersAll {
 		countEndpoint := fmt.Sprintf("Dimensions('%s')/Hierarchies('%s')/Elements/$count", url.PathEscape(dimName), url.PathEscape(hierarchy))
-		if data, err := cl.Get(countEndpoint); err == nil {
-			if n, parseErr := strconv.Atoi(strings.TrimSpace(string(data))); parseErr == nil && n > treeElementGate {
-				output.PrintError(fmt.Sprintf("dimension has %d elements. Tree view requires --all for dimensions over %d; use --flat for a faster listing.", n, treeElementGate), jsonMode)
-				return errSilent
-			}
+		data, err := cl.Get(countEndpoint)
+		if err != nil {
+			output.PrintError(err.Error(), jsonMode)
+			return errSilent
+		}
+		n, parseErr := strconv.Atoi(strings.TrimSpace(string(data)))
+		if parseErr != nil {
+			output.PrintError("cannot verify dimension size (unexpected server response); re-run with --flat or --all.", jsonMode)
+			return errSilent
+		}
+		if n > treeElementGate {
+			output.PrintError(fmt.Sprintf("dimension has %d elements. Tree view requires --all for dimensions over %d; use --flat for a faster listing.", n, treeElementGate), jsonMode)
+			return errSilent
 		}
 	}
 
@@ -243,8 +265,7 @@ func runDimsMembers(cmd *cobra.Command, args []string) error {
 		if err == nil {
 			var resp model.ElementResponse
 			if jsonErr := json.Unmarshal(data, &resp); jsonErr == nil {
-				displayMembers(resp.Value, len(resp.Value), limit, jsonMode, treeMode)
-				return nil
+				return displayMembers(resp.Value, len(resp.Value), limit, jsonMode, treeMode)
 			}
 		}
 		filterFallback = true
@@ -274,11 +295,8 @@ func runDimsMembers(cmd *cobra.Command, args []string) error {
 		elements = filterElementsByName(elements, membersFilter)
 	}
 
-	displayMembers(elements, len(elements), limit, jsonMode, treeMode)
-	return nil
+	return displayMembers(elements, len(elements), limit, jsonMode, treeMode)
 }
-
-const treeElementGate = 5000
 
 func filterElementsByName(elements []model.Element, filter string) []model.Element {
 	lower := strings.ToLower(filter)
@@ -291,14 +309,14 @@ func filterElementsByName(elements []model.Element, filter string) []model.Eleme
 	return filtered
 }
 
-func displayMembers(elements []model.Element, total int, limit int, jsonMode bool, treeMode bool) {
+func displayMembers(elements []model.Element, total int, limit int, jsonMode bool, treeMode bool) error {
 	if membersCount {
 		if jsonMode {
 			output.PrintJSON(map[string]int{"count": total})
 		} else {
 			fmt.Printf("%d members\n", total)
 		}
-		return
+		return nil
 	}
 
 	if jsonMode {
@@ -307,13 +325,17 @@ func displayMembers(elements []model.Element, total int, limit int, jsonMode boo
 			shown = shown[:limit]
 		}
 		output.PrintJSON(shown)
-		return
+		return nil
 	}
 
 	headers := []string{"NAME", "TYPE"}
 
 	if treeMode {
-		roots := buildTree(elements)
+		roots, overflow := buildTreeBounded(elements, treeRenderCeiling)
+		if overflow {
+			output.PrintError(fmt.Sprintf("hierarchy would expand to more than %d render rows (likely from layered diamonds); use --flat.", treeRenderCeiling), jsonMode)
+			return errSilent
+		}
 		flatTotal, uniqueCount := treeStats(roots)
 		shown := flattenTreeCapped(roots, limit)
 		rows := make([][]string, len(shown))
@@ -322,7 +344,7 @@ func displayMembers(elements []model.Element, total int, limit int, jsonMode boo
 		}
 		output.PrintTable(headers, rows)
 		output.PrintTreeSummary(len(shown), flatTotal, uniqueCount)
-		return
+		return nil
 	}
 
 	shown := elements
@@ -335,6 +357,7 @@ func displayMembers(elements []model.Element, total int, limit int, jsonMode boo
 	}
 	output.PrintTable(headers, rows)
 	output.PrintSummary(len(shown), total)
+	return nil
 }
 
 // --- hierarchy tree (indentation) ---
@@ -351,10 +374,23 @@ type indentedRow struct {
 }
 
 // buildTree turns a flat element list (with populated Components) into a
-// forest. Natural roots are elements that never appear as a child; a second
-// pass adds synthetic roots for residual or cycle-only subgraphs so no
-// element disappears from the output.
+// forest. Natural roots are elements that never appear as a child; a
+// second pass adds synthetic roots for residual or cycle-only subgraphs
+// so no element disappears from the output. Cycles are broken by a
+// per-DFS-path visited set — diamonds (same child under multiple
+// parents) render in every location because that set is scoped to a
+// single walk, not shared across parents.
 func buildTree(elements []model.Element) []*treeNode {
+	roots, _ := buildTreeBounded(elements, 0)
+	return roots
+}
+
+// buildTreeBounded is the same as buildTree but caps the total number
+// of materialised tree nodes at budget. When the budget is exceeded it
+// stops walking and returns overflow=true so callers can bail out
+// before allocating a dimension-size worth of nodes. Pass budget <= 0
+// for no cap.
+func buildTreeBounded(elements []model.Element, budget int) (roots []*treeNode, overflow bool) {
 	byName := make(map[string]*model.Element, len(elements))
 	childOf := make(map[string]bool)
 	for i := range elements {
@@ -364,38 +400,67 @@ func buildTree(elements []model.Element) []*treeNode {
 		}
 	}
 
-	visitedAll := make(map[string]bool)
-	var roots []*treeNode
+	ctx := &treeBuildCtx{
+		byName:     byName,
+		visitedAll: make(map[string]bool),
+		budget:     budget,
+	}
 
 	for i := range elements {
 		name := elements[i].Name
-		if !childOf[name] && !visitedAll[name] {
-			roots = append(roots, buildNode(&elements[i], byName, visitedAll, map[string]bool{}))
+		if ctx.over() {
+			break
+		}
+		if !childOf[name] && !ctx.visitedAll[name] {
+			roots = append(roots, buildNode(&elements[i], ctx, map[string]bool{}))
 		}
 	}
 	for i := range elements {
-		if !visitedAll[elements[i].Name] {
-			roots = append(roots, buildNode(&elements[i], byName, visitedAll, map[string]bool{}))
+		if ctx.over() {
+			break
+		}
+		if !ctx.visitedAll[elements[i].Name] {
+			roots = append(roots, buildNode(&elements[i], ctx, map[string]bool{}))
 		}
 	}
-	return roots
+	return roots, ctx.overflow
 }
 
-func buildNode(e *model.Element, byName map[string]*model.Element, visitedAll, visitedPath map[string]bool) *treeNode {
+type treeBuildCtx struct {
+	byName     map[string]*model.Element
+	visitedAll map[string]bool
+	budget     int
+	count      int
+	overflow   bool
+}
+
+func (c *treeBuildCtx) over() bool {
+	return c.overflow
+}
+
+func buildNode(e *model.Element, ctx *treeBuildCtx, visitedPath map[string]bool) *treeNode {
+	ctx.count++
+	if ctx.budget > 0 && ctx.count > ctx.budget {
+		ctx.overflow = true
+		return &treeNode{elem: e}
+	}
 	if visitedPath[e.Name] {
 		return &treeNode{elem: e}
 	}
 	visitedPath[e.Name] = true
-	visitedAll[e.Name] = true
+	ctx.visitedAll[e.Name] = true
 	defer delete(visitedPath, e.Name)
 
 	node := &treeNode{elem: e}
 	for _, c := range e.Components {
-		child, ok := byName[c.Name]
+		if ctx.overflow {
+			break
+		}
+		child, ok := ctx.byName[c.Name]
 		if !ok {
 			continue
 		}
-		node.children = append(node.children, buildNode(child, byName, visitedAll, visitedPath))
+		node.children = append(node.children, buildNode(child, ctx, visitedPath))
 	}
 	return node
 }

--- a/cmd/dims.go
+++ b/cmd/dims.go
@@ -161,6 +161,7 @@ var (
 	membersLimit     int
 	membersAll       bool
 	membersCount     bool
+	membersFlat      bool
 )
 
 var dimsMembersCmd = &cobra.Command{
@@ -173,8 +174,14 @@ Equivalent to: Dimension Editor in TM1 Architect
 REST API:      GET /Dimensions('name')/Hierarchies('name')/Elements
 
 By default uses the dimension's same-named hierarchy.
-Use --hierarchy for alternate hierarchies.`,
+Use --hierarchy for alternate hierarchies.
+
+Output is indented by default to show hierarchy: children of consolidated
+elements are indented two spaces per level. Use --flat for a single-level
+list. Indentation is disabled automatically with --filter, --count, and
+--output json.`,
 	Example: `  tm1cli dims members Period
+  tm1cli dims members Period --flat
   tm1cli dims members Region --hierarchy "Alternate Region"
   tm1cli dims members Period --filter "Q"
   tm1cli dims members Account --output json`,
@@ -205,7 +212,12 @@ func runDimsMembers(cmd *cobra.Command, args []string) error {
 		hierarchy = dimName
 	}
 
+	treeMode := !jsonMode && !membersCount && !membersFlat && membersFilter == ""
+
 	endpoint := fmt.Sprintf("Dimensions('%s')/Hierarchies('%s')/Elements?$select=Name,Type", url.PathEscape(dimName), url.PathEscape(hierarchy))
+	if treeMode {
+		endpoint += "&$expand=Components($select=Name)"
+	}
 
 	// Try server-side filter
 	filterFallback := false
@@ -216,7 +228,7 @@ func runDimsMembers(cmd *cobra.Command, args []string) error {
 		if err == nil {
 			var resp model.ElementResponse
 			if jsonErr := json.Unmarshal(data, &resp); jsonErr == nil {
-				displayMembers(resp.Value, len(resp.Value), limit, jsonMode)
+				displayMembers(resp.Value, len(resp.Value), limit, jsonMode, treeMode)
 				return nil
 			}
 		}
@@ -225,7 +237,7 @@ func runDimsMembers(cmd *cobra.Command, args []string) error {
 	}
 
 	fetchEndpoint := endpoint
-	if limit > 0 && membersFilter == "" {
+	if limit > 0 && membersFilter == "" && !treeMode {
 		fetchEndpoint += fmt.Sprintf("&$top=%d", limit)
 	}
 
@@ -247,7 +259,7 @@ func runDimsMembers(cmd *cobra.Command, args []string) error {
 		elements = filterElementsByName(elements, membersFilter)
 	}
 
-	displayMembers(elements, len(elements), limit, jsonMode)
+	displayMembers(elements, len(elements), limit, jsonMode, treeMode)
 	return nil
 }
 
@@ -262,7 +274,7 @@ func filterElementsByName(elements []model.Element, filter string) []model.Eleme
 	return filtered
 }
 
-func displayMembers(elements []model.Element, total int, limit int, jsonMode bool) {
+func displayMembers(elements []model.Element, total int, limit int, jsonMode bool, treeMode bool) {
 	if membersCount {
 		if jsonMode {
 			output.PrintJSON(map[string]int{"count": total})
@@ -272,23 +284,123 @@ func displayMembers(elements []model.Element, total int, limit int, jsonMode boo
 		return
 	}
 
-	shown := elements
-	if limit > 0 && len(shown) > limit {
-		shown = shown[:limit]
-	}
-
 	if jsonMode {
+		shown := elements
+		if limit > 0 && len(shown) > limit {
+			shown = shown[:limit]
+		}
 		output.PrintJSON(shown)
 		return
 	}
 
 	headers := []string{"NAME", "TYPE"}
+
+	if treeMode {
+		flat := flattenTree(buildTree(elements))
+		flatTotal := len(flat)
+		shown := flat
+		if limit > 0 && len(shown) > limit {
+			shown = shown[:limit]
+		}
+		rows := make([][]string, len(shown))
+		for i, r := range shown {
+			rows[i] = []string{strings.Repeat("  ", r.depth) + r.name, r.elType}
+		}
+		output.PrintTable(headers, rows)
+		output.PrintSummary(len(shown), flatTotal)
+		return
+	}
+
+	shown := elements
+	if limit > 0 && len(shown) > limit {
+		shown = shown[:limit]
+	}
 	rows := make([][]string, len(shown))
 	for i, e := range shown {
 		rows[i] = []string{e.Name, e.Type}
 	}
 	output.PrintTable(headers, rows)
 	output.PrintSummary(len(shown), total)
+}
+
+// --- hierarchy tree (indentation) ---
+
+type treeNode struct {
+	elem     *model.Element
+	children []*treeNode
+}
+
+type indentedRow struct {
+	depth  int
+	name   string
+	elType string
+}
+
+// buildTree turns a flat element list (with populated Components) into a
+// forest. Natural roots are elements that never appear as a child; a second
+// pass adds synthetic roots for residual or cycle-only subgraphs so no
+// element disappears from the output.
+func buildTree(elements []model.Element) []*treeNode {
+	byName := make(map[string]*model.Element, len(elements))
+	for i := range elements {
+		byName[elements[i].Name] = &elements[i]
+	}
+	childOf := make(map[string]bool)
+	for _, e := range elements {
+		for _, c := range e.Components {
+			childOf[c.Name] = true
+		}
+	}
+
+	visitedAll := make(map[string]bool)
+	var roots []*treeNode
+
+	for i := range elements {
+		name := elements[i].Name
+		if !childOf[name] && !visitedAll[name] {
+			roots = append(roots, buildNode(&elements[i], byName, visitedAll, map[string]bool{}))
+		}
+	}
+	for i := range elements {
+		if !visitedAll[elements[i].Name] {
+			roots = append(roots, buildNode(&elements[i], byName, visitedAll, map[string]bool{}))
+		}
+	}
+	return roots
+}
+
+func buildNode(e *model.Element, byName map[string]*model.Element, visitedAll, visitedPath map[string]bool) *treeNode {
+	if visitedPath[e.Name] {
+		return &treeNode{elem: e}
+	}
+	visitedPath[e.Name] = true
+	visitedAll[e.Name] = true
+	defer delete(visitedPath, e.Name)
+
+	node := &treeNode{elem: e}
+	for _, c := range e.Components {
+		child, ok := byName[c.Name]
+		if !ok {
+			continue
+		}
+		node.children = append(node.children, buildNode(child, byName, visitedAll, visitedPath))
+	}
+	return node
+}
+
+func flattenTree(roots []*treeNode) []indentedRow {
+	var out []indentedRow
+	var dfs func(*treeNode, int)
+	dfs = func(n *treeNode, d int) {
+		out = append(out, indentedRow{depth: d, name: n.elem.Name, elType: n.elem.Type})
+		for _, c := range n.children {
+			dfs(c, d+1)
+		}
+	}
+	for _, r := range roots {
+		dfs(r, 0)
+	}
+	return out
 }
 
 func init() {
@@ -306,4 +418,5 @@ func init() {
 	dimsMembersCmd.Flags().IntVar(&membersLimit, "limit", 0, "Max results to show (default from settings)")
 	dimsMembersCmd.Flags().BoolVar(&membersAll, "all", false, "Show all members, no limit")
 	dimsMembersCmd.Flags().BoolVar(&membersCount, "count", false, "Show count only")
+	dimsMembersCmd.Flags().BoolVar(&membersFlat, "flat", false, "Disable hierarchy indentation (default indents consolidated children)")
 }

--- a/cmd/dims.go
+++ b/cmd/dims.go
@@ -342,12 +342,10 @@ type indentedRow struct {
 // element disappears from the output.
 func buildTree(elements []model.Element) []*treeNode {
 	byName := make(map[string]*model.Element, len(elements))
+	childOf := make(map[string]bool)
 	for i := range elements {
 		byName[elements[i].Name] = &elements[i]
-	}
-	childOf := make(map[string]bool)
-	for _, e := range elements {
-		for _, c := range e.Components {
+		for _, c := range elements[i].Components {
 			childOf[c.Name] = true
 		}
 	}

--- a/cmd/dims.go
+++ b/cmd/dims.go
@@ -2,10 +2,12 @@ package cmd
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/url"
 	"strconv"
 	"strings"
+	"tm1cli/internal/client"
 	"tm1cli/internal/model"
 	"tm1cli/internal/output"
 
@@ -240,6 +242,10 @@ func runDimsMembers(cmd *cobra.Command, args []string) error {
 		data, err := cl.Get(countEndpoint)
 		switch {
 		case err != nil:
+			if errors.Is(err, client.ErrNotFound) {
+				output.PrintError(err.Error(), jsonMode)
+				return errSilent
+			}
 			output.PrintWarning(preflightFallbackMessage("cannot verify dimension size", limit))
 			treeMode = false
 		default:
@@ -484,15 +490,17 @@ func flattenTree(roots []*treeNode) []indentedRow {
 }
 
 // flattenTreeCapped walks the tree in DFS preorder and stops materializing
-// rows once the cap is reached. Pass cap <= 0 for no cap. The DFS itself
-// short-circuits — callers still needing a full flatTotal should use
-// treeStats for a count-only pass.
-func flattenTreeCapped(roots []*treeNode, cap int) []indentedRow {
+// rows once budget rows have been emitted. Pass budget <= 0 for no cap.
+// The DFS itself short-circuits — callers still needing a full flatTotal
+// should use treeStats for a count-only pass. (Named budget, not cap,
+// because cap() is a Go builtin and a parameter named cap would shadow
+// it inside the function body.)
+func flattenTreeCapped(roots []*treeNode, budget int) []indentedRow {
 	var out []indentedRow
 	var dfs func(*treeNode, int) bool
 	dfs = func(n *treeNode, d int) bool {
 		out = append(out, indentedRow{depth: d, name: n.elem.Name, elType: n.elem.Type})
-		if cap > 0 && len(out) >= cap {
+		if budget > 0 && len(out) >= budget {
 			return false
 		}
 		for _, c := range n.children {

--- a/cmd/dims.go
+++ b/cmd/dims.go
@@ -179,7 +179,11 @@ Use --hierarchy for alternate hierarchies.
 Output is indented by default to show hierarchy: children of consolidated
 elements are indented two spaces per level. Use --flat for a single-level
 list. Indentation is disabled automatically with --filter, --count, and
---output json.`,
+--output json.
+
+Tree mode fetches the full hierarchy so indentation stays intact; on very
+large dimensions (>5000 elements) a stderr warning is emitted recommending
+--flat for faster queries.`,
 	Example: `  tm1cli dims members Period
   tm1cli dims members Period --flat
   tm1cli dims members Region --hierarchy "Alternate Region"
@@ -259,9 +263,15 @@ func runDimsMembers(cmd *cobra.Command, args []string) error {
 		elements = filterElementsByName(elements, membersFilter)
 	}
 
+	if treeMode && len(elements) > treeWarnThreshold {
+		output.PrintWarning(fmt.Sprintf("Fetched %d elements; use --flat for faster queries on large dimensions.", len(elements)))
+	}
+
 	displayMembers(elements, len(elements), limit, jsonMode, treeMode)
 	return nil
 }
+
+const treeWarnThreshold = 5000
 
 func filterElementsByName(elements []model.Element, filter string) []model.Element {
 	lower := strings.ToLower(filter)

--- a/cmd/dims.go
+++ b/cmd/dims.go
@@ -308,6 +308,10 @@ func displayMembers(elements []model.Element, total int, limit int, jsonMode boo
 	if treeMode {
 		flat := flattenTree(buildTree(elements))
 		flatTotal := len(flat)
+		uniqueNames := make(map[string]struct{}, flatTotal)
+		for _, r := range flat {
+			uniqueNames[r.name] = struct{}{}
+		}
 		shown := flat
 		if limit > 0 && len(shown) > limit {
 			shown = shown[:limit]
@@ -317,7 +321,7 @@ func displayMembers(elements []model.Element, total int, limit int, jsonMode boo
 			rows[i] = []string{strings.Repeat("  ", r.depth) + r.name, r.elType}
 		}
 		output.PrintTable(headers, rows)
-		output.PrintSummary(len(shown), flatTotal)
+		output.PrintTreeSummary(len(shown), flatTotal, len(uniqueNames))
 		return
 	}
 

--- a/cmd/dims.go
+++ b/cmd/dims.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/url"
+	"strconv"
 	"strings"
 	"tm1cli/internal/model"
 	"tm1cli/internal/output"
@@ -181,9 +182,9 @@ elements are indented two spaces per level. Use --flat for a single-level
 list. Indentation is disabled automatically with --filter, --count, and
 --output json.
 
-Tree mode fetches the full hierarchy so indentation stays intact; on very
-large dimensions (>5000 elements) a stderr warning is emitted recommending
---flat for faster queries.`,
+Tree mode fetches the full hierarchy so indentation stays intact. For
+dimensions over 5000 elements, tree view is gated behind --all; use
+--flat for a faster listing or --all to acknowledge the fetch cost.`,
 	Example: `  tm1cli dims members Period
   tm1cli dims members Period --flat
   tm1cli dims members Region --hierarchy "Alternate Region"
@@ -217,6 +218,16 @@ func runDimsMembers(cmd *cobra.Command, args []string) error {
 	}
 
 	treeMode := !jsonMode && !membersCount && !membersFlat && membersFilter == ""
+
+	if treeMode && !membersAll {
+		countEndpoint := fmt.Sprintf("Dimensions('%s')/Hierarchies('%s')/Elements/$count", url.PathEscape(dimName), url.PathEscape(hierarchy))
+		if data, err := cl.Get(countEndpoint); err == nil {
+			if n, parseErr := strconv.Atoi(strings.TrimSpace(string(data))); parseErr == nil && n > treeElementGate {
+				output.PrintError(fmt.Sprintf("dimension has %d elements. Tree view requires --all for dimensions over %d; use --flat for a faster listing.", n, treeElementGate), jsonMode)
+				return errSilent
+			}
+		}
+	}
 
 	endpoint := fmt.Sprintf("Dimensions('%s')/Hierarchies('%s')/Elements?$select=Name,Type", url.PathEscape(dimName), url.PathEscape(hierarchy))
 	if treeMode {
@@ -263,15 +274,11 @@ func runDimsMembers(cmd *cobra.Command, args []string) error {
 		elements = filterElementsByName(elements, membersFilter)
 	}
 
-	if treeMode && len(elements) > treeWarnThreshold {
-		output.PrintWarning(fmt.Sprintf("Fetched %d elements; use --flat for faster queries on large dimensions.", len(elements)))
-	}
-
 	displayMembers(elements, len(elements), limit, jsonMode, treeMode)
 	return nil
 }
 
-const treeWarnThreshold = 5000
+const treeElementGate = 5000
 
 func filterElementsByName(elements []model.Element, filter string) []model.Element {
 	lower := strings.ToLower(filter)
@@ -306,22 +313,15 @@ func displayMembers(elements []model.Element, total int, limit int, jsonMode boo
 	headers := []string{"NAME", "TYPE"}
 
 	if treeMode {
-		flat := flattenTree(buildTree(elements))
-		flatTotal := len(flat)
-		uniqueNames := make(map[string]struct{}, flatTotal)
-		for _, r := range flat {
-			uniqueNames[r.name] = struct{}{}
-		}
-		shown := flat
-		if limit > 0 && len(shown) > limit {
-			shown = shown[:limit]
-		}
+		roots := buildTree(elements)
+		flatTotal, uniqueCount := treeStats(roots)
+		shown := flattenTreeCapped(roots, limit)
 		rows := make([][]string, len(shown))
 		for i, r := range shown {
 			rows[i] = []string{strings.Repeat("  ", r.depth) + r.name, r.elType}
 		}
 		output.PrintTable(headers, rows)
-		output.PrintTreeSummary(len(shown), flatTotal, len(uniqueNames))
+		output.PrintTreeSummary(len(shown), flatTotal, uniqueCount)
 		return
 	}
 
@@ -401,18 +401,52 @@ func buildNode(e *model.Element, byName map[string]*model.Element, visitedAll, v
 }
 
 func flattenTree(roots []*treeNode) []indentedRow {
+	return flattenTreeCapped(roots, 0)
+}
+
+// flattenTreeCapped walks the tree in DFS preorder and stops materializing
+// rows once the cap is reached. Pass cap <= 0 for no cap. The DFS itself
+// short-circuits — callers still needing a full flatTotal should use
+// treeStats for a count-only pass.
+func flattenTreeCapped(roots []*treeNode, cap int) []indentedRow {
 	var out []indentedRow
-	var dfs func(*treeNode, int)
-	dfs = func(n *treeNode, d int) {
+	var dfs func(*treeNode, int) bool
+	dfs = func(n *treeNode, d int) bool {
 		out = append(out, indentedRow{depth: d, name: n.elem.Name, elType: n.elem.Type})
+		if cap > 0 && len(out) >= cap {
+			return false
+		}
 		for _, c := range n.children {
-			dfs(c, d+1)
+			if !dfs(c, d+1) {
+				return false
+			}
+		}
+		return true
+	}
+	for _, r := range roots {
+		if !dfs(r, 0) {
+			return out
+		}
+	}
+	return out
+}
+
+// treeStats counts total DFS rows and unique element names without
+// materializing row structs.
+func treeStats(roots []*treeNode) (flatTotal int, uniqueCount int) {
+	seen := make(map[string]struct{})
+	var dfs func(*treeNode)
+	dfs = func(n *treeNode) {
+		flatTotal++
+		seen[n.elem.Name] = struct{}{}
+		for _, c := range n.children {
+			dfs(c)
 		}
 	}
 	for _, r := range roots {
-		dfs(r, 0)
+		dfs(r)
 	}
-	return out
+	return flatTotal, len(seen)
 }
 
 func init() {

--- a/cmd/dims_test.go
+++ b/cmd/dims_test.go
@@ -891,6 +891,48 @@ func TestBuildTree_PreservesComponentOrder(t *testing.T) {
 	}
 }
 
+func TestFlattenTreeCapped_StopsAtCap(t *testing.T) {
+	elements := []model.Element{
+		{Name: "A", Type: "Consolidated", Components: []model.Component{{Name: "B"}, {Name: "C"}}},
+		{Name: "B", Type: "Consolidated", Components: []model.Component{{Name: "D"}}},
+		{Name: "C", Type: "Numeric"},
+		{Name: "D", Type: "Numeric"},
+	}
+	roots := buildTree(elements)
+
+	shown := flattenTreeCapped(roots, 2)
+	if len(shown) != 2 {
+		t.Fatalf("cap=2 should return 2 rows, got %d: %v", len(shown), flatNamesDepths(shown))
+	}
+	want := []string{"A@0", "B@1"}
+	if !stringSliceEqual(flatNamesDepths(shown), want) {
+		t.Errorf("cap=2 DFS preorder = %v, want %v", flatNamesDepths(shown), want)
+	}
+
+	unCapped := flattenTreeCapped(roots, 0)
+	if len(unCapped) != 4 {
+		t.Errorf("cap=0 should walk all rows, got %d: %v", len(unCapped), flatNamesDepths(unCapped))
+	}
+}
+
+func TestTreeStats_CountsRowsAndUnique(t *testing.T) {
+	elements := []model.Element{
+		{Name: "A", Type: "Consolidated", Components: []model.Component{{Name: "B"}, {Name: "C"}}},
+		{Name: "B", Type: "Consolidated", Components: []model.Component{{Name: "D"}}},
+		{Name: "C", Type: "Consolidated", Components: []model.Component{{Name: "D"}}},
+		{Name: "D", Type: "Numeric"},
+	}
+	roots := buildTree(elements)
+
+	flatTotal, uniqueCount := treeStats(roots)
+	if flatTotal != 5 {
+		t.Errorf("flatTotal = %d, want 5 (A,B,D,C,D)", flatTotal)
+	}
+	if uniqueCount != 4 {
+		t.Errorf("uniqueCount = %d, want 4 (A,B,C,D)", uniqueCount)
+	}
+}
+
 func TestBuildTree_EmptyInput(t *testing.T) {
 	if got := buildTree(nil); len(got) != 0 {
 		t.Errorf("buildTree(nil) = %v, want empty", got)
@@ -1136,37 +1178,66 @@ func TestRunDimsMembers_CountSkipsExpand(t *testing.T) {
 	}
 }
 
-func TestRunDimsMembers_TreeModeWarnsOnLargeFetch(t *testing.T) {
+func TestRunDimsMembers_TreeModeGatesWithoutAll(t *testing.T) {
 	resetCmdFlags(t)
 
-	names := make([]string, treeWarnThreshold+1)
-	types := make([]string, treeWarnThreshold+1)
-	for i := range names {
-		names[i] = fmt.Sprintf("Elem%d", i)
-		types[i] = "Numeric"
+	var elementsFetched bool
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/$count") {
+			w.Header().Set("Content-Type", "text/plain")
+			fmt.Fprintf(w, "%d", treeElementGate+1)
+			return
+		}
+		elementsFetched = true
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(elementsWithComponentsJSON([]string{"X"}, []string{"Numeric"}, nil))
+	})
+
+	captured := captureAll(t, func() {
+		err := runDimsMembers(dimsMembersCmd, []string{"Big"})
+		if err != errSilent {
+			t.Fatalf("expected errSilent when gate triggers, got: %v", err)
+		}
+	})
+
+	if elementsFetched {
+		t.Error("gate must abort before the heavy elements fetch; server saw the request")
 	}
+	if !strings.Contains(captured.Stderr, "--all") {
+		t.Errorf("gate error should suggest --all, got stderr: %q", captured.Stderr)
+	}
+	if !strings.Contains(captured.Stderr, "--flat") {
+		t.Errorf("gate error should suggest --flat, got stderr: %q", captured.Stderr)
+	}
+	wantCount := fmt.Sprintf("%d", treeElementGate+1)
+	if !strings.Contains(captured.Stderr, wantCount) {
+		t.Errorf("gate error should include the element count %s, got stderr: %q", wantCount, captured.Stderr)
+	}
+}
+
+func TestRunDimsMembers_TreeModeAllowsLargeWithAll(t *testing.T) {
+	resetCmdFlags(t)
+	membersAll = true
 
 	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/$count") {
+			w.Header().Set("Content-Type", "text/plain")
+			fmt.Fprintf(w, "%d", treeElementGate+1)
+			return
+		}
 		w.Header().Set("Content-Type", "application/json")
-		w.Write(elementsWithComponentsJSON(names, types, nil))
+		w.Write(elementsWithComponentsJSON([]string{"Year"}, []string{"Consolidated"}, nil))
 	})
 
 	captured := captureAll(t, func() {
 		err := runDimsMembers(dimsMembersCmd, []string{"Big"})
 		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
+			t.Fatalf("--all should bypass the gate, got error: %v", err)
 		}
 	})
 
-	if !strings.Contains(captured.Stderr, "[warn]") {
-		t.Errorf("expected warning for oversize tree fetch, got stderr: %q", captured.Stderr)
-	}
-	if !strings.Contains(captured.Stderr, "--flat") {
-		t.Errorf("warning should mention --flat, got stderr: %q", captured.Stderr)
-	}
-	wantCount := fmt.Sprintf("%d", treeWarnThreshold+1)
-	if !strings.Contains(captured.Stderr, wantCount) {
-		t.Errorf("warning should include element count %s, got stderr: %q", wantCount, captured.Stderr)
+	if !strings.Contains(captured.Stdout, "Year") {
+		t.Errorf("output should render elements when --all is set, got:\n%s", captured.Stdout)
 	}
 }
 
@@ -1174,6 +1245,11 @@ func TestRunDimsMembers_TreeModeQuietBelowThreshold(t *testing.T) {
 	resetCmdFlags(t)
 
 	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/$count") {
+			w.Header().Set("Content-Type", "text/plain")
+			w.Write([]byte("2"))
+			return
+		}
 		w.Header().Set("Content-Type", "application/json")
 		w.Write(elementsWithComponentsJSON(
 			[]string{"Year", "Q1"},
@@ -1185,40 +1261,37 @@ func TestRunDimsMembers_TreeModeQuietBelowThreshold(t *testing.T) {
 	captured := captureAll(t, func() {
 		err := runDimsMembers(dimsMembersCmd, []string{"Small"})
 		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
+			t.Fatalf("below-gate count should not error, got: %v", err)
 		}
 	})
 
-	if strings.Contains(captured.Stderr, "Fetched") {
-		t.Errorf("small dimensions should not emit fetch-size warning, got stderr: %q", captured.Stderr)
+	if strings.Contains(captured.Stderr, "--all") {
+		t.Errorf("small dimensions should not trigger the gate error, got stderr: %q", captured.Stderr)
 	}
 }
 
-func TestRunDimsMembers_FlatModeNeverWarnsOnSize(t *testing.T) {
+func TestRunDimsMembers_FlatModeSkipsCountPreflight(t *testing.T) {
 	resetCmdFlags(t)
 	membersFlat = true
 
-	names := make([]string, treeWarnThreshold+1)
-	types := make([]string, treeWarnThreshold+1)
-	for i := range names {
-		names[i] = fmt.Sprintf("Elem%d", i)
-		types[i] = "Numeric"
-	}
-
+	var countCalled bool
 	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/$count") {
+			countCalled = true
+		}
 		w.Header().Set("Content-Type", "application/json")
-		w.Write(elementsJSON(names, types))
+		w.Write(elementsJSON([]string{"Year"}, []string{"Consolidated"}))
 	})
 
-	captured := captureAll(t, func() {
+	captureAll(t, func() {
 		err := runDimsMembers(dimsMembersCmd, []string{"Big"})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 	})
 
-	if strings.Contains(captured.Stderr, "Fetched") {
-		t.Errorf("--flat should never emit fetch-size warning, got stderr: %q", captured.Stderr)
+	if countCalled {
+		t.Error("--flat should skip the $count pre-flight entirely")
 	}
 }
 

--- a/cmd/dims_test.go
+++ b/cmd/dims_test.go
@@ -891,6 +891,114 @@ func TestBuildTree_PreservesComponentOrder(t *testing.T) {
 	}
 }
 
+func TestBuildTreeBounded_UnderBudgetNoOverflow(t *testing.T) {
+	elements := []model.Element{
+		{Name: "A", Type: "Consolidated", Components: []model.Component{{Name: "B"}}},
+		{Name: "B", Type: "Numeric"},
+	}
+
+	_, overflow := buildTreeBounded(elements, 100)
+	if overflow {
+		t.Error("2-node tree should not overflow a 100-node budget")
+	}
+}
+
+func TestBuildTreeBounded_LayeredDiamondOverflows(t *testing.T) {
+	// Build a layered diamond: each layer doubles the render count via
+	// two parents sharing the same two children. 8 layers with ~2 unique
+	// elements each expand to roughly 2^8 = 256 nodes, which blows past
+	// budget=16 but uses only ~16 unique elements.
+	elements := []model.Element{}
+	layers := 8
+	for i := 0; i < layers; i++ {
+		parent := fmt.Sprintf("L%dP", i)
+		left := fmt.Sprintf("L%dA", i+1)
+		right := fmt.Sprintf("L%dB", i+1)
+		elements = append(elements, model.Element{
+			Name:       parent,
+			Type:       "Consolidated",
+			Components: []model.Component{{Name: left}, {Name: right}},
+		})
+		// Each non-leaf child points to the next layer's parent (shared).
+		if i < layers-1 {
+			nextParent := fmt.Sprintf("L%dP", i+1)
+			elements = append(elements,
+				model.Element{Name: left, Type: "Consolidated", Components: []model.Component{{Name: nextParent}}},
+				model.Element{Name: right, Type: "Consolidated", Components: []model.Component{{Name: nextParent}}},
+			)
+		} else {
+			elements = append(elements,
+				model.Element{Name: left, Type: "Numeric"},
+				model.Element{Name: right, Type: "Numeric"},
+			)
+		}
+	}
+
+	_, overflow := buildTreeBounded(elements, 64)
+	if !overflow {
+		t.Error("layered-diamond expansion should overflow a 64-node budget")
+	}
+
+	_, overflow = buildTreeBounded(elements, 0)
+	if overflow {
+		t.Error("unlimited budget (0) should never overflow")
+	}
+}
+
+func TestRunDimsMembers_TreeModeDiamondOverflowErrors(t *testing.T) {
+	resetCmdFlags(t)
+
+	// Build layered diamonds that over-expand past treeRenderCeiling
+	// while keeping unique element count below the gate.
+	names := []string{}
+	types := []string{}
+	children := map[string][]string{}
+	layers := 24 // 2^24 >> 50000
+	for i := 0; i < layers; i++ {
+		parent := fmt.Sprintf("L%dP", i)
+		left := fmt.Sprintf("L%dA", i+1)
+		right := fmt.Sprintf("L%dB", i+1)
+		names = append(names, parent)
+		types = append(types, "Consolidated")
+		children[parent] = []string{left, right}
+		if i == layers-1 {
+			names = append(names, left, right)
+			types = append(types, "Numeric", "Numeric")
+		} else {
+			nextParent := fmt.Sprintf("L%dP", i+1)
+			names = append(names, left, right)
+			types = append(types, "Consolidated", "Consolidated")
+			children[left] = []string{nextParent}
+			children[right] = []string{nextParent}
+		}
+	}
+
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/$count") {
+			// Small unique count — gate does not trigger.
+			w.Header().Set("Content-Type", "text/plain")
+			fmt.Fprintf(w, "%d", len(names))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(elementsWithComponentsJSON(names, types, children))
+	})
+
+	captured := captureAll(t, func() {
+		err := runDimsMembers(dimsMembersCmd, []string{"DiamondDim"})
+		if err != errSilent {
+			t.Fatalf("diamond explosion should error with errSilent, got: %v", err)
+		}
+	})
+
+	if !strings.Contains(captured.Stderr, "render rows") {
+		t.Errorf("overflow error should mention 'render rows', got stderr: %q", captured.Stderr)
+	}
+	if !strings.Contains(captured.Stderr, "--flat") {
+		t.Errorf("overflow error should suggest --flat, got stderr: %q", captured.Stderr)
+	}
+}
+
 func TestFlattenTreeCapped_StopsAtCap(t *testing.T) {
 	elements := []model.Element{
 		{Name: "A", Type: "Consolidated", Components: []model.Component{{Name: "B"}, {Name: "C"}}},
@@ -1058,6 +1166,11 @@ func TestRunDimsMembers_TreeOutputEndToEnd(t *testing.T) {
 	resetCmdFlags(t)
 
 	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/$count") {
+			w.Header().Set("Content-Type", "text/plain")
+			w.Write([]byte("3"))
+			return
+		}
 		w.Header().Set("Content-Type", "application/json")
 		w.Write(elementsWithComponentsJSON(
 			[]string{"Year", "Q1", "Jan"},
@@ -1203,8 +1316,8 @@ func TestRunDimsMembers_TreeModeGatesWithoutAll(t *testing.T) {
 	if elementsFetched {
 		t.Error("gate must abort before the heavy elements fetch; server saw the request")
 	}
-	if !strings.Contains(captured.Stderr, "--all") {
-		t.Errorf("gate error should suggest --all, got stderr: %q", captured.Stderr)
+	if !strings.Contains(captured.Stderr, "Tree view requires --all") {
+		t.Errorf("gate error should lock the phrase 'Tree view requires --all', got stderr: %q", captured.Stderr)
 	}
 	if !strings.Contains(captured.Stderr, "--flat") {
 		t.Errorf("gate error should suggest --flat, got stderr: %q", captured.Stderr)
@@ -1212,6 +1325,66 @@ func TestRunDimsMembers_TreeModeGatesWithoutAll(t *testing.T) {
 	wantCount := fmt.Sprintf("%d", treeElementGate+1)
 	if !strings.Contains(captured.Stderr, wantCount) {
 		t.Errorf("gate error should include the element count %s, got stderr: %q", wantCount, captured.Stderr)
+	}
+}
+
+func TestRunDimsMembers_TreeModePreflightFailsClosed(t *testing.T) {
+	resetCmdFlags(t)
+
+	var heavyFetched bool
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/$count") {
+			w.WriteHeader(http.StatusInternalServerError)
+			w.Write([]byte(`{"error":"$count not supported"}`))
+			return
+		}
+		heavyFetched = true
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(elementsWithComponentsJSON([]string{"Year"}, []string{"Consolidated"}, nil))
+	})
+
+	captured := captureAll(t, func() {
+		err := runDimsMembers(dimsMembersCmd, []string{"Any"})
+		if err != errSilent {
+			t.Fatalf("expected errSilent when preflight fails, got: %v", err)
+		}
+	})
+
+	if heavyFetched {
+		t.Error("preflight failure must fail closed; heavy fetch should not run")
+	}
+	if captured.Stderr == "" {
+		t.Error("preflight failure must emit a user-visible error on stderr")
+	}
+}
+
+func TestRunDimsMembers_TreeModePreflightNonIntegerFailsClosed(t *testing.T) {
+	resetCmdFlags(t)
+
+	var heavyFetched bool
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/$count") {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(`{"not":"an integer"}`))
+			return
+		}
+		heavyFetched = true
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(elementsWithComponentsJSON([]string{"Year"}, []string{"Consolidated"}, nil))
+	})
+
+	captured := captureAll(t, func() {
+		err := runDimsMembers(dimsMembersCmd, []string{"Any"})
+		if err != errSilent {
+			t.Fatalf("expected errSilent on non-integer preflight response, got: %v", err)
+		}
+	})
+
+	if heavyFetched {
+		t.Error("non-integer preflight response must fail closed; heavy fetch should not run")
+	}
+	if !strings.Contains(captured.Stderr, "cannot verify dimension size") {
+		t.Errorf("should report size-verification failure, got stderr: %q", captured.Stderr)
 	}
 }
 
@@ -1301,6 +1474,11 @@ func TestRunDimsMembers_TreeModeOmitsTop(t *testing.T) {
 
 	var capturedQuery string
 	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/$count") {
+			w.Header().Set("Content-Type", "text/plain")
+			w.Write([]byte("1"))
+			return
+		}
 		capturedQuery = r.URL.RawQuery
 		w.Header().Set("Content-Type", "application/json")
 		w.Write(elementsWithComponentsJSON(
@@ -1422,6 +1600,11 @@ func TestRunDimsMembers_EndToEnd(t *testing.T) {
 	resetCmdFlags(t)
 
 	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/$count") {
+			w.Header().Set("Content-Type", "text/plain")
+			w.Write([]byte("3"))
+			return
+		}
 		w.Header().Set("Content-Type", "application/json")
 		w.Write(elementsJSON(
 			[]string{"Jan", "Feb", "Mar"},
@@ -1456,6 +1639,12 @@ func TestRunDimsMembers_CustomHierarchy(t *testing.T) {
 
 	var capturedPath string
 	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/$count") {
+			capturedPath = r.URL.Path
+			w.Header().Set("Content-Type", "text/plain")
+			w.Write([]byte("2"))
+			return
+		}
 		capturedPath = r.URL.Path
 		w.Header().Set("Content-Type", "application/json")
 		w.Write(elementsJSON([]string{"East", "West"}, []string{"Numeric", "Numeric"}))
@@ -1484,6 +1673,12 @@ func TestRunDimsMembers_DefaultHierarchyMatchesDimName(t *testing.T) {
 
 	var capturedPath string
 	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/$count") {
+			capturedPath = r.URL.Path
+			w.Header().Set("Content-Type", "text/plain")
+			w.Write([]byte("1"))
+			return
+		}
 		capturedPath = r.URL.Path
 		w.Header().Set("Content-Type", "application/json")
 		w.Write(elementsJSON([]string{"Q1"}, []string{"Consolidated"}))

--- a/cmd/dims_test.go
+++ b/cmd/dims_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"strings"
 	"testing"
@@ -493,7 +494,7 @@ func TestDisplayMembers_TableOutput(t *testing.T) {
 	}
 
 	out := captureStdout(t, func() {
-		displayMembers(elements, 3, 0, false)
+		displayMembers(elements, 3, 0, false, false)
 	})
 
 	// Check headers
@@ -526,7 +527,7 @@ func TestDisplayMembers_JSONOutput(t *testing.T) {
 	}
 
 	out := captureStdout(t, func() {
-		displayMembers(elements, 2, 0, true)
+		displayMembers(elements, 2, 0, true, false)
 	})
 
 	var parsed []model.Element
@@ -557,7 +558,7 @@ func TestDisplayMembers_CountTable(t *testing.T) {
 	}
 
 	out := captureStdout(t, func() {
-		displayMembers(elements, 4, 0, false)
+		displayMembers(elements, 4, 0, false, false)
 	})
 
 	expected := "4 members\n"
@@ -576,7 +577,7 @@ func TestDisplayMembers_CountJSON(t *testing.T) {
 	}
 
 	out := captureStdout(t, func() {
-		displayMembers(elements, 10, 0, true)
+		displayMembers(elements, 10, 0, true, false)
 	})
 
 	var parsed map[string]int
@@ -602,7 +603,7 @@ func TestDisplayMembers_LimitTruncation(t *testing.T) {
 	}
 
 	captured := captureAll(t, func() {
-		displayMembers(elements, 5, 2, false)
+		displayMembers(elements, 5, 2, false, false)
 	})
 
 	// Should show first 2 only
@@ -633,7 +634,7 @@ func TestDisplayMembers_NoSummaryWhenAllShown(t *testing.T) {
 	}
 
 	captured := captureAll(t, func() {
-		displayMembers(elements, 2, 0, false)
+		displayMembers(elements, 2, 0, false, false)
 	})
 
 	if strings.Contains(captured.Stderr, "Showing") {
@@ -653,7 +654,7 @@ func TestDisplayMembers_LimitZeroShowsAll(t *testing.T) {
 	}
 
 	out := captureStdout(t, func() {
-		displayMembers(elements, 3, 0, false)
+		displayMembers(elements, 3, 0, false, false)
 	})
 
 	for _, e := range elements {
@@ -676,7 +677,7 @@ func TestDisplayMembers_JSONLimitTruncation(t *testing.T) {
 	}
 
 	out := captureStdout(t, func() {
-		displayMembers(elements, 4, 2, true)
+		displayMembers(elements, 4, 2, true, false)
 	})
 
 	var parsed []model.Element
@@ -694,7 +695,7 @@ func TestDisplayMembers_EmptyElements(t *testing.T) {
 	membersCount = false
 
 	out := captureStdout(t, func() {
-		displayMembers([]model.Element{}, 0, 0, false)
+		displayMembers([]model.Element{}, 0, 0, false, false)
 	})
 
 	// Should still print headers
@@ -717,7 +718,7 @@ func TestDisplayMembers_CountUsesTotalNotLen(t *testing.T) {
 	}
 
 	out := captureStdout(t, func() {
-		displayMembers(elements, 42, 0, false)
+		displayMembers(elements, 42, 0, false, false)
 	})
 
 	expected := "42 members\n"
@@ -743,6 +744,398 @@ func TestDisplayDims_CountUsesTotalNotLen(t *testing.T) {
 	expected := "99 dimensions\n"
 	if out != expected {
 		t.Errorf("count output = %q, want %q (should use total parameter)", out, expected)
+	}
+}
+
+// ============================================================
+// buildTree / flattenTree
+// ============================================================
+
+func flatNamesDepths(rows []indentedRow) []string {
+	out := make([]string, len(rows))
+	for i, r := range rows {
+		out[i] = fmt.Sprintf("%s@%d", r.name, r.depth)
+	}
+	return out
+}
+
+func TestBuildTree_SimpleHierarchy(t *testing.T) {
+	elements := []model.Element{
+		{Name: "Year", Type: "Consolidated", Components: []model.Component{{Name: "Q1"}, {Name: "Q2"}}},
+		{Name: "Q1", Type: "Consolidated", Components: []model.Component{{Name: "Jan"}}},
+		{Name: "Q2", Type: "Consolidated", Components: []model.Component{{Name: "Feb"}}},
+		{Name: "Jan", Type: "Numeric"},
+		{Name: "Feb", Type: "Numeric"},
+	}
+
+	flat := flattenTree(buildTree(elements))
+
+	want := []string{"Year@0", "Q1@1", "Jan@2", "Q2@1", "Feb@2"}
+	if !stringSliceEqual(flatNamesDepths(flat), want) {
+		t.Errorf("flatten = %v, want %v", flatNamesDepths(flat), want)
+	}
+}
+
+func TestBuildTree_AllLeaves(t *testing.T) {
+	elements := []model.Element{
+		{Name: "A", Type: "Numeric"},
+		{Name: "B", Type: "Numeric"},
+		{Name: "C", Type: "Numeric"},
+	}
+
+	flat := flattenTree(buildTree(elements))
+
+	want := []string{"A@0", "B@0", "C@0"}
+	if !stringSliceEqual(flatNamesDepths(flat), want) {
+		t.Errorf("flatten = %v, want %v", flatNamesDepths(flat), want)
+	}
+}
+
+func TestBuildTree_Diamond(t *testing.T) {
+	elements := []model.Element{
+		{Name: "A", Type: "Consolidated", Components: []model.Component{{Name: "B"}, {Name: "C"}}},
+		{Name: "B", Type: "Consolidated", Components: []model.Component{{Name: "D"}}},
+		{Name: "C", Type: "Consolidated", Components: []model.Component{{Name: "D"}}},
+		{Name: "D", Type: "Numeric"},
+	}
+
+	flat := flattenTree(buildTree(elements))
+
+	want := []string{"A@0", "B@1", "D@2", "C@1", "D@2"}
+	if !stringSliceEqual(flatNamesDepths(flat), want) {
+		t.Errorf("diamond flatten = %v, want %v", flatNamesDepths(flat), want)
+	}
+}
+
+func TestBuildTree_CycleIsGuarded(t *testing.T) {
+	elements := []model.Element{
+		{Name: "A", Type: "Consolidated", Components: []model.Component{{Name: "B"}}},
+		{Name: "B", Type: "Consolidated", Components: []model.Component{{Name: "A"}}},
+		{Name: "X", Type: "Numeric"},
+	}
+
+	flat := flattenTree(buildTree(elements))
+
+	names := make(map[string]int)
+	for _, r := range flat {
+		names[r.name]++
+	}
+	if names["X"] != 1 {
+		t.Errorf("X should appear exactly once, got %d: %v", names["X"], flatNamesDepths(flat))
+	}
+	if names["A"] == 0 || names["B"] == 0 {
+		t.Errorf("A and B should both appear, got: %v", flatNamesDepths(flat))
+	}
+	if len(flat) > 10 {
+		t.Errorf("output should be finite and small for a cycle, got %d rows: %v", len(flat), flatNamesDepths(flat))
+	}
+}
+
+func TestBuildTree_PureCycleRendersAllElements(t *testing.T) {
+	elements := []model.Element{
+		{Name: "A", Type: "Consolidated", Components: []model.Component{{Name: "B"}}},
+		{Name: "B", Type: "Consolidated", Components: []model.Component{{Name: "A"}}},
+	}
+
+	flat := flattenTree(buildTree(elements))
+
+	seen := make(map[string]bool)
+	for _, r := range flat {
+		seen[r.name] = true
+	}
+	if !seen["A"] || !seen["B"] {
+		t.Errorf("pure cycle should still render every element; got %v", flatNamesDepths(flat))
+	}
+}
+
+func TestBuildTree_UnknownComponentIgnored(t *testing.T) {
+	elements := []model.Element{
+		{Name: "A", Type: "Consolidated", Components: []model.Component{{Name: "Ghost"}}},
+	}
+
+	flat := flattenTree(buildTree(elements))
+
+	want := []string{"A@0"}
+	if !stringSliceEqual(flatNamesDepths(flat), want) {
+		t.Errorf("unknown component should be ignored; flatten = %v, want %v", flatNamesDepths(flat), want)
+	}
+}
+
+func TestBuildTree_RootOrderPreserved(t *testing.T) {
+	elements := []model.Element{
+		{Name: "C", Type: "Numeric"},
+		{Name: "A", Type: "Numeric"},
+		{Name: "B", Type: "Numeric"},
+	}
+
+	flat := flattenTree(buildTree(elements))
+
+	want := []string{"C@0", "A@0", "B@0"}
+	if !stringSliceEqual(flatNamesDepths(flat), want) {
+		t.Errorf("root order should follow input; flatten = %v, want %v", flatNamesDepths(flat), want)
+	}
+}
+
+func TestBuildTree_PreservesComponentOrder(t *testing.T) {
+	elements := []model.Element{
+		{Name: "A", Type: "Consolidated", Components: []model.Component{{Name: "C"}, {Name: "B"}}},
+		{Name: "B", Type: "Numeric"},
+		{Name: "C", Type: "Numeric"},
+	}
+
+	flat := flattenTree(buildTree(elements))
+
+	want := []string{"A@0", "C@1", "B@1"}
+	if !stringSliceEqual(flatNamesDepths(flat), want) {
+		t.Errorf("component order should follow Components slice; flatten = %v, want %v", flatNamesDepths(flat), want)
+	}
+}
+
+func TestBuildTree_EmptyInput(t *testing.T) {
+	if got := buildTree(nil); len(got) != 0 {
+		t.Errorf("buildTree(nil) = %v, want empty", got)
+	}
+	if got := buildTree([]model.Element{}); len(got) != 0 {
+		t.Errorf("buildTree([]) = %v, want empty", got)
+	}
+	if got := flattenTree(nil); len(got) != 0 {
+		t.Errorf("flattenTree(nil) = %v, want empty", got)
+	}
+}
+
+// ============================================================
+// displayMembers — tree mode
+// ============================================================
+
+func treeFixtureElements() []model.Element {
+	return []model.Element{
+		{Name: "Year", Type: "Consolidated", Components: []model.Component{{Name: "Q1"}, {Name: "Q2"}}},
+		{Name: "Q1", Type: "Consolidated", Components: []model.Component{{Name: "Jan"}}},
+		{Name: "Q2", Type: "Consolidated", Components: []model.Component{{Name: "Feb"}}},
+		{Name: "Jan", Type: "Numeric"},
+		{Name: "Feb", Type: "Numeric"},
+	}
+}
+
+func TestDisplayMembers_TreeIndentation(t *testing.T) {
+	origCount := membersCount
+	defer func() { membersCount = origCount }()
+	membersCount = false
+
+	elements := treeFixtureElements()
+
+	out := captureStdout(t, func() {
+		displayMembers(elements, len(elements), 0, false, true)
+	})
+
+	wantSubstrings := []string{"Year", "  Q1", "    Jan", "  Q2", "    Feb"}
+	for _, s := range wantSubstrings {
+		if !strings.Contains(out, s) {
+			t.Errorf("tree output missing %q; got:\n%s", s, out)
+		}
+	}
+}
+
+func TestDisplayMembers_TreeLimitTruncation(t *testing.T) {
+	origCount := membersCount
+	defer func() { membersCount = origCount }()
+	membersCount = false
+
+	elements := treeFixtureElements()
+
+	captured := captureAll(t, func() {
+		displayMembers(elements, len(elements), 3, false, true)
+	})
+
+	if !strings.Contains(captured.Stdout, "Year") {
+		t.Error("output missing Year")
+	}
+	if !strings.Contains(captured.Stdout, "Q1") {
+		t.Error("output missing Q1")
+	}
+	if !strings.Contains(captured.Stdout, "Jan") {
+		t.Error("output missing Jan")
+	}
+	if strings.Contains(captured.Stdout, "Q2") {
+		t.Error("output should NOT contain Q2 (truncated)")
+	}
+	if strings.Contains(captured.Stdout, "Feb") {
+		t.Error("output should NOT contain Feb (truncated)")
+	}
+	if !strings.Contains(captured.Stderr, "Showing 3 of 5") {
+		t.Errorf("stderr should contain truncation summary, got: %q", captured.Stderr)
+	}
+}
+
+func TestDisplayMembers_TreeEmptyElements(t *testing.T) {
+	origCount := membersCount
+	defer func() { membersCount = origCount }()
+	membersCount = false
+
+	out := captureStdout(t, func() {
+		displayMembers([]model.Element{}, 0, 0, false, true)
+	})
+
+	if !strings.Contains(out, "NAME") || !strings.Contains(out, "TYPE") {
+		t.Errorf("tree output should still print headers for empty input, got:\n%s", out)
+	}
+}
+
+// ============================================================
+// runDimsMembers — tree mode integration
+// ============================================================
+
+func TestRunDimsMembers_TreeOutputEndToEnd(t *testing.T) {
+	resetCmdFlags(t)
+
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(elementsWithComponentsJSON(
+			[]string{"Year", "Q1", "Jan"},
+			[]string{"Consolidated", "Consolidated", "Numeric"},
+			map[string][]string{"Year": {"Q1"}, "Q1": {"Jan"}},
+		))
+	})
+
+	captured := captureAll(t, func() {
+		err := runDimsMembers(dimsMembersCmd, []string{"Period"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	for _, want := range []string{"Year", "  Q1", "    Jan"} {
+		if !strings.Contains(captured.Stdout, want) {
+			t.Errorf("tree stdout missing %q; got:\n%s", want, captured.Stdout)
+		}
+	}
+}
+
+func TestRunDimsMembers_FlatFlagSkipsExpand(t *testing.T) {
+	resetCmdFlags(t)
+	membersFlat = true
+
+	var capturedQuery string
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		capturedQuery = r.URL.RawQuery
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(elementsJSON(
+			[]string{"Year", "Q1", "Jan"},
+			[]string{"Consolidated", "Consolidated", "Numeric"},
+		))
+	})
+
+	captured := captureAll(t, func() {
+		err := runDimsMembers(dimsMembersCmd, []string{"Period"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	if strings.Contains(capturedQuery, "expand") {
+		t.Errorf("--flat should not send $expand, got query: %s", capturedQuery)
+	}
+	if strings.Contains(captured.Stdout, "  Q1") {
+		t.Errorf("--flat output should not be indented, got:\n%s", captured.Stdout)
+	}
+}
+
+func TestRunDimsMembers_FilterSkipsExpand(t *testing.T) {
+	resetCmdFlags(t)
+	membersFilter = "q"
+
+	var capturedQuery string
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		capturedQuery = r.URL.RawQuery
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(elementsJSON([]string{"Q1"}, []string{"Consolidated"}))
+	})
+
+	captureAll(t, func() {
+		err := runDimsMembers(dimsMembersCmd, []string{"Period"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	if strings.Contains(capturedQuery, "expand") {
+		t.Errorf("--filter should not send $expand, got query: %s", capturedQuery)
+	}
+}
+
+func TestRunDimsMembers_JSONSkipsExpand(t *testing.T) {
+	resetCmdFlags(t)
+	flagOutput = "json"
+
+	var capturedQuery string
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		capturedQuery = r.URL.RawQuery
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(elementsJSON([]string{"Year"}, []string{"Consolidated"}))
+	})
+
+	captureAll(t, func() {
+		err := runDimsMembers(dimsMembersCmd, []string{"Period"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	if strings.Contains(capturedQuery, "expand") {
+		t.Errorf("--output json should not send $expand, got query: %s", capturedQuery)
+	}
+}
+
+func TestRunDimsMembers_CountSkipsExpand(t *testing.T) {
+	resetCmdFlags(t)
+	membersCount = true
+
+	var capturedQuery string
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		capturedQuery = r.URL.RawQuery
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(elementsJSON([]string{"Year"}, []string{"Consolidated"}))
+	})
+
+	captureAll(t, func() {
+		err := runDimsMembers(dimsMembersCmd, []string{"Period"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	if strings.Contains(capturedQuery, "expand") {
+		t.Errorf("--count should not send $expand, got query: %s", capturedQuery)
+	}
+}
+
+func TestRunDimsMembers_TreeModeOmitsTop(t *testing.T) {
+	resetCmdFlags(t)
+	membersLimit = 10
+
+	var capturedQuery string
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		capturedQuery = r.URL.RawQuery
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(elementsWithComponentsJSON(
+			[]string{"Year"},
+			[]string{"Consolidated"},
+			nil,
+		))
+	})
+
+	captureAll(t, func() {
+		err := runDimsMembers(dimsMembersCmd, []string{"Period"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	if strings.Contains(capturedQuery, "top=") {
+		t.Errorf("tree mode must not send $top (would break hierarchy); got query: %s", capturedQuery)
+	}
+	if !strings.Contains(capturedQuery, "expand") {
+		t.Errorf("tree mode should send $expand; got query: %s", capturedQuery)
 	}
 }
 

--- a/cmd/dims_test.go
+++ b/cmd/dims_test.go
@@ -1339,6 +1339,33 @@ func TestRunDimsMembers_TreeModeOverGateFallsBackToFlat(t *testing.T) {
 	}
 }
 
+func TestRunDimsMembers_TreeModePreflight404SurfacesDirectly(t *testing.T) {
+	// Regression: a 404 on the $count preflight must short-circuit to
+	// a "Not found" error. Previously it fell through to the
+	// "cannot verify dimension size" warning, which nudged users
+	// toward --all before the real not-found error showed up.
+	resetCmdFlags(t)
+
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		w.Write([]byte(`{"error":"Dimension not found"}`))
+	})
+
+	captured := captureAll(t, func() {
+		err := runDimsMembers(dimsMembersCmd, []string{"NoSuchDim"})
+		if err != errSilent {
+			t.Fatalf("404 preflight should return errSilent, got: %v", err)
+		}
+	})
+
+	if strings.Contains(captured.Stderr, "[warn]") {
+		t.Errorf("404 preflight must NOT emit the size-verification warning, got stderr: %q", captured.Stderr)
+	}
+	if !strings.Contains(captured.Stderr, "Not found") {
+		t.Errorf("404 preflight should surface the not-found error, got stderr: %q", captured.Stderr)
+	}
+}
+
 func TestRunDimsMembers_TreeModePreflightErrorFallsBackToFlat(t *testing.T) {
 	resetCmdFlags(t)
 	membersLimit = 50

--- a/cmd/dims_test.go
+++ b/cmd/dims_test.go
@@ -1109,6 +1109,92 @@ func TestRunDimsMembers_CountSkipsExpand(t *testing.T) {
 	}
 }
 
+func TestRunDimsMembers_TreeModeWarnsOnLargeFetch(t *testing.T) {
+	resetCmdFlags(t)
+
+	names := make([]string, treeWarnThreshold+1)
+	types := make([]string, treeWarnThreshold+1)
+	for i := range names {
+		names[i] = fmt.Sprintf("Elem%d", i)
+		types[i] = "Numeric"
+	}
+
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(elementsWithComponentsJSON(names, types, nil))
+	})
+
+	captured := captureAll(t, func() {
+		err := runDimsMembers(dimsMembersCmd, []string{"Big"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	if !strings.Contains(captured.Stderr, "[warn]") {
+		t.Errorf("expected warning for oversize tree fetch, got stderr: %q", captured.Stderr)
+	}
+	if !strings.Contains(captured.Stderr, "--flat") {
+		t.Errorf("warning should mention --flat, got stderr: %q", captured.Stderr)
+	}
+	wantCount := fmt.Sprintf("%d", treeWarnThreshold+1)
+	if !strings.Contains(captured.Stderr, wantCount) {
+		t.Errorf("warning should include element count %s, got stderr: %q", wantCount, captured.Stderr)
+	}
+}
+
+func TestRunDimsMembers_TreeModeQuietBelowThreshold(t *testing.T) {
+	resetCmdFlags(t)
+
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(elementsWithComponentsJSON(
+			[]string{"Year", "Q1"},
+			[]string{"Consolidated", "Numeric"},
+			map[string][]string{"Year": {"Q1"}},
+		))
+	})
+
+	captured := captureAll(t, func() {
+		err := runDimsMembers(dimsMembersCmd, []string{"Small"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	if strings.Contains(captured.Stderr, "Fetched") {
+		t.Errorf("small dimensions should not emit fetch-size warning, got stderr: %q", captured.Stderr)
+	}
+}
+
+func TestRunDimsMembers_FlatModeNeverWarnsOnSize(t *testing.T) {
+	resetCmdFlags(t)
+	membersFlat = true
+
+	names := make([]string, treeWarnThreshold+1)
+	types := make([]string, treeWarnThreshold+1)
+	for i := range names {
+		names[i] = fmt.Sprintf("Elem%d", i)
+		types[i] = "Numeric"
+	}
+
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(elementsJSON(names, types))
+	})
+
+	captured := captureAll(t, func() {
+		err := runDimsMembers(dimsMembersCmd, []string{"Big"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	if strings.Contains(captured.Stderr, "Fetched") {
+		t.Errorf("--flat should never emit fetch-size warning, got stderr: %q", captured.Stderr)
+	}
+}
+
 func TestRunDimsMembers_TreeModeOmitsTop(t *testing.T) {
 	resetCmdFlags(t)
 	membersLimit = 10

--- a/cmd/dims_test.go
+++ b/cmd/dims_test.go
@@ -1328,63 +1328,72 @@ func TestRunDimsMembers_TreeModeGatesWithoutAll(t *testing.T) {
 	}
 }
 
-func TestRunDimsMembers_TreeModePreflightFailsClosed(t *testing.T) {
+func TestRunDimsMembers_TreeModePreflightErrorFallsBackToFlat(t *testing.T) {
 	resetCmdFlags(t)
 
-	var heavyFetched bool
+	var capturedQuery string
 	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
 		if strings.HasSuffix(r.URL.Path, "/$count") {
 			w.WriteHeader(http.StatusInternalServerError)
 			w.Write([]byte(`{"error":"$count not supported"}`))
 			return
 		}
-		heavyFetched = true
+		capturedQuery = r.URL.RawQuery
 		w.Header().Set("Content-Type", "application/json")
-		w.Write(elementsWithComponentsJSON([]string{"Year"}, []string{"Consolidated"}, nil))
+		w.Write(elementsJSON([]string{"Year"}, []string{"Consolidated"}))
 	})
 
 	captured := captureAll(t, func() {
 		err := runDimsMembers(dimsMembersCmd, []string{"Any"})
-		if err != errSilent {
-			t.Fatalf("expected errSilent when preflight fails, got: %v", err)
+		if err != nil {
+			t.Fatalf("preflight failure should fall back to flat, got: %v", err)
 		}
 	})
 
-	if heavyFetched {
-		t.Error("preflight failure must fail closed; heavy fetch should not run")
+	if !strings.Contains(captured.Stderr, "[warn]") {
+		t.Errorf("fallback should emit [warn] on stderr, got: %q", captured.Stderr)
 	}
-	if captured.Stderr == "" {
-		t.Error("preflight failure must emit a user-visible error on stderr")
+	if !strings.Contains(captured.Stderr, "flat output") {
+		t.Errorf("fallback warning should mention flat output, got: %q", captured.Stderr)
+	}
+	if !strings.Contains(captured.Stdout, "Year") {
+		t.Errorf("fallback should still render elements, got stdout: %q", captured.Stdout)
+	}
+	if strings.Contains(capturedQuery, "expand") {
+		t.Errorf("fallback fetch must NOT include $expand (tree mode disabled); got query: %s", capturedQuery)
 	}
 }
 
-func TestRunDimsMembers_TreeModePreflightNonIntegerFailsClosed(t *testing.T) {
+func TestRunDimsMembers_TreeModePreflightNonIntegerFallsBackToFlat(t *testing.T) {
 	resetCmdFlags(t)
 
-	var heavyFetched bool
+	var capturedQuery string
 	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
 		if strings.HasSuffix(r.URL.Path, "/$count") {
 			w.Header().Set("Content-Type", "application/json")
 			w.Write([]byte(`{"not":"an integer"}`))
 			return
 		}
-		heavyFetched = true
+		capturedQuery = r.URL.RawQuery
 		w.Header().Set("Content-Type", "application/json")
-		w.Write(elementsWithComponentsJSON([]string{"Year"}, []string{"Consolidated"}, nil))
+		w.Write(elementsJSON([]string{"Year"}, []string{"Consolidated"}))
 	})
 
 	captured := captureAll(t, func() {
 		err := runDimsMembers(dimsMembersCmd, []string{"Any"})
-		if err != errSilent {
-			t.Fatalf("expected errSilent on non-integer preflight response, got: %v", err)
+		if err != nil {
+			t.Fatalf("non-integer preflight should fall back, got: %v", err)
 		}
 	})
 
-	if heavyFetched {
-		t.Error("non-integer preflight response must fail closed; heavy fetch should not run")
-	}
 	if !strings.Contains(captured.Stderr, "cannot verify dimension size") {
-		t.Errorf("should report size-verification failure, got stderr: %q", captured.Stderr)
+		t.Errorf("fallback warning should mention size verification, got stderr: %q", captured.Stderr)
+	}
+	if !strings.Contains(captured.Stdout, "Year") {
+		t.Errorf("fallback should still render elements, got stdout: %q", captured.Stdout)
+	}
+	if strings.Contains(capturedQuery, "expand") {
+		t.Errorf("fallback fetch must NOT include $expand; got query: %s", capturedQuery)
 	}
 }
 

--- a/cmd/dims_test.go
+++ b/cmd/dims_test.go
@@ -1292,40 +1292,50 @@ func TestRunDimsMembers_CountSkipsExpand(t *testing.T) {
 	}
 }
 
-func TestRunDimsMembers_TreeModeGatesWithoutAll(t *testing.T) {
+func TestRunDimsMembers_TreeModeOverGateFallsBackToFlat(t *testing.T) {
+	// Preserves the pre-PR contract of --all: exceeding the 5000-element
+	// gate no longer hard-errors. The user instead gets flat output with
+	// a warning naming the count and nudging toward --all.
 	resetCmdFlags(t)
+	membersLimit = 50
 
-	var elementsFetched bool
+	var capturedQuery string
 	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
 		if strings.HasSuffix(r.URL.Path, "/$count") {
 			w.Header().Set("Content-Type", "text/plain")
 			fmt.Fprintf(w, "%d", treeElementGate+1)
 			return
 		}
-		elementsFetched = true
+		capturedQuery = r.URL.RawQuery
 		w.Header().Set("Content-Type", "application/json")
-		w.Write(elementsWithComponentsJSON([]string{"X"}, []string{"Numeric"}, nil))
+		w.Write(elementsJSON([]string{"X"}, []string{"Numeric"}))
 	})
 
 	captured := captureAll(t, func() {
 		err := runDimsMembers(dimsMembersCmd, []string{"Big"})
-		if err != errSilent {
-			t.Fatalf("expected errSilent when gate triggers, got: %v", err)
+		if err != nil {
+			t.Fatalf("over-gate path should fall back, got: %v", err)
 		}
 	})
 
-	if elementsFetched {
-		t.Error("gate must abort before the heavy elements fetch; server saw the request")
-	}
-	if !strings.Contains(captured.Stderr, "Tree view requires --all") {
-		t.Errorf("gate error should lock the phrase 'Tree view requires --all', got stderr: %q", captured.Stderr)
-	}
-	if !strings.Contains(captured.Stderr, "--flat") {
-		t.Errorf("gate error should suggest --flat, got stderr: %q", captured.Stderr)
+	if !strings.Contains(captured.Stderr, "[warn]") {
+		t.Errorf("over-gate fallback should emit [warn] on stderr, got: %q", captured.Stderr)
 	}
 	wantCount := fmt.Sprintf("%d", treeElementGate+1)
 	if !strings.Contains(captured.Stderr, wantCount) {
-		t.Errorf("gate error should include the element count %s, got stderr: %q", wantCount, captured.Stderr)
+		t.Errorf("warning should include the element count %s, got stderr: %q", wantCount, captured.Stderr)
+	}
+	if !strings.Contains(captured.Stderr, "over 5000") {
+		t.Errorf("warning should state 'over %d' for clarity, got stderr: %q", treeElementGate, captured.Stderr)
+	}
+	if !strings.Contains(captured.Stderr, "50") || !strings.Contains(captured.Stderr, "full dimension") {
+		t.Errorf("warning should disclose row limit and suggest --all; got: %q", captured.Stderr)
+	}
+	if !strings.Contains(captured.Stdout, "X") {
+		t.Errorf("fallback should render elements; got stdout: %q", captured.Stdout)
+	}
+	if strings.Contains(capturedQuery, "expand") {
+		t.Errorf("fallback fetch must NOT include $expand; got query: %s", capturedQuery)
 	}
 }
 

--- a/cmd/dims_test.go
+++ b/cmd/dims_test.go
@@ -962,8 +962,35 @@ func TestDisplayMembers_TreeLimitTruncation(t *testing.T) {
 	if strings.Contains(captured.Stdout, "Feb") {
 		t.Error("output should NOT contain Feb (truncated)")
 	}
-	if !strings.Contains(captured.Stderr, "Showing 3 of 5") {
-		t.Errorf("stderr should contain truncation summary, got: %q", captured.Stderr)
+	if !strings.Contains(captured.Stderr, "Showing 3 of 5 rows") {
+		t.Errorf("stderr should contain tree truncation summary, got: %q", captured.Stderr)
+	}
+}
+
+func TestDisplayMembers_TreeDiamondReportsUniqueCount(t *testing.T) {
+	origCount := membersCount
+	defer func() { membersCount = origCount }()
+	membersCount = false
+
+	elements := []model.Element{
+		{Name: "A", Type: "Consolidated", Components: []model.Component{{Name: "B"}, {Name: "C"}}},
+		{Name: "B", Type: "Consolidated", Components: []model.Component{{Name: "D"}}},
+		{Name: "C", Type: "Consolidated", Components: []model.Component{{Name: "D"}}},
+		{Name: "D", Type: "Numeric"},
+	}
+
+	captured := captureAll(t, func() {
+		displayMembers(elements, len(elements), 3, false, true)
+	})
+
+	if !strings.Contains(captured.Stderr, "rows") {
+		t.Errorf("summary should say 'rows' in tree mode, got: %q", captured.Stderr)
+	}
+	if !strings.Contains(captured.Stderr, "unique") {
+		t.Errorf("diamond hierarchy should report unique element count, got: %q", captured.Stderr)
+	}
+	if !strings.Contains(captured.Stderr, "4 unique") {
+		t.Errorf("unique count should be 4 (A,B,C,D), got: %q", captured.Stderr)
 	}
 }
 

--- a/cmd/dims_test.go
+++ b/cmd/dims_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strconv"
 	"strings"
 	"testing"
 	"tm1cli/internal/model"
@@ -1330,6 +1331,7 @@ func TestRunDimsMembers_TreeModeGatesWithoutAll(t *testing.T) {
 
 func TestRunDimsMembers_TreeModePreflightErrorFallsBackToFlat(t *testing.T) {
 	resetCmdFlags(t)
+	membersLimit = 50
 
 	var capturedQuery string
 	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
@@ -1356,6 +1358,12 @@ func TestRunDimsMembers_TreeModePreflightErrorFallsBackToFlat(t *testing.T) {
 	if !strings.Contains(captured.Stderr, "flat output") {
 		t.Errorf("fallback warning should mention flat output, got: %q", captured.Stderr)
 	}
+	if !strings.Contains(captured.Stderr, "50") {
+		t.Errorf("fallback warning should disclose the row limit (50), got: %q", captured.Stderr)
+	}
+	if !strings.Contains(captured.Stderr, "full dimension") {
+		t.Errorf("fallback warning should suggest --all for the full dimension, got: %q", captured.Stderr)
+	}
 	if !strings.Contains(captured.Stdout, "Year") {
 		t.Errorf("fallback should still render elements, got stdout: %q", captured.Stdout)
 	}
@@ -1364,8 +1372,55 @@ func TestRunDimsMembers_TreeModePreflightErrorFallsBackToFlat(t *testing.T) {
 	}
 }
 
+func TestRunDimsMembers_TreeModePreflightFallbackWarnsAboutTruncation(t *testing.T) {
+	// Reviewer-requested regression: $count 500, default limit 50,
+	// dimension has 100 elements — the fallback must disclose the
+	// truncation so users don't silently consume 50/100 rows.
+	resetCmdFlags(t)
+	membersLimit = 50
+
+	names := make([]string, 100)
+	types := make([]string, 100)
+	for i := range names {
+		names[i] = fmt.Sprintf("E%d", i)
+		types[i] = "Numeric"
+	}
+
+	var servedTop int
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/$count") {
+			w.WriteHeader(http.StatusInternalServerError)
+			w.Write([]byte(`{"error":"$count unsupported"}`))
+			return
+		}
+		servedTop = len(names)
+		if topParam := r.URL.Query().Get("$top"); topParam != "" {
+			if n, err := strconv.Atoi(topParam); err == nil && n < servedTop {
+				servedTop = n
+			}
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(elementsJSON(names[:servedTop], types[:servedTop]))
+	})
+
+	captured := captureAll(t, func() {
+		err := runDimsMembers(dimsMembersCmd, []string{"HundredDim"})
+		if err != nil {
+			t.Fatalf("fallback should succeed, got: %v", err)
+		}
+	})
+
+	if servedTop != 50 {
+		t.Errorf("fallback should still send $top=50 to protect against huge dims, server saw top=%d", servedTop)
+	}
+	if !strings.Contains(captured.Stderr, "50") || !strings.Contains(captured.Stderr, "full dimension") {
+		t.Errorf("fallback warning must disclose the 50-row limit and suggest --all; got: %q", captured.Stderr)
+	}
+}
+
 func TestRunDimsMembers_TreeModePreflightNonIntegerFallsBackToFlat(t *testing.T) {
 	resetCmdFlags(t)
+	membersLimit = 25
 
 	var capturedQuery string
 	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
@@ -1388,6 +1443,9 @@ func TestRunDimsMembers_TreeModePreflightNonIntegerFallsBackToFlat(t *testing.T)
 
 	if !strings.Contains(captured.Stderr, "cannot verify dimension size") {
 		t.Errorf("fallback warning should mention size verification, got stderr: %q", captured.Stderr)
+	}
+	if !strings.Contains(captured.Stderr, "25") {
+		t.Errorf("fallback warning should disclose the row limit (25), got stderr: %q", captured.Stderr)
 	}
 	if !strings.Contains(captured.Stdout, "Year") {
 		t.Errorf("fallback should still render elements, got stdout: %q", captured.Stdout)

--- a/cmd/testhelpers_test.go
+++ b/cmd/testhelpers_test.go
@@ -188,6 +188,7 @@ func zeroAllFlags() {
 	membersLimit = 0
 	membersAll = false
 	membersCount = false
+	membersFlat = false
 	procListFilter = ""
 	procListLimit = 0
 	procListAll = false
@@ -261,6 +262,36 @@ func elementsJSON(names []string, types []string) []byte {
 			typ = types[i]
 		}
 		resp.Value = append(resp.Value, elem{Name: name, Type: typ})
+	}
+	data, _ := json.Marshal(resp)
+	return data
+}
+
+// elementsWithComponentsJSON returns JSON for a TM1 Elements response with
+// an expanded Components relation. children maps a parent element name to
+// the ordered list of child element names.
+func elementsWithComponentsJSON(names []string, types []string, children map[string][]string) []byte {
+	type comp struct {
+		Name string `json:"Name"`
+	}
+	type elem struct {
+		Name       string `json:"Name"`
+		Type       string `json:"Type"`
+		Components []comp `json:"Components,omitempty"`
+	}
+	resp := struct {
+		Value []elem `json:"value"`
+	}{}
+	for i, name := range names {
+		typ := "Numeric"
+		if i < len(types) {
+			typ = types[i]
+		}
+		e := elem{Name: name, Type: typ}
+		for _, childName := range children[name] {
+			e.Components = append(e.Components, comp{Name: childName})
+		}
+		resp.Value = append(resp.Value, e)
 	}
 	data, _ := json.Marshal(resp)
 	return data

--- a/internal/model/dimension.go
+++ b/internal/model/dimension.go
@@ -9,8 +9,13 @@ type DimensionResponse struct {
 }
 
 type Element struct {
+	Name       string      `json:"Name"`
+	Type       string      `json:"Type"`
+	Components []Component `json:"Components,omitempty"`
+}
+
+type Component struct {
 	Name string `json:"Name"`
-	Type string `json:"Type"`
 }
 
 type ElementResponse struct {

--- a/internal/model/dimension_test.go
+++ b/internal/model/dimension_test.go
@@ -99,10 +99,49 @@ func TestElementJSON(t *testing.T) {
 			if err := json.Unmarshal(data, &got); err != nil {
 				t.Fatalf("Unmarshal error: %v", err)
 			}
-			if got != tt.input {
+			if got.Name != tt.input.Name || got.Type != tt.input.Type || len(got.Components) != len(tt.input.Components) {
 				t.Errorf("Round-trip = %+v, want %+v", got, tt.input)
 			}
 		})
+	}
+}
+
+func TestElementJSON_WithComponents(t *testing.T) {
+	e := Element{
+		Name:       "Year",
+		Type:       "Consolidated",
+		Components: []Component{{Name: "Q1"}, {Name: "Q2"}},
+	}
+	data, err := json.Marshal(e)
+	if err != nil {
+		t.Fatalf("Marshal error: %v", err)
+	}
+	want := `{"Name":"Year","Type":"Consolidated","Components":[{"Name":"Q1"},{"Name":"Q2"}]}`
+	if string(data) != want {
+		t.Errorf("Marshal = %s, want %s", data, want)
+	}
+
+	var got Element
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("Unmarshal error: %v", err)
+	}
+	if got.Name != e.Name || got.Type != e.Type || len(got.Components) != 2 {
+		t.Errorf("Round-trip lost fields: %+v", got)
+	}
+	if got.Components[0].Name != "Q1" || got.Components[1].Name != "Q2" {
+		t.Errorf("Components order not preserved: %+v", got.Components)
+	}
+}
+
+func TestElementJSON_OmitsComponentsWhenNil(t *testing.T) {
+	e := Element{Name: "Jan", Type: "Numeric"}
+	data, err := json.Marshal(e)
+	if err != nil {
+		t.Fatalf("Marshal error: %v", err)
+	}
+	got := string(data)
+	if got != `{"Name":"Jan","Type":"Numeric"}` {
+		t.Errorf("Marshal = %s, want %s", got, `{"Name":"Jan","Type":"Numeric"}`)
 	}
 }
 

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -29,6 +29,22 @@ func PrintSummary(shown int, total int) {
 	}
 }
 
+// PrintTreeSummary is the tree-mode equivalent of PrintSummary. The
+// displayed count is paths ("rows") rather than unique elements because
+// diamond hierarchies render shared children under every parent; the
+// unique-element count is appended when it differs so users aren't
+// misled into thinking "Showing 3 of 7" means 7 distinct members.
+func PrintTreeSummary(shownRows int, totalRows int, uniqueElements int) {
+	if shownRows >= totalRows {
+		return
+	}
+	if uniqueElements > 0 && uniqueElements != totalRows {
+		fmt.Fprintf(os.Stderr, "Showing %d of %d rows (%d unique elements). Use --filter to search or --all to show everything.\n", shownRows, totalRows, uniqueElements)
+		return
+	}
+	fmt.Fprintf(os.Stderr, "Showing %d of %d rows. Use --filter to search or --all to show everything.\n", shownRows, totalRows)
+}
+
 func PrintError(msg string, jsonMode bool) {
 	if jsonMode {
 		errObj := map[string]interface{}{"error": msg}

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -29,16 +29,23 @@ func PrintSummary(shown int, total int) {
 	}
 }
 
+// UniqueElementsUnknown signals to PrintTreeSummary that the caller did
+// not compute a unique-element count; the "(N unique elements)" clause
+// will be suppressed.
+const UniqueElementsUnknown = -1
+
 // PrintTreeSummary is the tree-mode equivalent of PrintSummary. The
 // displayed count is paths ("rows") rather than unique elements because
 // diamond hierarchies render shared children under every parent; the
 // unique-element count is appended when it differs so users aren't
-// misled into thinking "Showing 3 of 7" means 7 distinct members.
+// misled into thinking "Showing 3 of 7" means 7 distinct members. Pass
+// UniqueElementsUnknown (or a value equal to totalRows) to suppress the
+// unique-count suffix.
 func PrintTreeSummary(shownRows int, totalRows int, uniqueElements int) {
 	if shownRows >= totalRows {
 		return
 	}
-	if uniqueElements > 0 && uniqueElements != totalRows {
+	if uniqueElements != UniqueElementsUnknown && uniqueElements != totalRows {
 		fmt.Fprintf(os.Stderr, "Showing %d of %d rows (%d unique elements). Use --filter to search or --all to show everything.\n", shownRows, totalRows, uniqueElements)
 		return
 	}

--- a/internal/output/output_test.go
+++ b/internal/output/output_test.go
@@ -258,6 +258,69 @@ func TestPrintSummary(t *testing.T) {
 	}
 }
 
+func TestPrintTreeSummary(t *testing.T) {
+	tests := []struct {
+		name      string
+		shown     int
+		total     int
+		unique    int
+		wantEmpty bool
+		contains  []string
+	}{
+		{
+			name:      "no output when shown >= total",
+			shown:     5,
+			total:     5,
+			unique:    5,
+			wantEmpty: true,
+		},
+		{
+			name:     "says rows and omits unique when unique == total",
+			shown:    3,
+			total:    10,
+			unique:   10,
+			contains: []string{"Showing 3 of 10 rows", "--filter", "--all"},
+		},
+		{
+			name:     "includes unique-element count when diamonds present",
+			shown:    3,
+			total:    10,
+			unique:   7,
+			contains: []string{"Showing 3 of 10 rows", "7 unique elements"},
+		},
+		{
+			name:     "unique == 0 is treated as unknown and omitted",
+			shown:    3,
+			total:    10,
+			unique:   0,
+			contains: []string{"Showing 3 of 10 rows"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := captureStderr(t, func() {
+				PrintTreeSummary(tt.shown, tt.total, tt.unique)
+			})
+
+			if tt.wantEmpty {
+				if got != "" {
+					t.Errorf("expected empty output, got: %q", got)
+				}
+				return
+			}
+			for _, want := range tt.contains {
+				if !strings.Contains(got, want) {
+					t.Errorf("output missing %q, got: %s", want, got)
+				}
+			}
+			if tt.unique == tt.total && strings.Contains(got, "unique") {
+				t.Errorf("should not mention 'unique' when unique == total, got: %s", got)
+			}
+		})
+	}
+}
+
 func TestPrintError(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/internal/output/output_test.go
+++ b/internal/output/output_test.go
@@ -289,10 +289,10 @@ func TestPrintTreeSummary(t *testing.T) {
 			contains: []string{"Showing 3 of 10 rows", "7 unique elements"},
 		},
 		{
-			name:     "unique == 0 is treated as unknown and omitted",
+			name:     "UniqueElementsUnknown sentinel omits unique clause",
 			shown:    3,
 			total:    10,
-			unique:   0,
+			unique:   UniqueElementsUnknown,
 			contains: []string{"Showing 3 of 10 rows"},
 		},
 	}


### PR DESCRIPTION
## Summary

- `tm1cli dims members <dim>` now renders dimension hierarchy as an indented tree by default. Children of consolidated elements are indented two spaces per level.
- Adds `--flat` as the escape hatch. `--filter`, `--count`, and `--output json` retain the existing flat behavior so scripted consumers are unaffected.
- Fetches elements with `$expand=Components($select=Name)` in tree mode and intentionally skips `$top` so the hierarchy is never truncated mid-tree.

## Design notes

- Diamonds (element reused under multiple parents) render at every location, matching TM1 Architect's Dimension Editor.
- Cycles are guarded per DFS path; a second-pass "synthetic root" loop ensures residual or cycle-only subgraphs still render — no element disappears.
- New `Component` type + `Components []Component` on `model.Element` uses `omitempty`, preserving prior JSON shape when components aren't fetched.

Closes #24

## Test plan

- [x] `go test ./...` — 639 tests pass, 33 new
- [x] `go vet ./...` — clean
- [x] `go build ./...` — clean
- [x] Unit tests: simple / all-leaves / diamond / cycle / pure cycle / unknown component / root order / component order / empty input
- [x] Integration tests (httptest): tree URL shape, `--flat` / `--filter` / `--count` / `--output json` each skip `$expand`, tree mode omits `$top`
- [x] Model round-trip tests cover `Components` present and `omitempty` when nil
- [ ] Manual verification against a real TM1 server (deferred to reviewer)