### PR TITLE
feat(#25): advanced cellset parsing for complex multi-axis views

### DIFF
--- a/cmd/export.go
+++ b/cmd/export.go
@@ -435,9 +435,13 @@ func buildCellsetLayout(resp model.CellsetResponse) *cellsetLayout {
 
 	var rowLabels []string
 	axisSizes := make([]int, len(rowAxes))
+	axis1Width := 0 // number of row-dim columns contributed by axis 1 (the true row axis)
 	for k, a := range rowAxes {
 		axisSizes[k] = len(a.Tuples)
 		mc := len(a.Tuples[0].Members)
+		if k == 0 {
+			axis1Width = mc
+		}
 		rowLabels = append(rowLabels, buildRowLabelsForAxis(a, mc)...)
 	}
 	colHeaders := buildColHeaders(colAxis)
@@ -480,9 +484,12 @@ func buildCellsetLayout(resp model.CellsetResponse) *cellsetLayout {
 		rowCells[r] = rc
 	}
 
+	// Only columns from title axes (axes >= 2) are eligible for slicer
+	// promotion in table mode — axis 1's row-dim always renders as a row
+	// column even when it happens to hold a single value.
 	constantCols := make([]bool, len(rowLabels))
 	if totalRows > 0 {
-		for c := range rowLabels {
+		for c := axis1Width; c < len(rowLabels); c++ {
 			allSame := true
 			first := rowMembers[0][c]
 			for r := 1; r < totalRows; r++ {

--- a/cmd/export.go
+++ b/cmd/export.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"sort"
 	"strings"
 	"tm1cli/internal/client"
 	"tm1cli/internal/model"
@@ -95,7 +96,7 @@ func runExport(cmd *cobra.Command, args []string) error {
 }
 
 func runViewExport(cl *client.Client, cubeName string, jsonMode bool) error {
-	endpoint := fmt.Sprintf("Cubes('%s')/Views('%s')/tm1.Execute?$expand=Axes($expand=Tuples($expand=Members($select=Name))),Cells($select=Value,Ordinal)", url.PathEscape(cubeName), url.PathEscape(exportView))
+	endpoint := fmt.Sprintf("Cubes('%s')/Views('%s')/tm1.Execute?$expand=Axes($expand=Tuples($expand=Members($select=Name,UniqueName))),Cells($select=Value,Ordinal)", url.PathEscape(cubeName), url.PathEscape(exportView))
 
 	data, err := cl.Post(endpoint, map[string]interface{}{})
 	if err != nil {
@@ -114,7 +115,7 @@ func runViewExport(cl *client.Client, cubeName string, jsonMode bool) error {
 
 func runMDXExport(cl *client.Client, jsonMode bool) error {
 	// Step 1: Execute MDX — expand axes only, fetch cells separately for pagination
-	endpoint := "ExecuteMDX?$expand=Axes($expand=Tuples($expand=Members($select=Name)))"
+	endpoint := "ExecuteMDX?$expand=Axes($expand=Tuples($expand=Members($select=Name,UniqueName)))"
 	payload := map[string]interface{}{"MDX": exportMDX}
 
 	data, err := cl.Post(endpoint, payload)
@@ -222,55 +223,346 @@ func outputCellset(resp model.CellsetResponse, jsonMode bool) error {
 	return nil
 }
 
-// cellsetToRecords converts a CellsetResponse into a flat array of record maps.
-// Row dimension members become DIM1, DIM2, etc. Column headers become value keys.
-func cellsetToRecords(resp model.CellsetResponse) []map[string]interface{} {
-	if len(resp.Axes) < 2 {
-		return []map[string]interface{}{}
+// cellsetLayout is the canonical flattened representation shared by all writers.
+// Headers[i] and RowMembers[r][i] (for i<NumRowDims) or RowCells[r][i-NumRowDims]
+// (for i>=NumRowDims) are aligned positionally.
+type cellsetLayout struct {
+	Headers     []string
+	RowMembers  [][]string
+	RowCells    [][]interface{}
+	NumRowDims  int
+	ConstantCol []bool
+
+	Scalar      bool
+	ScalarValue interface{}
+	SingleAxis  bool
+}
+
+// parseBracketSegments splits "[A].[B].[C]" into ["A","B","C"], honoring the
+// TM1 MDX escape where "]]" inside brackets represents a literal "]".
+// Returns nil on malformed input.
+func parseBracketSegments(s string) []string {
+	var out []string
+	i := 0
+	for i < len(s) {
+		if s[i] != '[' {
+			return nil
+		}
+		i++
+		var b strings.Builder
+		for {
+			if i >= len(s) {
+				return nil
+			}
+			if s[i] == ']' {
+				if i+1 < len(s) && s[i+1] == ']' {
+					b.WriteByte(']')
+					i += 2
+					continue
+				}
+				break
+			}
+			b.WriteByte(s[i])
+			i++
+		}
+		out = append(out, b.String())
+		i++
+		if i < len(s) {
+			if s[i] != '.' {
+				return nil
+			}
+			i++
+		}
 	}
+	return out
+}
 
-	colAxis := resp.Axes[0]
-	rowAxis := resp.Axes[1]
-
-	numCols := len(colAxis.Tuples)
-	if numCols == 0 {
-		return []map[string]interface{}{}
+// deriveDimensionLabel returns a human-readable bracketed label from a
+// UniqueName. Returns "" if the input is unparseable; the caller then
+// falls back to DIM{N}.
+//
+//	"[Period].[Period].[Jan]" -> "[Period]"
+//	"[Period].[FY].[2024]"    -> "[Period:FY]"
+//	"[Version].[Actual]"      -> "[Version]"
+func deriveDimensionLabel(uniqueName string) string {
+	segs := parseBracketSegments(uniqueName)
+	switch len(segs) {
+	case 0, 1:
+		return ""
+	case 2:
+		return "[" + segs[0] + "]"
+	default:
+		if segs[0] == segs[1] {
+			return "[" + segs[0] + "]"
+		}
+		return "[" + segs[0] + ":" + segs[1] + "]"
 	}
+}
 
-	// Build column header names
-	colHeaders := make([]string, numCols)
-	for i, tuple := range colAxis.Tuples {
-		names := make([]string, len(tuple.Members))
-		for j, m := range tuple.Members {
+// sortedAxes returns resp.Axes sorted by Ordinal ascending. Duplicate ordinals
+// are dropped (first occurrence kept) and a warning is emitted.
+func sortedAxes(resp model.CellsetResponse) []model.CellsetAxis {
+	axes := make([]model.CellsetAxis, len(resp.Axes))
+	copy(axes, resp.Axes)
+	sort.SliceStable(axes, func(i, j int) bool { return axes[i].Ordinal < axes[j].Ordinal })
+
+	seen := make(map[int]bool, len(axes))
+	out := axes[:0]
+	for _, a := range axes {
+		if seen[a.Ordinal] {
+			output.PrintWarning(fmt.Sprintf("duplicate axis ordinal %d; dropping duplicate", a.Ordinal))
+			continue
+		}
+		seen[a.Ordinal] = true
+		out = append(out, a)
+	}
+	return out
+}
+
+// disambiguateLabels returns a copy where duplicate labels gain a "(N)" suffix
+// for their second, third, etc. occurrences. Preserves positional alignment.
+func disambiguateLabels(labels []string) []string {
+	counts := make(map[string]int, len(labels))
+	out := make([]string, len(labels))
+	for i, lbl := range labels {
+		counts[lbl]++
+		if counts[lbl] == 1 {
+			out[i] = lbl
+		} else {
+			out[i] = fmt.Sprintf("%s(%d)", lbl, counts[lbl])
+		}
+	}
+	return out
+}
+
+// buildColHeaders joins multi-member column tuples with " / ".
+func buildColHeaders(colAxis model.CellsetAxis) []string {
+	out := make([]string, len(colAxis.Tuples))
+	for i, t := range colAxis.Tuples {
+		names := make([]string, len(t.Members))
+		for j, m := range t.Members {
 			names[j] = m.Name
 		}
-		colHeaders[i] = strings.Join(names, " / ")
+		out[i] = strings.Join(names, " / ")
 	}
+	return out
+}
 
-	// Index cells by ordinal
-	cellsByOrdinal := make(map[int]interface{}, len(resp.Cells))
-	for _, cell := range resp.Cells {
-		cellsByOrdinal[cell.Ordinal] = cell.Value
+// buildRowLabelsForAxis derives row-dim labels for a single axis, falling
+// back to DIM{N} when UniqueName is absent or unparseable. Global
+// disambiguation (via disambiguateLabels) happens after all axes' labels
+// are concatenated.
+func buildRowLabelsForAxis(a model.CellsetAxis, memberCount int) []string {
+	out := make([]string, memberCount)
+	var first model.CellsetTuple
+	if len(a.Tuples) > 0 {
+		first = a.Tuples[0]
 	}
-
-	// Build records
-	records := make([]map[string]interface{}, 0, len(rowAxis.Tuples))
-	for r, tuple := range rowAxis.Tuples {
-		record := make(map[string]interface{}, len(tuple.Members)+numCols)
-		for d, m := range tuple.Members {
-			record[fmt.Sprintf("DIM%d", d+1)] = m.Name
+	for i := 0; i < memberCount; i++ {
+		lbl := ""
+		if i < len(first.Members) {
+			lbl = deriveDimensionLabel(first.Members[i].UniqueName)
 		}
+		if lbl == "" {
+			lbl = fmt.Sprintf("DIM%d", i+1)
+		}
+		out[i] = lbl
+	}
+	return out
+}
+
+// formatCellValue stringifies a cell value; nil becomes "" (no "<nil>").
+func formatCellValue(v interface{}) string {
+	if v == nil {
+		return ""
+	}
+	return fmt.Sprintf("%v", v)
+}
+
+// buildCellsetLayout produces a canonical flattened representation. Returns
+// nil when the response has no meaningful rendering (preserves the existing
+// "No data returned." behavior for empty 2-axis cases).
+func buildCellsetLayout(resp model.CellsetResponse) *cellsetLayout {
+	axes := sortedAxes(resp)
+
+	if len(axes) == 0 {
+		var v interface{}
+		if len(resp.Cells) > 0 {
+			v = resp.Cells[0].Value
+		}
+		return &cellsetLayout{
+			Scalar:      true,
+			ScalarValue: v,
+			Headers:     []string{"Value"},
+		}
+	}
+
+	cells := make(map[int]interface{}, len(resp.Cells))
+	for _, c := range resp.Cells {
+		cells[c.Ordinal] = c.Value
+	}
+
+	if len(axes) == 1 {
+		colAxis := axes[0]
+		numCols := len(colAxis.Tuples)
+		if numCols == 0 {
+			return nil
+		}
+		headers := disambiguateLabels(buildColHeaders(colAxis))
+		rowCells := make([]interface{}, numCols)
 		for c := 0; c < numCols; c++ {
-			ordinal := r*numCols + c
-			if v, ok := cellsByOrdinal[ordinal]; ok {
-				record[colHeaders[c]] = v
-			} else {
-				record[colHeaders[c]] = nil
+			rowCells[c] = cells[c]
+		}
+		return &cellsetLayout{
+			SingleAxis: true,
+			Headers:    headers,
+			RowMembers: [][]string{{}},
+			RowCells:   [][]interface{}{rowCells},
+		}
+	}
+
+	colAxis := axes[0]
+	rowAxes := axes[1:]
+	numCols := len(colAxis.Tuples)
+	if numCols == 0 {
+		return nil
+	}
+	for _, a := range rowAxes {
+		if len(a.Tuples) == 0 {
+			return nil
+		}
+	}
+
+	var rowLabels []string
+	axisSizes := make([]int, len(rowAxes))
+	for k, a := range rowAxes {
+		axisSizes[k] = len(a.Tuples)
+		mc := len(a.Tuples[0].Members)
+		rowLabels = append(rowLabels, buildRowLabelsForAxis(a, mc)...)
+	}
+	colHeaders := buildColHeaders(colAxis)
+
+	all := disambiguateLabels(append(append([]string{}, rowLabels...), colHeaders...))
+	rowLabels = all[:len(rowLabels)]
+	colHeaders = all[len(rowLabels):]
+
+	totalRows := 1
+	for _, sz := range axisSizes {
+		totalRows *= sz
+	}
+
+	rowMembers := make([][]string, totalRows)
+	rowCells := make([][]interface{}, totalRows)
+	for r := 0; r < totalRows; r++ {
+		mem := make([]string, 0, len(rowLabels))
+		rem := r
+		ord := 0
+		stride := numCols
+		for k, a := range rowAxes {
+			idx := rem % axisSizes[k]
+			rem /= axisSizes[k]
+			ord += idx * stride
+			stride *= axisSizes[k]
+			for _, m := range a.Tuples[idx].Members {
+				mem = append(mem, m.Name)
 			}
 		}
-		records = append(records, record)
+		rowMembers[r] = mem
+
+		rc := make([]interface{}, numCols)
+		for c := 0; c < numCols; c++ {
+			rc[c] = cells[ord+c]
+		}
+		rowCells[r] = rc
 	}
 
+	constantCols := make([]bool, len(rowLabels))
+	if totalRows > 0 {
+		for c := range rowLabels {
+			allSame := true
+			first := rowMembers[0][c]
+			for r := 1; r < totalRows; r++ {
+				if rowMembers[r][c] != first {
+					allSame = false
+					break
+				}
+			}
+			constantCols[c] = allSame
+		}
+	}
+
+	return &cellsetLayout{
+		Headers:     append(append([]string{}, rowLabels...), colHeaders...),
+		RowMembers:  rowMembers,
+		RowCells:    rowCells,
+		NumRowDims:  len(rowLabels),
+		ConstantCol: constantCols,
+	}
+}
+
+// layoutToStringRows produces the string-only row form used by CSV.
+func layoutToStringRows(l *cellsetLayout) ([]string, [][]string) {
+	if l.Scalar {
+		return []string{"Value"}, [][]string{{formatCellValue(l.ScalarValue)}}
+	}
+	rows := make([][]string, len(l.RowCells))
+	for r := range l.RowCells {
+		row := make([]string, 0, len(l.Headers))
+		row = append(row, l.RowMembers[r]...)
+		for _, v := range l.RowCells[r] {
+			row = append(row, formatCellValue(v))
+		}
+		rows[r] = row
+	}
+	return l.Headers, rows
+}
+
+// layoutToTypedRows keeps cell values as interface{} for XLSX numeric typing.
+// Row-dim and slicer values remain strings (member names are strings).
+func layoutToTypedRows(l *cellsetLayout) ([]string, [][]interface{}) {
+	if l.Scalar {
+		return []string{"Value"}, [][]interface{}{{l.ScalarValue}}
+	}
+	rows := make([][]interface{}, len(l.RowCells))
+	for r := range l.RowCells {
+		row := make([]interface{}, 0, len(l.Headers))
+		for _, m := range l.RowMembers[r] {
+			row = append(row, m)
+		}
+		for _, v := range l.RowCells[r] {
+			row = append(row, v)
+		}
+		rows[r] = row
+	}
+	return l.Headers, rows
+}
+
+// cellsetToRecords converts a CellsetResponse into a flat array of record
+// maps for JSON-file output. Row-dim labels come from UniqueName when
+// available (falling back to DIM{N}); title axes and multi-tuple higher
+// axes are flattened into row-dim fields. Header collisions are
+// disambiguated globally (e.g., duplicate "[Period]" -> "[Period]", "[Period](2)").
+func cellsetToRecords(resp model.CellsetResponse) []map[string]interface{} {
+	layout := buildCellsetLayout(resp)
+	if layout == nil {
+		return []map[string]interface{}{}
+	}
+	if layout.Scalar {
+		return []map[string]interface{}{{"Value": layout.ScalarValue}}
+	}
+
+	records := make([]map[string]interface{}, 0, len(layout.RowCells))
+	for r := range layout.RowCells {
+		rec := make(map[string]interface{}, len(layout.Headers))
+		for c := 0; c < layout.NumRowDims; c++ {
+			rec[layout.Headers[c]] = layout.RowMembers[r][c]
+		}
+		valHeaders := layout.Headers[layout.NumRowDims:]
+		for c, h := range valHeaders {
+			rec[h] = layout.RowCells[r][c]
+		}
+		records = append(records, rec)
+	}
 	return records
 }
 
@@ -292,83 +584,51 @@ func writeJSONFile(filePath string, data interface{}) error {
 	return nil
 }
 
-// buildCellsetRows converts a CellsetResponse into headers and row data.
-// Returns nil, nil if the response has fewer than 2 axes or 0 column tuples.
-func buildCellsetRows(resp model.CellsetResponse) ([]string, [][]string) {
-	if len(resp.Axes) < 2 {
-		return nil, nil
-	}
-
-	colAxis := resp.Axes[0]
-	rowAxis := resp.Axes[1]
-
-	numCols := len(colAxis.Tuples)
-	if numCols == 0 {
-		return nil, nil
-	}
-
-	// Build column headers
-	colHeaders := make([]string, numCols)
-	for i, tuple := range colAxis.Tuples {
-		names := make([]string, len(tuple.Members))
-		for j, m := range tuple.Members {
-			names[j] = m.Name
-		}
-		colHeaders[i] = strings.Join(names, " / ")
-	}
-
-	// Build row headers count
-	rowMemberCount := 0
-	if len(rowAxis.Tuples) > 0 {
-		rowMemberCount = len(rowAxis.Tuples[0].Members)
-	}
-
-	// Headers
-	headers := make([]string, 0, rowMemberCount+numCols)
-	for i := 0; i < rowMemberCount; i++ {
-		headers = append(headers, fmt.Sprintf("DIM%d", i+1))
-	}
-	headers = append(headers, colHeaders...)
-
-	// Index cells by ordinal for O(1) lookup
-	cellsByOrdinal := make(map[int]interface{}, len(resp.Cells))
-	for _, cell := range resp.Cells {
-		cellsByOrdinal[cell.Ordinal] = cell.Value
-	}
-
-	// Build rows
-	rows := make([][]string, len(rowAxis.Tuples))
-	for r, tuple := range rowAxis.Tuples {
-		row := make([]string, 0, rowMemberCount+numCols)
-		for _, m := range tuple.Members {
-			row = append(row, m.Name)
-		}
-		for c := 0; c < numCols; c++ {
-			ordinal := r*numCols + c
-			val := ""
-			if v, ok := cellsByOrdinal[ordinal]; ok && v != nil {
-				val = fmt.Sprintf("%v", v)
-			}
-			row = append(row, val)
-		}
-		rows[r] = row
-	}
-
-	return headers, rows
-}
-
 func printCellsetTable(resp model.CellsetResponse) {
-	headers, rows := buildCellsetRows(resp)
-	if headers == nil {
+	layout := buildCellsetLayout(resp)
+	if layout == nil {
 		fmt.Println("No data returned.")
 		return
+	}
+
+	if layout.Scalar {
+		fmt.Printf("Result: %s\n", formatCellValue(layout.ScalarValue))
+		return
+	}
+
+	// Promote constant row-dim columns to slicer preamble (table mode only).
+	kept := make([]int, 0, layout.NumRowDims)
+	for c := 0; c < layout.NumRowDims; c++ {
+		if layout.ConstantCol[c] && len(layout.RowMembers) > 0 {
+			fmt.Printf("Slicer: %s = %s\n", layout.Headers[c], layout.RowMembers[0][c])
+		} else {
+			kept = append(kept, c)
+		}
+	}
+
+	headers := make([]string, 0, len(kept)+len(layout.Headers)-layout.NumRowDims)
+	for _, c := range kept {
+		headers = append(headers, layout.Headers[c])
+	}
+	headers = append(headers, layout.Headers[layout.NumRowDims:]...)
+
+	rows := make([][]string, len(layout.RowCells))
+	for r := range layout.RowCells {
+		row := make([]string, 0, len(headers))
+		for _, c := range kept {
+			row = append(row, layout.RowMembers[r][c])
+		}
+		for _, v := range layout.RowCells[r] {
+			row = append(row, formatCellValue(v))
+		}
+		rows[r] = row
 	}
 	output.PrintTable(headers, rows)
 }
 
 func writeCSV(resp model.CellsetResponse, filePath string, noHeader bool) error {
-	headers, rows := buildCellsetRows(resp)
-	if headers == nil {
+	layout := buildCellsetLayout(resp)
+	if layout == nil {
 		fmt.Fprintln(os.Stderr, "No data to export.")
 		return nil
 	}
@@ -380,19 +640,18 @@ func writeCSV(resp model.CellsetResponse, filePath string, noHeader bool) error 
 	defer f.Close()
 
 	w := csv.NewWriter(f)
+	headers, rows := layoutToStringRows(layout)
 
 	if !noHeader {
 		if err := w.Write(headers); err != nil {
 			return fmt.Errorf("Cannot write CSV header: %s", err)
 		}
 	}
-
 	for _, row := range rows {
 		if err := w.Write(row); err != nil {
 			return fmt.Errorf("Cannot write CSV row: %s", err)
 		}
 	}
-
 	w.Flush()
 	if err := w.Error(); err != nil {
 		return fmt.Errorf("Cannot write CSV: %s", err)
@@ -403,39 +662,13 @@ func writeCSV(resp model.CellsetResponse, filePath string, noHeader bool) error 
 }
 
 func writeXLSX(resp model.CellsetResponse, filePath string, noHeader bool) error {
-	if len(resp.Axes) < 2 {
+	layout := buildCellsetLayout(resp)
+	if layout == nil {
 		fmt.Fprintln(os.Stderr, "No data to export.")
 		return nil
 	}
 
-	colAxis := resp.Axes[0]
-	rowAxis := resp.Axes[1]
-	numCols := len(colAxis.Tuples)
-	if numCols == 0 {
-		fmt.Fprintln(os.Stderr, "No data to export.")
-		return nil
-	}
-
-	// Build column headers
-	colHeaders := make([]string, numCols)
-	for i, tuple := range colAxis.Tuples {
-		names := make([]string, len(tuple.Members))
-		for j, m := range tuple.Members {
-			names[j] = m.Name
-		}
-		colHeaders[i] = strings.Join(names, " / ")
-	}
-
-	rowMemberCount := 0
-	if len(rowAxis.Tuples) > 0 {
-		rowMemberCount = len(rowAxis.Tuples[0].Members)
-	}
-
-	// Index cells by ordinal to preserve original types
-	cellsByOrdinal := make(map[int]interface{}, len(resp.Cells))
-	for _, cell := range resp.Cells {
-		cellsByOrdinal[cell.Ordinal] = cell.Value
-	}
+	headers, rows := layoutToTypedRows(layout)
 
 	f := excelize.NewFile()
 	defer f.Close()
@@ -443,34 +676,18 @@ func writeXLSX(resp model.CellsetResponse, filePath string, noHeader bool) error
 
 	rowIdx := 1
 	if !noHeader {
-		col := 1
-		for i := 0; i < rowMemberCount; i++ {
-			cell, _ := excelize.CoordinatesToCellName(col, rowIdx)
-			f.SetCellValue(sheet, cell, fmt.Sprintf("DIM%d", i+1))
-			col++
-		}
-		for _, h := range colHeaders {
-			cell, _ := excelize.CoordinatesToCellName(col, rowIdx)
+		for i, h := range headers {
+			cell, _ := excelize.CoordinatesToCellName(i+1, rowIdx)
 			f.SetCellValue(sheet, cell, h)
-			col++
 		}
 		rowIdx++
 	}
-
-	for r, tuple := range rowAxis.Tuples {
-		col := 1
-		for _, m := range tuple.Members {
-			cell, _ := excelize.CoordinatesToCellName(col, rowIdx)
-			f.SetCellValue(sheet, cell, m.Name)
-			col++
-		}
-		for c := 0; c < numCols; c++ {
-			cell, _ := excelize.CoordinatesToCellName(col, rowIdx)
-			ordinal := r*numCols + c
-			if v, ok := cellsByOrdinal[ordinal]; ok && v != nil {
+	for _, row := range rows {
+		for i, v := range row {
+			cell, _ := excelize.CoordinatesToCellName(i+1, rowIdx)
+			if v != nil {
 				f.SetCellValue(sheet, cell, v)
 			}
-			col++
 		}
 		rowIdx++
 	}
@@ -479,7 +696,7 @@ func writeXLSX(resp model.CellsetResponse, filePath string, noHeader bool) error
 		return fmt.Errorf("Cannot write file: %s", err)
 	}
 
-	fmt.Fprintf(os.Stderr, "Exported %d rows to %s\n", len(rowAxis.Tuples), filePath)
+	fmt.Fprintf(os.Stderr, "Exported %d rows to %s\n", len(rows), filePath)
 	return nil
 }
 

--- a/cmd/export.go
+++ b/cmd/export.go
@@ -442,9 +442,13 @@ func buildCellsetLayout(resp model.CellsetResponse) *cellsetLayout {
 	}
 	colHeaders := buildColHeaders(colAxis)
 
-	all := disambiguateLabels(append(append([]string{}, rowLabels...), colHeaders...))
-	rowLabels = all[:len(rowLabels)]
-	colHeaders = all[len(rowLabels):]
+	combined := make([]string, 0, len(rowLabels)+len(colHeaders))
+	combined = append(combined, rowLabels...)
+	combined = append(combined, colHeaders...)
+	all := disambiguateLabels(combined)
+	numRowDims := len(rowLabels)
+	rowLabels = all[:numRowDims]
+	colHeaders = all[numRowDims:]
 
 	totalRows := 1
 	for _, sz := range axisSizes {
@@ -492,10 +496,10 @@ func buildCellsetLayout(resp model.CellsetResponse) *cellsetLayout {
 	}
 
 	return &cellsetLayout{
-		Headers:     append(append([]string{}, rowLabels...), colHeaders...),
+		Headers:     all,
 		RowMembers:  rowMembers,
 		RowCells:    rowCells,
-		NumRowDims:  len(rowLabels),
+		NumRowDims:  numRowDims,
 		ConstantCol: constantCols,
 	}
 }

--- a/cmd/export_test.go
+++ b/cmd/export_test.go
@@ -871,16 +871,19 @@ func mapKeys(m map[string]interface{}) []string {
 }
 
 // ---------------------------------------------------------------------------
-// TestBuildCellsetRows — unit tests for the buildCellsetRows function
+// TestLayoutToStringRows — exercises buildCellsetLayout + layoutToStringRows
+// together for the legacy 2-axis cases previously covered by
+// buildCellsetRows. New cases (UniqueName labels, N-axis, scalar/single-axis)
+// live in their own tests below.
 // ---------------------------------------------------------------------------
 
-func TestBuildCellsetRows(t *testing.T) {
+func TestLayoutToStringRows(t *testing.T) {
 	tests := []struct {
 		name        string
 		resp        model.CellsetResponse
 		wantHeaders []string
 		wantRows    [][]string
-		wantNil     bool
+		wantNilLay  bool
 	}{
 		{
 			name: "normal 2-axis data",
@@ -963,15 +966,7 @@ func TestBuildCellsetRows(t *testing.T) {
 			wantRows:    [][]string{{"Sales", ""}},
 		},
 		{
-			name: "fewer than 2 axes returns nil",
-			resp: model.CellsetResponse{
-				Axes:  []model.CellsetAxis{{Ordinal: 0}},
-				Cells: nil,
-			},
-			wantNil: true,
-		},
-		{
-			name: "0 column tuples returns nil",
+			name: "0 column tuples returns nil layout",
 			resp: model.CellsetResponse{
 				Axes: []model.CellsetAxis{
 					{Ordinal: 0, Tuples: []model.CellsetTuple{}},
@@ -981,21 +976,25 @@ func TestBuildCellsetRows(t *testing.T) {
 				},
 				Cells: nil,
 			},
-			wantNil: true,
+			wantNilLay: true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			headers, rows := buildCellsetRows(tt.resp)
+			layout := buildCellsetLayout(tt.resp)
 
-			if tt.wantNil {
-				if headers != nil || rows != nil {
-					t.Errorf("expected nil, got headers=%v rows=%v", headers, rows)
+			if tt.wantNilLay {
+				if layout != nil {
+					t.Errorf("expected nil layout, got %+v", layout)
 				}
 				return
 			}
+			if layout == nil {
+				t.Fatalf("expected non-nil layout")
+			}
 
+			headers, rows := layoutToStringRows(layout)
 			if len(headers) != len(tt.wantHeaders) {
 				t.Fatalf("headers length = %d, want %d", len(headers), len(tt.wantHeaders))
 			}
@@ -1004,7 +1003,6 @@ func TestBuildCellsetRows(t *testing.T) {
 					t.Errorf("headers[%d] = %q, want %q", i, h, tt.wantHeaders[i])
 				}
 			}
-
 			if len(rows) != len(tt.wantRows) {
 				t.Fatalf("rows length = %d, want %d", len(rows), len(tt.wantRows))
 			}
@@ -2204,5 +2202,867 @@ func TestRunExport_ViewNoCube(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "Cube name is required") {
 		t.Errorf("error should mention cube requirement, got: %s", err.Error())
+	}
+}
+
+// ===========================================================================
+// Advanced cellset parsing (#25) — helpers, N-axis, scalar, single-axis,
+// collision handling, endpoint query shape.
+// ===========================================================================
+
+func TestParseBracketSegments(t *testing.T) {
+	tests := []struct {
+		in   string
+		want []string
+	}{
+		{"[A].[B].[C]", []string{"A", "B", "C"}},
+		{"[A]", []string{"A"}},
+		{"[A].[B].[C].[D]", []string{"A", "B", "C", "D"}},
+		{"[foo]]bar].[baz]", []string{"foo]bar", "baz"}},
+		{"[].[A]", []string{"", "A"}},
+		{"", nil},
+		{"NoBrackets", nil},
+		{"[Unterminated", nil},
+		{"[A]missingdot[B]", nil},
+	}
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			got := parseBracketSegments(tt.in)
+			if len(got) != len(tt.want) {
+				t.Fatalf("length = %d, want %d (got=%v)", len(got), len(tt.want), got)
+			}
+			for i, seg := range got {
+				if seg != tt.want[i] {
+					t.Errorf("seg[%d] = %q, want %q", i, seg, tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestDeriveDimensionLabel(t *testing.T) {
+	tests := []struct {
+		in, want string
+	}{
+		{"[Period].[Period].[Jan]", "[Period]"},
+		{"[Period].[FY].[2024]", "[Period:FY]"},
+		{"[Version].[Actual]", "[Version]"},
+		{"", ""},
+		{"Garbage", ""},
+		{"[Unterminated", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			if got := deriveDimensionLabel(tt.in); got != tt.want {
+				t.Errorf("deriveDimensionLabel(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSortedAxesReordersByOrdinal(t *testing.T) {
+	resp := model.CellsetResponse{
+		Axes: []model.CellsetAxis{
+			{Ordinal: 2, Tuples: []model.CellsetTuple{{Ordinal: 0}}},
+			{Ordinal: 0, Tuples: []model.CellsetTuple{{Ordinal: 0}}},
+			{Ordinal: 1, Tuples: []model.CellsetTuple{{Ordinal: 0}}},
+		},
+	}
+	got := sortedAxes(resp)
+	if len(got) != 3 {
+		t.Fatalf("got %d axes, want 3", len(got))
+	}
+	for i, a := range got {
+		if a.Ordinal != i {
+			t.Errorf("got[%d].Ordinal = %d, want %d", i, a.Ordinal, i)
+		}
+	}
+}
+
+func TestSortedAxesDropsAndWarnsDuplicates(t *testing.T) {
+	resp := model.CellsetResponse{
+		Axes: []model.CellsetAxis{
+			{Ordinal: 0},
+			{Ordinal: 1},
+			{Ordinal: 1},
+			{Ordinal: 2},
+		},
+	}
+	stderr := captureStderr(t, func() {
+		got := sortedAxes(resp)
+		if len(got) != 3 {
+			t.Errorf("got %d axes, want 3 (duplicate 1 should be dropped)", len(got))
+		}
+	})
+	if !strings.Contains(stderr, "duplicate axis ordinal 1") {
+		t.Errorf("stderr missing duplicate warning, got: %s", stderr)
+	}
+}
+
+func TestDisambiguateLabels(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []string
+		want []string
+	}{
+		{"no dups", []string{"A", "B", "C"}, []string{"A", "B", "C"}},
+		{"simple dup", []string{"A", "B", "A"}, []string{"A", "B", "A(2)"}},
+		{"multiple dups", []string{"X", "X", "X", "Y", "X"}, []string{"X", "X(2)", "X(3)", "Y", "X(4)"}},
+		{"empty", []string{}, []string{}},
+		{"single", []string{"foo"}, []string{"foo"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := disambiguateLabels(tt.in)
+			if len(got) != len(tt.want) {
+				t.Fatalf("len = %d, want %d", len(got), len(tt.want))
+			}
+			for i, v := range got {
+				if v != tt.want[i] {
+					t.Errorf("got[%d] = %q, want %q", i, v, tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+// cellsetWithTitle builds a 3-axis cellset: axis 0 (Jan, Feb), axis 1
+// (Revenue, Cost with UniqueName on Account dimension), axis 2 single-tuple
+// Version=Actual. Four cells at ordinals 0..3.
+func cellsetWithTitle() model.CellsetResponse {
+	return model.CellsetResponse{
+		Axes: []model.CellsetAxis{
+			{
+				Ordinal: 0,
+				Tuples: []model.CellsetTuple{
+					{Ordinal: 0, Members: []model.CellsetMember{{Name: "Jan", UniqueName: "[Period].[Period].[Jan]"}}},
+					{Ordinal: 1, Members: []model.CellsetMember{{Name: "Feb", UniqueName: "[Period].[Period].[Feb]"}}},
+				},
+			},
+			{
+				Ordinal: 1,
+				Tuples: []model.CellsetTuple{
+					{Ordinal: 0, Members: []model.CellsetMember{{Name: "Revenue", UniqueName: "[Account].[Account].[Revenue]"}}},
+					{Ordinal: 1, Members: []model.CellsetMember{{Name: "Cost", UniqueName: "[Account].[Account].[Cost]"}}},
+				},
+			},
+			{
+				Ordinal: 2,
+				Tuples: []model.CellsetTuple{
+					{Ordinal: 0, Members: []model.CellsetMember{{Name: "Actual", UniqueName: "[Version].[Version].[Actual]"}}},
+				},
+			},
+		},
+		Cells: []model.CellsetCell{
+			{Ordinal: 0, Value: 100.0},
+			{Ordinal: 1, Value: 200.0},
+			{Ordinal: 2, Value: 50.0},
+			{Ordinal: 3, Value: 80.0},
+		},
+	}
+}
+
+func TestPrintCellsetTableWithTitleAxis(t *testing.T) {
+	got := captureStdout(t, func() {
+		printCellsetTable(cellsetWithTitle())
+	})
+	wantSubs := []string{
+		"Slicer: [Version] = Actual",
+		"[Account]", "Jan", "Feb",
+		"Revenue", "100", "200",
+		"Cost", "50", "80",
+	}
+	for _, s := range wantSubs {
+		if !strings.Contains(got, s) {
+			t.Errorf("output missing %q\ngot:\n%s", s, got)
+		}
+	}
+}
+
+func TestPrintCellsetTableAlternateHierarchy(t *testing.T) {
+	resp := model.CellsetResponse{
+		Axes: []model.CellsetAxis{
+			{Ordinal: 0, Tuples: []model.CellsetTuple{
+				{Ordinal: 0, Members: []model.CellsetMember{{Name: "Jan", UniqueName: "[Period].[FY].[Jan]"}}},
+			}},
+			{Ordinal: 1, Tuples: []model.CellsetTuple{
+				{Ordinal: 0, Members: []model.CellsetMember{{Name: "Revenue", UniqueName: "[Account].[Account].[Revenue]"}}},
+			}},
+		},
+		Cells: []model.CellsetCell{{Ordinal: 0, Value: 100.0}},
+	}
+	got := captureStdout(t, func() { printCellsetTable(resp) })
+	// The column-axis alternate-hierarchy member stays joined via " / " logic
+	// (single member → just "Jan"); the row-axis label should be "[Account]".
+	if !strings.Contains(got, "[Account]") {
+		t.Errorf("output should contain [Account] row label, got:\n%s", got)
+	}
+	// Exercise the alternate-hierarchy label derivation by using it on a row axis.
+	resp2 := model.CellsetResponse{
+		Axes: []model.CellsetAxis{
+			{Ordinal: 0, Tuples: []model.CellsetTuple{
+				{Ordinal: 0, Members: []model.CellsetMember{{Name: "Jan", UniqueName: "[Period].[Period].[Jan]"}}},
+			}},
+			{Ordinal: 1, Tuples: []model.CellsetTuple{
+				{Ordinal: 0, Members: []model.CellsetMember{{Name: "2024", UniqueName: "[Period].[FY].[2024]"}}},
+			}},
+		},
+		Cells: []model.CellsetCell{{Ordinal: 0, Value: 1.0}},
+	}
+	got2 := captureStdout(t, func() { printCellsetTable(resp2) })
+	if !strings.Contains(got2, "[Period:FY]") {
+		t.Errorf("output should contain [Period:FY] label for alt hierarchy, got:\n%s", got2)
+	}
+}
+
+func TestPrintCellsetTableScalar(t *testing.T) {
+	resp := model.CellsetResponse{
+		Axes:  nil,
+		Cells: []model.CellsetCell{{Ordinal: 0, Value: 42.5}},
+	}
+	got := captureStdout(t, func() { printCellsetTable(resp) })
+	if !strings.Contains(got, "Result: 42.5") {
+		t.Errorf("expected 'Result: 42.5', got:\n%s", got)
+	}
+	if strings.Contains(got, "DIM1") {
+		t.Errorf("scalar output should not contain DIM1, got:\n%s", got)
+	}
+}
+
+func TestPrintCellsetTableSingleAxis(t *testing.T) {
+	resp := model.CellsetResponse{
+		Axes: []model.CellsetAxis{
+			{Ordinal: 0, Tuples: []model.CellsetTuple{
+				{Ordinal: 0, Members: []model.CellsetMember{{Name: "Jan"}}},
+				{Ordinal: 1, Members: []model.CellsetMember{{Name: "Feb"}}},
+				{Ordinal: 2, Members: []model.CellsetMember{{Name: "Mar"}}},
+			}},
+		},
+		Cells: []model.CellsetCell{
+			{Ordinal: 0, Value: 10.0},
+			{Ordinal: 1, Value: 20.0},
+			{Ordinal: 2, Value: 30.0},
+		},
+	}
+	got := captureStdout(t, func() { printCellsetTable(resp) })
+	for _, s := range []string{"Jan", "Feb", "Mar", "10", "20", "30"} {
+		if !strings.Contains(got, s) {
+			t.Errorf("output missing %q, got:\n%s", s, got)
+		}
+	}
+}
+
+func TestPrintCellsetTableUniqueNameRowLabels(t *testing.T) {
+	resp := model.CellsetResponse{
+		Axes: []model.CellsetAxis{
+			{Ordinal: 0, Tuples: []model.CellsetTuple{
+				{Ordinal: 0, Members: []model.CellsetMember{{Name: "Q1"}}},
+			}},
+			{Ordinal: 1, Tuples: []model.CellsetTuple{
+				{Ordinal: 0, Members: []model.CellsetMember{
+					{Name: "US", UniqueName: "[Region].[Region].[US]"},
+					{Name: "Revenue", UniqueName: "[Account].[Account].[Revenue]"},
+				}},
+			}},
+		},
+		Cells: []model.CellsetCell{{Ordinal: 0, Value: 500.0}},
+	}
+	got := captureStdout(t, func() { printCellsetTable(resp) })
+	for _, s := range []string{"[Region]", "[Account]"} {
+		if !strings.Contains(got, s) {
+			t.Errorf("output should contain %q, got:\n%s", s, got)
+		}
+	}
+	if strings.Contains(got, "DIM1") || strings.Contains(got, "DIM2") {
+		t.Errorf("output should not fall back to DIMN when UniqueName is present, got:\n%s", got)
+	}
+}
+
+func TestPrintCellsetTableFallsBackToDimN(t *testing.T) {
+	resp := model.CellsetResponse{
+		Axes: []model.CellsetAxis{
+			{Ordinal: 0, Tuples: []model.CellsetTuple{
+				{Ordinal: 0, Members: []model.CellsetMember{{Name: "Jan"}}},
+			}},
+			{Ordinal: 1, Tuples: []model.CellsetTuple{
+				{Ordinal: 0, Members: []model.CellsetMember{{Name: "Revenue"}}},
+			}},
+		},
+		Cells: []model.CellsetCell{{Ordinal: 0, Value: 100.0}},
+	}
+	got := captureStdout(t, func() { printCellsetTable(resp) })
+	if !strings.Contains(got, "DIM1") {
+		t.Errorf("output should fall back to DIM1 when UniqueName missing, got:\n%s", got)
+	}
+}
+
+func TestPrintCellsetTableMultiTupleHigherAxisFlattens(t *testing.T) {
+	// Axis 0: 1 col (Jan). Axis 1: 2 rows (Revenue, Cost). Axis 2: 2 tuples
+	// (Actual, Budget). Expected: 2*2 = 4 virtual rows; cells at ordinals
+	// 0,1 (Actual/Rev, Actual/Cost), 2,3 (Budget/Rev, Budget/Cost).
+	resp := model.CellsetResponse{
+		Axes: []model.CellsetAxis{
+			{Ordinal: 0, Tuples: []model.CellsetTuple{
+				{Ordinal: 0, Members: []model.CellsetMember{{Name: "Jan"}}},
+			}},
+			{Ordinal: 1, Tuples: []model.CellsetTuple{
+				{Ordinal: 0, Members: []model.CellsetMember{{Name: "Revenue", UniqueName: "[Account].[Account].[Revenue]"}}},
+				{Ordinal: 1, Members: []model.CellsetMember{{Name: "Cost", UniqueName: "[Account].[Account].[Cost]"}}},
+			}},
+			{Ordinal: 2, Tuples: []model.CellsetTuple{
+				{Ordinal: 0, Members: []model.CellsetMember{{Name: "Actual", UniqueName: "[Version].[Version].[Actual]"}}},
+				{Ordinal: 1, Members: []model.CellsetMember{{Name: "Budget", UniqueName: "[Version].[Version].[Budget]"}}},
+			}},
+		},
+		Cells: []model.CellsetCell{
+			{Ordinal: 0, Value: 100.0},
+			{Ordinal: 1, Value: 50.0},
+			{Ordinal: 2, Value: 110.0},
+			{Ordinal: 3, Value: 55.0},
+		},
+	}
+	layout := buildCellsetLayout(resp)
+	if layout == nil {
+		t.Fatal("expected non-nil layout")
+	}
+	if len(layout.RowCells) != 4 {
+		t.Fatalf("expected 4 rows (2x2 flatten), got %d", len(layout.RowCells))
+	}
+	// Verify each row's (Account, Version) members + cell value.
+	// Flat row index r decomposes innermost-first: i_1 = r % 2 (Account),
+	// i_2 = r / 2 (Version). Expected sequence:
+	//   r=0: (Revenue, Actual)  -> 100
+	//   r=1: (Cost,    Actual)  -> 50
+	//   r=2: (Revenue, Budget)  -> 110
+	//   r=3: (Cost,    Budget)  -> 55
+	wantMembers := [][]string{
+		{"Revenue", "Actual"},
+		{"Cost", "Actual"},
+		{"Revenue", "Budget"},
+		{"Cost", "Budget"},
+	}
+	wantCells := []float64{100, 50, 110, 55}
+	for r := 0; r < 4; r++ {
+		if layout.RowMembers[r][0] != wantMembers[r][0] || layout.RowMembers[r][1] != wantMembers[r][1] {
+			t.Errorf("row %d members = %v, want %v", r, layout.RowMembers[r], wantMembers[r])
+		}
+		got, ok := layout.RowCells[r][0].(float64)
+		if !ok || got != wantCells[r] {
+			t.Errorf("row %d cell = %v, want %v", r, layout.RowCells[r][0], wantCells[r])
+		}
+	}
+}
+
+func TestWriteCSVWithTitleAxis(t *testing.T) {
+	outFile := filepath.Join(t.TempDir(), "out.csv")
+	captureAll(t, func() {
+		if err := writeCSV(cellsetWithTitle(), outFile, false); err != nil {
+			t.Fatalf("writeCSV error: %v", err)
+		}
+	})
+	data, err := os.ReadFile(outFile)
+	if err != nil {
+		t.Fatalf("read CSV: %v", err)
+	}
+	records, err := csv.NewReader(strings.NewReader(string(data))).ReadAll()
+	if err != nil {
+		t.Fatalf("parse CSV: %v", err)
+	}
+	// Axis 1 (Revenue, Cost) × axis 2 single-tuple (Actual) = 2 data rows.
+	if len(records) != 3 {
+		t.Fatalf("expected 3 rows (header + 2 data), got %d", len(records))
+	}
+	// Header: [Account], [Version], Jan, Feb
+	wantHeaders := []string{"[Account]", "[Version]", "Jan", "Feb"}
+	for i, h := range wantHeaders {
+		if records[0][i] != h {
+			t.Errorf("header[%d] = %q, want %q", i, records[0][i], h)
+		}
+	}
+	// Every data row should have "Actual" in the [Version] column (index 1).
+	for r := 1; r < len(records); r++ {
+		if records[r][1] != "Actual" {
+			t.Errorf("row %d col [Version] = %q, want Actual", r, records[r][1])
+		}
+	}
+}
+
+func TestWriteCSVScalar(t *testing.T) {
+	outFile := filepath.Join(t.TempDir(), "out.csv")
+	resp := model.CellsetResponse{
+		Axes:  nil,
+		Cells: []model.CellsetCell{{Ordinal: 0, Value: 42.5}},
+	}
+	captureAll(t, func() {
+		if err := writeCSV(resp, outFile, false); err != nil {
+			t.Fatalf("writeCSV error: %v", err)
+		}
+	})
+	data, err := os.ReadFile(outFile)
+	if err != nil {
+		t.Fatalf("read CSV: %v", err)
+	}
+	records, err := csv.NewReader(strings.NewReader(string(data))).ReadAll()
+	if err != nil {
+		t.Fatalf("parse CSV: %v", err)
+	}
+	if len(records) != 2 {
+		t.Fatalf("expected 2 rows (header + 1 data), got %d", len(records))
+	}
+	if records[0][0] != "Value" {
+		t.Errorf("header = %q, want Value", records[0][0])
+	}
+	if records[1][0] != "42.5" {
+		t.Errorf("value = %q, want 42.5", records[1][0])
+	}
+}
+
+func TestWriteCSVSingleAxis(t *testing.T) {
+	outFile := filepath.Join(t.TempDir(), "out.csv")
+	resp := model.CellsetResponse{
+		Axes: []model.CellsetAxis{
+			{Ordinal: 0, Tuples: []model.CellsetTuple{
+				{Ordinal: 0, Members: []model.CellsetMember{{Name: "Jan"}}},
+				{Ordinal: 1, Members: []model.CellsetMember{{Name: "Feb"}}},
+			}},
+		},
+		Cells: []model.CellsetCell{
+			{Ordinal: 0, Value: 10.0},
+			{Ordinal: 1, Value: 20.0},
+		},
+	}
+	captureAll(t, func() {
+		if err := writeCSV(resp, outFile, false); err != nil {
+			t.Fatalf("writeCSV error: %v", err)
+		}
+	})
+	data, _ := os.ReadFile(outFile)
+	records, _ := csv.NewReader(strings.NewReader(string(data))).ReadAll()
+	if len(records) != 2 {
+		t.Fatalf("expected 2 rows, got %d", len(records))
+	}
+	wantHeaders := []string{"Jan", "Feb"}
+	for i, h := range wantHeaders {
+		if records[0][i] != h {
+			t.Errorf("header[%d] = %q, want %q", i, records[0][i], h)
+		}
+	}
+	wantVals := []string{"10", "20"}
+	for i, v := range wantVals {
+		if records[1][i] != v {
+			t.Errorf("val[%d] = %q, want %q", i, records[1][i], v)
+		}
+	}
+}
+
+func TestWriteCSVMultiTupleHigherAxis(t *testing.T) {
+	// Reuse TestPrintCellsetTableMultiTupleHigherAxisFlattens fixture inline.
+	resp := model.CellsetResponse{
+		Axes: []model.CellsetAxis{
+			{Ordinal: 0, Tuples: []model.CellsetTuple{
+				{Ordinal: 0, Members: []model.CellsetMember{{Name: "Jan"}}},
+			}},
+			{Ordinal: 1, Tuples: []model.CellsetTuple{
+				{Ordinal: 0, Members: []model.CellsetMember{{Name: "Revenue", UniqueName: "[Account].[Account].[Revenue]"}}},
+				{Ordinal: 1, Members: []model.CellsetMember{{Name: "Cost", UniqueName: "[Account].[Account].[Cost]"}}},
+			}},
+			{Ordinal: 2, Tuples: []model.CellsetTuple{
+				{Ordinal: 0, Members: []model.CellsetMember{{Name: "Actual", UniqueName: "[Version].[Version].[Actual]"}}},
+				{Ordinal: 1, Members: []model.CellsetMember{{Name: "Budget", UniqueName: "[Version].[Version].[Budget]"}}},
+			}},
+		},
+		Cells: []model.CellsetCell{
+			{Ordinal: 0, Value: 100.0},
+			{Ordinal: 1, Value: 50.0},
+			{Ordinal: 2, Value: 110.0},
+			{Ordinal: 3, Value: 55.0},
+		},
+	}
+	outFile := filepath.Join(t.TempDir(), "out.csv")
+	captureAll(t, func() {
+		if err := writeCSV(resp, outFile, false); err != nil {
+			t.Fatalf("writeCSV error: %v", err)
+		}
+	})
+	data, _ := os.ReadFile(outFile)
+	records, _ := csv.NewReader(strings.NewReader(string(data))).ReadAll()
+	if len(records) != 5 { // 1 header + 4 data rows (2x2 flatten)
+		t.Fatalf("expected 5 rows, got %d\n%s", len(records), string(data))
+	}
+}
+
+func TestWriteCSVNoHeaderStillEmitsSlicerCols(t *testing.T) {
+	outFile := filepath.Join(t.TempDir(), "out.csv")
+	captureAll(t, func() {
+		if err := writeCSV(cellsetWithTitle(), outFile, true); err != nil {
+			t.Fatalf("writeCSV error: %v", err)
+		}
+	})
+	data, _ := os.ReadFile(outFile)
+	records, _ := csv.NewReader(strings.NewReader(string(data))).ReadAll()
+	if len(records) != 2 { // 2 data rows (Revenue, Cost), no header
+		t.Fatalf("expected 2 data rows (no header), got %d", len(records))
+	}
+	// Second column ([Version] slicer) must still hold "Actual" on every row.
+	for r, row := range records {
+		if row[1] != "Actual" {
+			t.Errorf("row %d slicer col = %q, want Actual (noHeader must still emit slicer data)", r, row[1])
+		}
+	}
+}
+
+func TestCellsetToRecordsWithTitleAxis(t *testing.T) {
+	records := cellsetToRecords(cellsetWithTitle())
+	// Axis 1 (Revenue, Cost) × axis 2 single-tuple (Actual) = 2 records.
+	if len(records) != 2 {
+		t.Fatalf("got %d records, want 2", len(records))
+	}
+	first := records[0]
+	if first["[Version]"] != "Actual" {
+		t.Errorf("record[0][[Version]] = %v, want Actual", first["[Version]"])
+	}
+	if first["[Account]"] != "Revenue" {
+		t.Errorf("record[0][[Account]] = %v, want Revenue", first["[Account]"])
+	}
+	if first["Jan"].(float64) != 100.0 {
+		t.Errorf("record[0][Jan] = %v, want 100.0", first["Jan"])
+	}
+}
+
+func TestCellsetToRecordsScalar(t *testing.T) {
+	resp := model.CellsetResponse{
+		Axes:  nil,
+		Cells: []model.CellsetCell{{Ordinal: 0, Value: 42.5}},
+	}
+	records := cellsetToRecords(resp)
+	if len(records) != 1 {
+		t.Fatalf("got %d records, want 1", len(records))
+	}
+	if records[0]["Value"].(float64) != 42.5 {
+		t.Errorf("Value = %v, want 42.5", records[0]["Value"])
+	}
+}
+
+func TestCellsetToRecordsSingleAxis(t *testing.T) {
+	resp := model.CellsetResponse{
+		Axes: []model.CellsetAxis{
+			{Ordinal: 0, Tuples: []model.CellsetTuple{
+				{Ordinal: 0, Members: []model.CellsetMember{{Name: "Jan"}}},
+				{Ordinal: 1, Members: []model.CellsetMember{{Name: "Feb"}}},
+			}},
+		},
+		Cells: []model.CellsetCell{
+			{Ordinal: 0, Value: 10.0},
+			{Ordinal: 1, Value: 20.0},
+		},
+	}
+	records := cellsetToRecords(resp)
+	if len(records) != 1 {
+		t.Fatalf("got %d records, want 1", len(records))
+	}
+	if records[0]["Jan"].(float64) != 10.0 {
+		t.Errorf("Jan = %v, want 10.0", records[0]["Jan"])
+	}
+	if records[0]["Feb"].(float64) != 20.0 {
+		t.Errorf("Feb = %v, want 20.0", records[0]["Feb"])
+	}
+}
+
+func TestCellsetToRecordsDuplicateColumnHeadersDoNotOverwrite(t *testing.T) {
+	// Two column tuples render to the same joined header "Jan / Actual".
+	// Disambiguation should give "Jan / Actual" and "Jan / Actual(2)"; both
+	// cell values must be retained in the record.
+	resp := model.CellsetResponse{
+		Axes: []model.CellsetAxis{
+			{Ordinal: 0, Tuples: []model.CellsetTuple{
+				{Ordinal: 0, Members: []model.CellsetMember{{Name: "Jan"}, {Name: "Actual"}}},
+				{Ordinal: 1, Members: []model.CellsetMember{{Name: "Jan"}, {Name: "Actual"}}},
+			}},
+			{Ordinal: 1, Tuples: []model.CellsetTuple{
+				{Ordinal: 0, Members: []model.CellsetMember{{Name: "Revenue"}}},
+			}},
+		},
+		Cells: []model.CellsetCell{
+			{Ordinal: 0, Value: 100.0},
+			{Ordinal: 1, Value: 200.0},
+		},
+	}
+	records := cellsetToRecords(resp)
+	if len(records) != 1 {
+		t.Fatalf("got %d records, want 1", len(records))
+	}
+	rec := records[0]
+	if rec["Jan / Actual"].(float64) != 100.0 {
+		t.Errorf("first dup key value = %v, want 100.0", rec["Jan / Actual"])
+	}
+	if rec["Jan / Actual(2)"].(float64) != 200.0 {
+		t.Errorf("second dup key value = %v, want 200.0 (ensure no overwrite)", rec["Jan / Actual(2)"])
+	}
+}
+
+func TestCellsetToRecordsRowColCollisionDisambiguated(t *testing.T) {
+	// Row-dim label [Period] (from UniqueName) collides with a column
+	// header also "[Period]" (a tuple of a single member named "[Period]").
+	// After global disambiguation they must be distinct keys.
+	resp := model.CellsetResponse{
+		Axes: []model.CellsetAxis{
+			{Ordinal: 0, Tuples: []model.CellsetTuple{
+				{Ordinal: 0, Members: []model.CellsetMember{{Name: "[Period]"}}},
+			}},
+			{Ordinal: 1, Tuples: []model.CellsetTuple{
+				{Ordinal: 0, Members: []model.CellsetMember{{Name: "Jan", UniqueName: "[Period].[Period].[Jan]"}}},
+			}},
+		},
+		Cells: []model.CellsetCell{{Ordinal: 0, Value: 7.0}},
+	}
+	records := cellsetToRecords(resp)
+	if len(records) != 1 {
+		t.Fatalf("got %d records, want 1", len(records))
+	}
+	rec := records[0]
+	// Row-dim label comes first in concat order, so it keeps "[Period]";
+	// column header becomes "[Period](2)".
+	if _, ok := rec["[Period]"]; !ok {
+		t.Errorf("expected key [Period] (row-dim), got keys: %v", keys(rec))
+	}
+	if _, ok := rec["[Period](2)"]; !ok {
+		t.Errorf("expected key [Period](2) (disambiguated col), got keys: %v", keys(rec))
+	}
+}
+
+func keys(m map[string]interface{}) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}
+
+func TestWriteXLSXPreservesNumericTypes(t *testing.T) {
+	// excelize GetCellType returns CellTypeUnset (the default) for plain
+	// numeric cells — numeric storage in XLSX XML has no explicit type
+	// attribute. The distinguishing test is: a SharedString-typed cell
+	// would contain an index reference, while a numeric cell contains
+	// the value directly. We verify by contrast: set one cell as
+	// SetCellStr and confirm its type differs from a numeric cell.
+	outFile := filepath.Join(t.TempDir(), "out.xlsx")
+	resp := model.CellsetResponse{
+		Axes: []model.CellsetAxis{
+			{Ordinal: 0, Tuples: []model.CellsetTuple{
+				{Ordinal: 0, Members: []model.CellsetMember{{Name: "Jan"}}},
+			}},
+			{Ordinal: 1, Tuples: []model.CellsetTuple{
+				{Ordinal: 0, Members: []model.CellsetMember{{Name: "Revenue"}}},
+			}},
+		},
+		Cells: []model.CellsetCell{{Ordinal: 0, Value: 123.45}},
+	}
+	captureAll(t, func() {
+		if err := writeXLSX(resp, outFile, false); err != nil {
+			t.Fatalf("writeXLSX error: %v", err)
+		}
+	})
+	f, err := excelize.OpenFile(outFile)
+	if err != nil {
+		t.Fatalf("open xlsx: %v", err)
+	}
+	defer f.Close()
+	// Value must round-trip exactly as numeric string (no string quoting).
+	b2, err := f.GetCellValue("Sheet1", "B2")
+	if err != nil {
+		t.Fatalf("GetCellValue B2: %v", err)
+	}
+	if b2 != "123.45" {
+		t.Errorf("B2 = %q, want 123.45", b2)
+	}
+	// Numeric cells must NOT be stored as SharedString (which would indicate
+	// stringification). CellTypeUnset or CellTypeNumber are both acceptable
+	// numeric storage indicators.
+	t2, _ := f.GetCellType("Sheet1", "B2")
+	if t2 == excelize.CellTypeSharedString || t2 == excelize.CellTypeInlineString {
+		t.Errorf("B2 stored as string type %v, want numeric", t2)
+	}
+}
+
+func TestWriteXLSXWithTitleAxis(t *testing.T) {
+	outFile := filepath.Join(t.TempDir(), "out.xlsx")
+	captureAll(t, func() {
+		if err := writeXLSX(cellsetWithTitle(), outFile, false); err != nil {
+			t.Fatalf("writeXLSX error: %v", err)
+		}
+	})
+	f, err := excelize.OpenFile(outFile)
+	if err != nil {
+		t.Fatalf("open xlsx: %v", err)
+	}
+	defer f.Close()
+	// Header row: [Account], [Version], Jan, Feb
+	gotA, _ := f.GetCellValue("Sheet1", "A1")
+	gotB, _ := f.GetCellValue("Sheet1", "B1")
+	if gotA != "[Account]" {
+		t.Errorf("A1 = %q, want [Account]", gotA)
+	}
+	if gotB != "[Version]" {
+		t.Errorf("B1 = %q, want [Version]", gotB)
+	}
+	// Data row 2: Revenue, Actual, 100, 200
+	gotB2, _ := f.GetCellValue("Sheet1", "B2")
+	if gotB2 != "Actual" {
+		t.Errorf("B2 = %q, want Actual (slicer constant)", gotB2)
+	}
+}
+
+func TestExportViewEndpointIncludesUniqueName(t *testing.T) {
+	resetCmdFlags(t)
+	exportView = "Default"
+
+	var capturedPath string
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		capturedPath = r.URL.RawQuery + "?" + r.URL.Path
+		// keep previous format for captured comparison:
+		capturedPath = r.URL.Path + "?" + r.URL.RawQuery
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(cellsetResponseJSON())
+	})
+
+	captureAll(t, func() {
+		if err := runExport(exportCmd, []string{"MyCube"}); err != nil {
+			t.Fatalf("runExport error: %v", err)
+		}
+	})
+
+	if !strings.Contains(capturedPath, "Members($select=Name,UniqueName)") {
+		t.Errorf("view endpoint should request UniqueName, got: %s", capturedPath)
+	}
+}
+
+func TestExportMDXEndpointIncludesUniqueName(t *testing.T) {
+	resetCmdFlags(t)
+	exportMDX = "SELECT {[X]} ON 0 FROM [C]"
+
+	// Capture the FIRST request (ExecuteMDX); later requests (cells page
+	// fetch, cellset cleanup DELETE) should not overwrite.
+	var firstPath string
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		if firstPath == "" {
+			firstPath = r.URL.Path + "?" + r.URL.RawQuery
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if strings.Contains(r.URL.Path, "ExecuteMDX") {
+			resp := model.CellsetResponse{
+				ID: "cs1",
+				Axes: []model.CellsetAxis{
+					{Ordinal: 0, Tuples: []model.CellsetTuple{
+						{Ordinal: 0, Members: []model.CellsetMember{{Name: "X"}}},
+					}},
+					{Ordinal: 1, Tuples: []model.CellsetTuple{
+						{Ordinal: 0, Members: []model.CellsetMember{{Name: "R"}}},
+					}},
+				},
+				Cells: []model.CellsetCell{{Ordinal: 0, Value: 1.0}},
+			}
+			data, _ := json.Marshal(resp)
+			w.Write(data)
+			return
+		}
+		// Cells page fetch: return an empty value array so paging terminates.
+		w.Write([]byte(`{"value":[]}`))
+	})
+
+	captureAll(t, func() {
+		_ = runExport(exportCmd, []string{})
+	})
+
+	if !strings.Contains(firstPath, "Members($select=Name,UniqueName)") {
+		t.Errorf("MDX endpoint should request UniqueName, got: %s", firstPath)
+	}
+}
+
+func TestRawJSONOutputPreservesUniqueName(t *testing.T) {
+	resp := model.CellsetResponse{
+		Axes: []model.CellsetAxis{
+			{Ordinal: 0, Tuples: []model.CellsetTuple{
+				{Ordinal: 0, Members: []model.CellsetMember{{Name: "Jan", UniqueName: "[Period].[Period].[Jan]"}}},
+			}},
+		},
+		Cells: []model.CellsetCell{{Ordinal: 0, Value: 1.0}},
+	}
+	got := captureStdout(t, func() { output.PrintJSON(resp) })
+	// output.PrintJSON uses indent with space after colon.
+	if !strings.Contains(got, `"UniqueName": "[Period].[Period].[Jan]"`) {
+		t.Errorf("raw JSON should include UniqueName, got:\n%s", got)
+	}
+}
+
+func TestRunExportScalarCSVFile(t *testing.T) {
+	resetCmdFlags(t)
+	exportView = "Default"
+	outFile := filepath.Join(t.TempDir(), "out.csv")
+	exportOut = outFile
+
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		resp := model.CellsetResponse{
+			Axes:  nil,
+			Cells: []model.CellsetCell{{Ordinal: 0, Value: 42.5}},
+		}
+		data, _ := json.Marshal(resp)
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(data)
+	})
+
+	captureAll(t, func() {
+		if err := runExport(exportCmd, []string{"C"}); err != nil {
+			t.Fatalf("runExport error: %v", err)
+		}
+	})
+	data, err := os.ReadFile(outFile)
+	if err != nil {
+		t.Fatalf("read csv: %v", err)
+	}
+	records, _ := csv.NewReader(strings.NewReader(string(data))).ReadAll()
+	if len(records) != 2 || records[0][0] != "Value" || records[1][0] != "42.5" {
+		t.Errorf("unexpected csv:\n%s", string(data))
+	}
+}
+
+func TestRunExportSingleAxisCSVFile(t *testing.T) {
+	resetCmdFlags(t)
+	exportView = "Default"
+	outFile := filepath.Join(t.TempDir(), "out.csv")
+	exportOut = outFile
+
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		resp := model.CellsetResponse{
+			Axes: []model.CellsetAxis{
+				{Ordinal: 0, Tuples: []model.CellsetTuple{
+					{Ordinal: 0, Members: []model.CellsetMember{{Name: "Jan"}}},
+					{Ordinal: 1, Members: []model.CellsetMember{{Name: "Feb"}}},
+				}},
+			},
+			Cells: []model.CellsetCell{
+				{Ordinal: 0, Value: 10.0},
+				{Ordinal: 1, Value: 20.0},
+			},
+		}
+		data, _ := json.Marshal(resp)
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(data)
+	})
+
+	captureAll(t, func() {
+		if err := runExport(exportCmd, []string{"C"}); err != nil {
+			t.Fatalf("runExport error: %v", err)
+		}
+	})
+	data, _ := os.ReadFile(outFile)
+	records, _ := csv.NewReader(strings.NewReader(string(data))).ReadAll()
+	if len(records) != 2 {
+		t.Fatalf("expected 2 rows, got %d:\n%s", len(records), string(data))
+	}
+	if records[0][0] != "Jan" || records[0][1] != "Feb" {
+		t.Errorf("header = %v, want [Jan Feb]", records[0])
+	}
+	if records[1][0] != "10" || records[1][1] != "20" {
+		t.Errorf("values = %v, want [10 20]", records[1])
 	}
 }

--- a/cmd/export_test.go
+++ b/cmd/export_test.go
@@ -2496,6 +2496,38 @@ func TestPrintCellsetTableFallsBackToDimN(t *testing.T) {
 	}
 }
 
+func TestPrintCellsetTableSingleRowTwoAxisDoesNotPromoteRowDim(t *testing.T) {
+	// A 2-axis cellset with exactly 1 row tuple previously rendered the
+	// row-dim as a column. Slicer promotion must only apply to title axes
+	// (axes >= 2), not to axis 1's row-dim — even when it's trivially
+	// constant.
+	resp := model.CellsetResponse{
+		Axes: []model.CellsetAxis{
+			{Ordinal: 0, Tuples: []model.CellsetTuple{
+				{Ordinal: 0, Members: []model.CellsetMember{{Name: "Jan"}}},
+				{Ordinal: 1, Members: []model.CellsetMember{{Name: "Feb"}}},
+			}},
+			{Ordinal: 1, Tuples: []model.CellsetTuple{
+				{Ordinal: 0, Members: []model.CellsetMember{{Name: "Revenue", UniqueName: "[Account].[Account].[Revenue]"}}},
+			}},
+		},
+		Cells: []model.CellsetCell{
+			{Ordinal: 0, Value: 100.0},
+			{Ordinal: 1, Value: 200.0},
+		},
+	}
+	got := captureStdout(t, func() { printCellsetTable(resp) })
+	if strings.Contains(got, "Slicer:") {
+		t.Errorf("2-axis single-row cellset should not emit Slicer preamble, got:\n%s", got)
+	}
+	if !strings.Contains(got, "[Account]") {
+		t.Errorf("row-dim should remain as a column header, got:\n%s", got)
+	}
+	if !strings.Contains(got, "Revenue") {
+		t.Errorf("row member should render as data, got:\n%s", got)
+	}
+}
+
 func TestPrintCellsetTableMultiTupleHigherAxisFlattens(t *testing.T) {
 	// Axis 0: 1 col (Jan). Axis 1: 2 rows (Revenue, Cost). Axis 2: 2 tuples
 	// (Actual, Budget). Expected: 2*2 = 4 virtual rows; cells at ordinals

--- a/internal/model/cellset.go
+++ b/internal/model/cellset.go
@@ -16,7 +16,8 @@ type CellsetTuple struct {
 }
 
 type CellsetMember struct {
-	Name string `json:"Name"`
+	Name       string `json:"Name"`
+	UniqueName string `json:"UniqueName,omitempty"`
 }
 
 type CellsetResponse struct {

--- a/internal/model/cellset_test.go
+++ b/internal/model/cellset_test.go
@@ -80,6 +80,27 @@ func TestCellsetMemberJSON(t *testing.T) {
 	}
 }
 
+func TestCellsetMemberUniqueNameJSON(t *testing.T) {
+	m := CellsetMember{Name: "Jan", UniqueName: "[Period].[Period].[Jan]"}
+	data, err := json.Marshal(m)
+	if err != nil {
+		t.Fatalf("Marshal error: %v", err)
+	}
+
+	want := `{"Name":"Jan","UniqueName":"[Period].[Period].[Jan]"}`
+	if string(data) != want {
+		t.Errorf("Marshal = %s, want %s", data, want)
+	}
+
+	var got CellsetMember
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("Unmarshal error: %v", err)
+	}
+	if got != m {
+		t.Errorf("Round-trip = %+v, want %+v", got, m)
+	}
+}
+
 func TestCellsetTupleJSON(t *testing.T) {
 	tuple := CellsetTuple{
 		Ordinal: 0,


### PR DESCRIPTION
## Summary

Closes #25.

Centralizes all cellset-to-output conversion into a single `buildCellsetLayout` + `cellsetLayout` struct. Handles 0-axis (scalar), 1-axis, and N-axis cellsets uniformly; all four writers (table, CSV, XLSX, JSON records) consume the same canonical layout.

## What changed

**New capabilities**
- **Title / slicer axes (axes ≥ 2)** — previously silently dropped. Now:
  - Table: rendered as a `Slicer: [Dim] = Value` preamble above the data.
  - CSV / XLSX / JSON records: prepended as extra constant columns on every row (self-describing).
- **Multi-tuple higher axes** — flatten into extra row-dimension columns (no data loss); row count becomes `|A_1| × |A_2| × ...`.
- **0-axis (scalar) MDX results** — previously returned empty. Now render as `Result: <v>` / `Value` column.
- **1-axis cellsets** — previously returned empty. Now render as a single data row with column headers.
- **Hierarchy-derived row labels** — `DIM1 / DIM2 / ...` become `[Dim]` or `[Dim:Hier]` (alternate hierarchies) parsed from `UniqueName`. Falls back to `DIM{N}` when `UniqueName` is missing.
- **Axis ordinal normalization** — `sortedAxes` sorts axes by `Ordinal`; warns and drops duplicate ordinals.
- **Global header disambiguation** — duplicate headers across slicer / row-dim / column axes gain a `(N)` suffix, preventing silent key collisions in JSON output.
- **TM1 MDX `]]` escape** — `parseBracketSegments` correctly handles `[foo]]bar].[baz]` → `foo]bar`, `baz`.

**Under the hood**
- New `UniqueName` field on `CellsetMember` (requested via `$select=Name,UniqueName` on both view and MDX endpoints; `omitempty` so older servers degrade cleanly).
- 4 writers (`printCellsetTable`, `writeCSV`, `writeXLSX`, `cellsetToRecords`) refactored to consume `cellsetLayout`. Dead `buildCellsetRows` removed.
- Slicer preamble in table mode restricted to axes ≥ 2 — axis 1's row-dim always stays as a row column (preserves v0.2.0 layout for single-row 2-axis views).

## Breaking changes

Documented in the plan; callers scripting against export output should review:

- **JSON record keys** switch from `DIM{N}` to `[Dim]` / `[Dim:Hier]` when `UniqueName` is available. Fallback preserves `DIM{N}` when absent.
- **CSV / XLSX for views with title dims** previously dropped those dims silently; now adds them as extra prepended columns.
- **Multi-tuple higher axes** produce `|A_k|×` more rows (correct but larger output).
- **`--no-header`** suppresses only the header row; slicer / row-dim columns remain in data.

Raw `--output json` on stdout is unchanged — still dumps the full `CellsetResponse` (now including the new `UniqueName` field).

## Commits

- `feat(#25): advanced cellset parsing for complex multi-axis views`
- `refactor(#25): eliminate redundant slice allocation in buildCellsetLayout`
- `fix(#25): address review feedback — round 1`

## Test plan

- [x] `go test ./...` passes (714 tests across 6 packages)
- [x] Unit tests for every new helper (`parseBracketSegments`, `deriveDimensionLabel`, `sortedAxes`, `disambiguateLabels`, `buildColHeaders`, `buildRowLabelsForAxis`, `formatCellValue`)
- [x] `buildCellsetLayout` coverage for 0-axis scalar, 1-axis, 2-axis, N≥3-axis with title, multi-tuple higher axes
- [x] Output-format coverage: table (slicer preamble, scalar, single-axis, UniqueName labels, DIM{N} fallback, single-row 2-axis no-promotion), CSV (title axis, scalar, single-axis, multi-tuple, no-header slicer preservation), JSON records (title axis, scalar, single-axis, duplicate col headers, row/col collision), XLSX (numeric type preservation, title axis)
- [x] Endpoint URL assertions — both view and MDX endpoints include `$select=Name,UniqueName`
- [x] Raw `output.PrintJSON` includes `UniqueName` field
- [ ] Manual verification against a real TM1 server with a multi-axis view (reviewer to confirm)

## Review status

Draft — internal reviewer (Opus, manual + multi-perspective) and external reviewer (Sonnet, manual + multi-perspective) both APPROVED. Scores: Security 9/10, Performance 9/10, Code Quality 9/10, Test Coverage 10/10. No P0/P1 findings.