### PR TITLE
fix(#21): validate CAM namespace and improve auth error messages

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -127,6 +127,10 @@ func runConfigAdd(cmd *cobra.Command, args []string) error {
 		namespace, _ = reader.ReadString('\n')
 		namespace = strings.TrimSpace(namespace)
 	}
+	if authMode == "cam" && namespace == "" {
+		fmt.Fprintln(os.Stderr, "Error: CAM namespace is required. Use --namespace or enter it at the prompt.")
+		return errSilent
+	}
 
 	// Username
 	user := addFlagUser
@@ -358,6 +362,10 @@ func runConfigEdit(cmd *cobra.Command, args []string) error {
 		input = strings.TrimSpace(input)
 		if input != "" {
 			srv.Namespace = input
+		}
+		if srv.Namespace == "" {
+			fmt.Fprintln(os.Stderr, "Error: CAM namespace is required for cam auth.")
+			return errSilent
 		}
 	} else {
 		srv.Namespace = ""

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -32,6 +32,10 @@ type Client struct {
 }
 
 func NewClient(server config.ServerConfig, password string, tlsVerify bool, verbose bool) (*Client, error) {
+	if strings.EqualFold(server.AuthMode, "cam") && server.Namespace == "" {
+		return nil, fmt.Errorf("CAM auth requires a namespace; set it with --namespace or 'tm1cli config edit'")
+	}
+
 	jar, err := cookiejar.New(nil)
 	if err != nil {
 		return nil, fmt.Errorf("cannot create cookie jar: %w", err)
@@ -187,6 +191,9 @@ func (c *Client) wrapError(err error) error {
 func (c *Client) httpError(status int, body []byte, endpoint string) error {
 	switch status {
 	case 401:
+		if strings.EqualFold(c.authMode, "cam") {
+			return fmt.Errorf("Authentication failed. Check username, password, and CAM namespace (%s).", c.namespace)
+		}
 		return fmt.Errorf("Authentication failed. Check credentials.")
 	case 404:
 		return fmt.Errorf("Not found: %s: %w", endpoint, ErrNotFound)

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -396,6 +396,106 @@ func TestPatch(t *testing.T) {
 	}
 }
 
+func TestNewClientCAMValidation(t *testing.T) {
+	t.Run("cam with namespace succeeds", func(t *testing.T) {
+		srv := config.ServerConfig{
+			URL:       "https://localhost:8010",
+			User:      "admin",
+			AuthMode:  "cam",
+			Namespace: "LDAP",
+		}
+		_, err := NewClient(srv, "secret", false, false)
+		if err != nil {
+			t.Fatalf("expected no error, got: %v", err)
+		}
+	})
+
+	t.Run("cam with empty namespace returns error", func(t *testing.T) {
+		srv := config.ServerConfig{
+			URL:      "https://localhost:8010",
+			User:     "admin",
+			AuthMode: "cam",
+		}
+		_, err := NewClient(srv, "secret", false, false)
+		if err == nil {
+			t.Fatal("expected error for cam with empty namespace, got nil")
+		}
+		if !strings.Contains(err.Error(), "namespace") {
+			t.Errorf("error = %q, want it to mention 'namespace'", err.Error())
+		}
+	})
+
+	t.Run("cam auth mode is case-insensitive for namespace validation", func(t *testing.T) {
+		srv := config.ServerConfig{
+			URL:      "https://localhost:8010",
+			User:     "admin",
+			AuthMode: "CAM",
+		}
+		_, err := NewClient(srv, "secret", false, false)
+		if err == nil {
+			t.Fatal("expected error for CAM (uppercase) with empty namespace, got nil")
+		}
+		if !strings.Contains(err.Error(), "namespace") {
+			t.Errorf("error = %q, want it to mention 'namespace'", err.Error())
+		}
+	})
+
+	t.Run("basic auth with empty namespace succeeds", func(t *testing.T) {
+		srv := config.ServerConfig{
+			URL:      "https://localhost:8010",
+			User:     "admin",
+			AuthMode: "basic",
+		}
+		_, err := NewClient(srv, "secret", false, false)
+		if err != nil {
+			t.Fatalf("expected no error for basic auth without namespace, got: %v", err)
+		}
+	})
+}
+
+func TestCAMAuth401Error(t *testing.T) {
+	t.Run("CAM 401 mentions namespace in error", func(t *testing.T) {
+		ts := newTestServer(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized)
+			w.Write([]byte(`{"message":"Authentication required."}`))
+		})
+		defer ts.Close()
+
+		c := newTestClient(t, ts.URL, func(srv *config.ServerConfig) {
+			srv.AuthMode = "cam"
+			srv.Namespace = "LDAP"
+		})
+
+		_, err := c.Get("Cubes")
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "namespace") {
+			t.Errorf("CAM 401 error = %q, want it to mention 'namespace'", err.Error())
+		}
+		if !strings.Contains(err.Error(), "LDAP") {
+			t.Errorf("CAM 401 error = %q, want it to contain the namespace name 'LDAP'", err.Error())
+		}
+	})
+
+	t.Run("basic 401 does not mention namespace", func(t *testing.T) {
+		ts := newTestServer(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized)
+			w.Write([]byte(`Unauthorized`))
+		})
+		defer ts.Close()
+
+		c := newTestClient(t, ts.URL)
+		_, err := c.Get("Cubes")
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if strings.Contains(err.Error(), "namespace") {
+			t.Errorf("basic 401 error = %q, should not mention 'namespace'", err.Error())
+		}
+	})
+}
+
 func TestSetAuth(t *testing.T) {
 	t.Run("basic auth sets Authorization header", func(t *testing.T) {
 		var capturedAuth string


### PR DESCRIPTION
## Summary

- `NewClient` fails fast with a clear error when `cam` mode has an empty namespace
- CAM 401 errors now include the namespace name (e.g. `Check username, password, and CAM namespace (LDAP).`)
- `config add` and `config edit` validate that namespace is non-empty for CAM auth, with an explicit stderr message

## Changes

- `internal/client/client.go` — namespace guard in `NewClient`; auth-mode-aware 401 error in `httpError`
- `cmd/config.go` — namespace validation in `config add` and `config edit`
- `internal/client/client_test.go` — 4 new tests covering empty namespace rejection, case-insensitive CAM mode, and CAM vs basic 401 error messages

## Test plan

- [ ] `go test ./...` passes (722 tests)
- [ ] `tm1cli config add --auth cam` without `--namespace` shows clear error
- [ ] CAM 401 error message includes namespace name
- [ ] Basic auth 401 error message unchanged

Closes #21