### PR TITLE
feat(#75): threads list — show running TM1 threads

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,17 @@ tm1cli process run "LoadData"              # run without params
 tm1cli process run "LoadData" --param pSource=file.csv --param pYear=2024
 ```
 
+### Threads
+
+```bash
+tm1cli threads list                       # list running threads
+tm1cli threads list --state Run           # filter by state (Idle|Run|Wait|CommitWait|Rollback)
+tm1cli threads list --user Admin          # filter by user (partial, case-insensitive)
+tm1cli threads list --min-elapsed 10s     # threads running longer than 10 seconds
+tm1cli threads list --all                 # no 50-row limit
+tm1cli threads list --output json         # full 14-field JSON output
+```
+
 ### Export
 
 ```bash

--- a/cmd/testhelpers_test.go
+++ b/cmd/testhelpers_test.go
@@ -214,6 +214,11 @@ func zeroAllFlags() {
 	subsetsHierarchy = ""
 	watchInterval = "5s"
 	watchSeconds = 0
+	threadsUser = ""
+	threadsState = ""
+	threadsMinElapsed = ""
+	threadsLimit = 0
+	threadsAll = false
 }
 
 // cubesJSON returns JSON for a TM1 Cubes response.
@@ -374,5 +379,17 @@ func serverConfigJSON(name, version, host string, port int) []byte {
 		AdminHost:      host,
 		HTTPPortNumber: port,
 	})
+	return data
+}
+
+// threadsJSON returns JSON for a TM1 Threads response.
+func threadsJSON(threads ...model.Thread) []byte {
+	resp := struct {
+		Value []model.Thread `json:"value"`
+	}{Value: threads}
+	if resp.Value == nil {
+		resp.Value = []model.Thread{}
+	}
+	data, _ := json.Marshal(resp)
 	return data
 }

--- a/cmd/threads.go
+++ b/cmd/threads.go
@@ -69,7 +69,12 @@ func runThreadsList(cmd *cobra.Command, args []string) error {
 	limit := getLimit(cfg, threadsLimit, threadsAll)
 	endpoint := "Threads?$select=ID,Type,Name,Context,State,Function,ObjectType,ObjectName,RLocks,IXLocks,WLocks,ElapsedTime,WaitTime,Info"
 
-	data, err := cl.Get(endpoint)
+	fetchEndpoint := endpoint
+	if limit > 0 {
+		fetchEndpoint += fmt.Sprintf("&$top=%d", limit+100)
+	}
+
+	data, err := cl.Get(fetchEndpoint)
 	if err != nil {
 		output.PrintError(err.Error(), jsonMode)
 		return errSilent

--- a/cmd/threads.go
+++ b/cmd/threads.go
@@ -58,11 +58,12 @@ func runThreadsList(cmd *cobra.Command, args []string) error {
 
 	var minElapsed time.Duration
 	if threadsMinElapsed != "" {
-		minElapsed, err = time.ParseDuration(threadsMinElapsed)
+		d, err := time.ParseDuration(threadsMinElapsed)
 		if err != nil {
 			output.PrintError(fmt.Sprintf("Invalid --min-elapsed value %q: %s", threadsMinElapsed, err), jsonMode)
 			return errSilent
 		}
+		minElapsed = d
 	}
 
 	limit := getLimit(cfg, threadsLimit, threadsAll)
@@ -83,12 +84,6 @@ func runThreadsList(cmd *cobra.Command, args []string) error {
 	threads := filterThreads(resp.Value, threadsUser, threadsState, minElapsed)
 	displayThreads(threads, len(threads), limit, jsonMode)
 	return nil
-}
-
-// parseODataDuration is a package-level alias for model.ParseODataDuration,
-// exposed here so cmd-package tests can exercise the parsing logic directly.
-func parseODataDuration(s string) float64 {
-	return model.ParseODataDuration(s)
 }
 
 func filterThreads(threads []model.Thread, user, state string, minElapsed time.Duration) []model.Thread {
@@ -150,7 +145,7 @@ func displayThreads(threads []model.Thread, total int, limit int, jsonMode bool)
 		}
 	}
 	output.PrintTable(headers, rows)
-	fmt.Printf("Showing %d of %d\n", len(shown), total)
+	output.PrintSummary(len(shown), total)
 }
 
 func init() {

--- a/cmd/threads.go
+++ b/cmd/threads.go
@@ -1,0 +1,165 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+	"tm1cli/internal/model"
+	"tm1cli/internal/output"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	threadsUser       string
+	threadsState      string
+	threadsMinElapsed string
+	threadsLimit      int
+	threadsAll        bool
+)
+
+var threadsCmd = &cobra.Command{
+	Use:   "threads",
+	Short: "Manage TM1 server threads",
+	Long:  `Manage and inspect threads running on the TM1 server.`,
+}
+
+var threadsListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List currently running threads",
+	Long: `List currently running threads on the TM1 server.
+
+REST API: GET /Threads
+
+Results are limited to 50 by default. Use --all to show all threads.`,
+	Example: `  tm1cli threads list
+  tm1cli threads list --state Run
+  tm1cli threads list --user Admin
+  tm1cli threads list --min-elapsed 10s
+  tm1cli threads list --all
+  tm1cli threads list --output json`,
+	RunE: runThreadsList,
+}
+
+func runThreadsList(cmd *cobra.Command, args []string) error {
+	cfg, err := loadConfig()
+	if err != nil {
+		output.PrintError(err.Error(), isJSONOutput(nil))
+		return errSilent
+	}
+
+	jsonMode := isJSONOutput(cfg)
+	cl, err := createClient(cfg)
+	if err != nil {
+		output.PrintError(err.Error(), jsonMode)
+		return errSilent
+	}
+
+	var minElapsed time.Duration
+	if threadsMinElapsed != "" {
+		minElapsed, err = time.ParseDuration(threadsMinElapsed)
+		if err != nil {
+			output.PrintError(fmt.Sprintf("Invalid --min-elapsed value %q: %s", threadsMinElapsed, err), jsonMode)
+			return errSilent
+		}
+	}
+
+	limit := getLimit(cfg, threadsLimit, threadsAll)
+	endpoint := "Threads?$select=ID,Type,Name,Context,State,Function,ObjectType,ObjectName,RLocks,IXLocks,WLocks,ElapsedTime,WaitTime,Info"
+
+	data, err := cl.Get(endpoint)
+	if err != nil {
+		output.PrintError(err.Error(), jsonMode)
+		return errSilent
+	}
+
+	var resp model.ThreadResponse
+	if err := json.Unmarshal(data, &resp); err != nil {
+		output.PrintError("Cannot parse server response.", jsonMode)
+		return errSilent
+	}
+
+	threads := filterThreads(resp.Value, threadsUser, threadsState, minElapsed)
+	displayThreads(threads, len(threads), limit, jsonMode)
+	return nil
+}
+
+// parseODataDuration is a package-level alias for model.ParseODataDuration,
+// exposed here so cmd-package tests can exercise the parsing logic directly.
+func parseODataDuration(s string) float64 {
+	return model.ParseODataDuration(s)
+}
+
+func filterThreads(threads []model.Thread, user, state string, minElapsed time.Duration) []model.Thread {
+	if user == "" && state == "" && minElapsed == 0 {
+		return threads
+	}
+	var out []model.Thread
+	for _, t := range threads {
+		if user != "" && !strings.Contains(strings.ToLower(t.Name), strings.ToLower(user)) {
+			continue
+		}
+		if state != "" && !strings.EqualFold(t.State, state) {
+			continue
+		}
+		if minElapsed > 0 && float64(t.ElapsedTime) < minElapsed.Seconds() {
+			continue
+		}
+		out = append(out, t)
+	}
+	return out
+}
+
+func formatThreadDuration(d model.ThreadDuration) string {
+	secs := float64(d)
+	if secs < 1 {
+		return fmt.Sprintf("%dms", int(secs*1000))
+	}
+	dur := time.Duration(secs * float64(time.Second))
+	if dur < time.Minute {
+		return fmt.Sprintf("%.1fs", secs)
+	}
+	m := int(dur.Minutes())
+	s := int(dur.Seconds()) % 60
+	return fmt.Sprintf("%dm%ds", m, s)
+}
+
+func displayThreads(threads []model.Thread, total int, limit int, jsonMode bool) {
+	shown := threads
+	if limit > 0 && len(shown) > limit {
+		shown = shown[:limit]
+	}
+
+	if jsonMode {
+		output.PrintJSON(shown)
+		return
+	}
+
+	headers := []string{"ID", "NAME", "TYPE", "STATE", "FUNCTION", "ELAPSED", "WAIT"}
+	rows := make([][]string, len(shown))
+	for i, t := range shown {
+		rows[i] = []string{
+			fmt.Sprintf("%d", t.ID),
+			t.Name,
+			t.Type,
+			t.State,
+			t.Function,
+			formatThreadDuration(t.ElapsedTime),
+			formatThreadDuration(t.WaitTime),
+		}
+	}
+	output.PrintTable(headers, rows)
+	fmt.Printf("Showing %d of %d\n", len(shown), total)
+}
+
+func init() {
+	rootCmd.AddCommand(threadsCmd)
+	threadsCmd.AddCommand(threadsListCmd)
+
+	threadsListCmd.Flags().StringVar(&threadsUser, "user", "", "Filter by thread name/user (case-insensitive, partial match)")
+	threadsListCmd.Flags().StringVar(&threadsState, "state", "", "Filter by state (Idle|Run|Wait|CommitWait|Rollback)")
+	threadsListCmd.Flags().StringVar(&threadsMinElapsed, "min-elapsed", "", "Minimum elapsed time filter (e.g. 10s, 1m30s)")
+	threadsListCmd.Flags().IntVar(&threadsLimit, "limit", 0, "Max results to show (default from settings)")
+	threadsListCmd.Flags().BoolVar(&threadsAll, "all", false, "Show all results, no limit")
+}

--- a/cmd/threads.go
+++ b/cmd/threads.go
@@ -114,6 +114,9 @@ func filterThreads(threads []model.Thread, user, state string, minElapsed time.D
 
 func formatThreadDuration(d model.ThreadDuration) string {
 	secs := float64(d)
+	if secs <= 0 {
+		return "0ms"
+	}
 	if secs < 1 {
 		return fmt.Sprintf("%dms", int(secs*1000))
 	}

--- a/cmd/threads.go
+++ b/cmd/threads.go
@@ -149,7 +149,7 @@ func displayThreads(threads []model.Thread, total int, limit int, jsonMode bool)
 		}
 	}
 	output.PrintTable(headers, rows)
-	output.PrintSummary(len(shown), total)
+	output.PrintSummary(len(shown), total, "--user, --state, or --min-elapsed to filter or --all")
 }
 
 func init() {

--- a/cmd/threads.go
+++ b/cmd/threads.go
@@ -70,7 +70,8 @@ func runThreadsList(cmd *cobra.Command, args []string) error {
 	endpoint := "Threads?$select=ID,Type,Name,Context,State,Function,ObjectType,ObjectName,RLocks,IXLocks,WLocks,ElapsedTime,WaitTime,Info"
 
 	fetchEndpoint := endpoint
-	if limit > 0 {
+	activeFilters := threadsUser != "" || threadsState != "" || threadsMinElapsed != ""
+	if limit > 0 && !activeFilters {
 		fetchEndpoint += fmt.Sprintf("&$top=%d", limit+100)
 	}
 

--- a/cmd/threads.go
+++ b/cmd/threads.go
@@ -115,8 +115,12 @@ func formatThreadDuration(d model.ThreadDuration) string {
 	if dur < time.Minute {
 		return fmt.Sprintf("%.1fs", secs)
 	}
-	m := int(dur.Minutes())
+	h := int(dur.Hours())
+	m := int(dur.Minutes()) % 60
 	s := int(dur.Seconds()) % 60
+	if h > 0 {
+		return fmt.Sprintf("%dh%dm%ds", h, m, s)
+	}
 	return fmt.Sprintf("%dm%ds", m, s)
 }
 

--- a/cmd/threads_test.go
+++ b/cmd/threads_test.go
@@ -241,7 +241,9 @@ func TestThreadsListTruncation(t *testing.T) {
 	for i := range threads {
 		threads[i] = model.Thread{ID: int64(i + 1), Name: "user", State: "Idle"}
 	}
+	var gotURL string
 	ts := setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		gotURL = r.URL.String()
 		w.Header().Set("Content-Type", "application/json")
 		w.Write(threadsJSON(threads...))
 	})
@@ -252,6 +254,9 @@ func TestThreadsListTruncation(t *testing.T) {
 		rootCmd.Execute()
 	})
 
+	if !strings.Contains(gotURL, "$top=") {
+		t.Errorf("expected $top in request URL to limit server fetch, got: %s", gotURL)
+	}
 	if !strings.Contains(cap.Stderr, "Showing 50 of 55") {
 		t.Errorf("expected truncation summary on stderr, got: %s", cap.Stderr)
 	}

--- a/cmd/threads_test.go
+++ b/cmd/threads_test.go
@@ -1,0 +1,277 @@
+package cmd
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+	"tm1cli/internal/model"
+)
+
+// --- Unit: filterThreads ---
+
+func TestFilterThreads(t *testing.T) {
+	threads := []model.Thread{
+		{ID: 1, Name: "Admin", State: "Run", ElapsedTime: 5.0},
+		{ID: 2, Name: "UserA", State: "Idle", ElapsedTime: 20.0},
+		{ID: 3, Name: "worker", State: "Run", ElapsedTime: 60.0},
+	}
+
+	tests := []struct {
+		name       string
+		user       string
+		state      string
+		minElapsed time.Duration
+		wantIDs    []int64
+	}{
+		{
+			name:    "no filters returns all",
+			wantIDs: []int64{1, 2, 3},
+		},
+		{
+			name:    "filter by user case-insensitively",
+			user:    "admin",
+			wantIDs: []int64{1},
+		},
+		{
+			name:    "filter by state case-insensitively",
+			state:   "run",
+			wantIDs: []int64{1, 3},
+		},
+		{
+			name:       "filter by min-elapsed",
+			minElapsed: 10 * time.Second,
+			wantIDs:    []int64{2, 3},
+		},
+		{
+			name:    "all filtered out returns nil",
+			state:   "CommitWait",
+			wantIDs: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := filterThreads(threads, tt.user, tt.state, tt.minElapsed)
+			if len(got) != len(tt.wantIDs) {
+				t.Fatalf("got %d threads, want %d", len(got), len(tt.wantIDs))
+			}
+			for i, id := range tt.wantIDs {
+				if got[i].ID != id {
+					t.Errorf("got[%d].ID = %d, want %d", i, got[i].ID, id)
+				}
+			}
+		})
+	}
+}
+
+// --- Unit: formatThreadDuration ---
+
+func TestFormatThreadDuration(t *testing.T) {
+	tests := []struct {
+		secs float64
+		want string
+	}{
+		{0.0, "0ms"},
+		{0.5, "500ms"},
+		{1.5, "1.5s"},
+		{59.9, "59.9s"},
+		{90.0, "1m30s"},
+	}
+	for _, tt := range tests {
+		got := formatThreadDuration(model.ThreadDuration(tt.secs))
+		if got != tt.want {
+			t.Errorf("formatThreadDuration(%v) = %q, want %q", tt.secs, got, tt.want)
+		}
+	}
+}
+
+// --- Unit: parseODataDuration ---
+
+func TestParseODataDuration(t *testing.T) {
+	tests := []struct {
+		input string
+		want  float64
+	}{
+		{"PT10S", 10.0},
+		{"PT1M30S", 90.0},
+		{"PT1H0M0S", 3600.0},
+		{"duration'PT10S'", 10.0},
+		{"PT0.5S", 0.5},
+	}
+	for _, tt := range tests {
+		got := parseODataDuration(tt.input)
+		if got != tt.want {
+			t.Errorf("parseODataDuration(%q) = %v, want %v", tt.input, got, tt.want)
+		}
+	}
+}
+
+// --- Unit: ThreadDuration JSON unmarshal ---
+
+func TestThreadDurationUnmarshalJSON(t *testing.T) {
+	t.Run("float64 value", func(t *testing.T) {
+		var d model.ThreadDuration
+		if err := json.Unmarshal([]byte("5.0"), &d); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if float64(d) != 5.0 {
+			t.Errorf("got %v, want 5.0", d)
+		}
+	})
+	t.Run("ISO duration string", func(t *testing.T) {
+		var d model.ThreadDuration
+		if err := json.Unmarshal([]byte(`"PT10S"`), &d); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if float64(d) != 10.0 {
+			t.Errorf("got %v, want 10.0", d)
+		}
+	})
+}
+
+// --- Integration: threads list ---
+
+func TestThreadsList(t *testing.T) {
+	thread1 := model.Thread{ID: 1, Type: "User", Name: "Admin", Context: "REST", State: "Run", Function: "GET", ElapsedTime: 5.0, WaitTime: 0.1}
+	thread2 := model.Thread{ID: 2, Type: "Worker", Name: "UserA", Context: "Chore", State: "Idle", Function: "None", ElapsedTime: 20.0, WaitTime: 0.0}
+
+	tests := []struct {
+		name       string
+		args       []string
+		threads    []model.Thread
+		wantOut    []string
+		wantErrOut []string
+		wantExit   bool
+	}{
+		{
+			name:    "table output lists threads",
+			args:    []string{"threads", "list"},
+			threads: []model.Thread{thread1, thread2},
+			wantOut: []string{"Admin", "Run", "UserA", "Idle"},
+		},
+		{
+			name:    "empty thread list shows zero summary",
+			args:    []string{"threads", "list"},
+			threads: []model.Thread{},
+			wantOut: []string{"Showing 0 of 0"},
+		},
+		{
+			name:    "filter by state",
+			args:    []string{"threads", "list", "--state", "Run"},
+			threads: []model.Thread{thread1, thread2},
+			wantOut: []string{"Admin"},
+		},
+		{
+			name:    "filter by user",
+			args:    []string{"threads", "list", "--user", "admin"},
+			threads: []model.Thread{thread1, thread2},
+			wantOut: []string{"Admin"},
+		},
+		{
+			name:    "filter by min-elapsed",
+			args:    []string{"threads", "list", "--min-elapsed", "10s"},
+			threads: []model.Thread{thread1, thread2},
+			wantOut: []string{"UserA"},
+		},
+		{
+			name:     "invalid min-elapsed returns error",
+			args:     []string{"threads", "list", "--min-elapsed", "bad"},
+			threads:  []model.Thread{thread1},
+			wantExit: true,
+		},
+		{
+			name:    "verbose mode shows endpoint",
+			args:    []string{"threads", "list", "--verbose"},
+			threads: []model.Thread{thread1},
+			wantErrOut: []string{"Threads"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resetCmdFlags(t)
+			ts := setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.Write(threadsJSON(tt.threads...))
+			})
+			_ = ts
+
+			cap := captureAll(t, func() {
+				rootCmd.SetArgs(tt.args)
+				rootCmd.Execute()
+			})
+
+			if tt.wantExit && cap.Stderr == "" {
+				t.Error("expected error output but got none")
+			}
+			for _, want := range tt.wantOut {
+				if !strings.Contains(cap.Stdout, want) {
+					t.Errorf("stdout missing %q\nstdout: %s", want, cap.Stdout)
+				}
+			}
+			for _, want := range tt.wantErrOut {
+				if !strings.Contains(cap.Stderr, want) {
+					t.Errorf("stderr missing %q\nstderr: %s", want, cap.Stderr)
+				}
+			}
+		})
+	}
+}
+
+// TestThreadsListJSON verifies JSON output shape.
+func TestThreadsListJSON(t *testing.T) {
+	resetCmdFlags(t)
+	thread := model.Thread{ID: 42, Type: "User", Name: "Admin", State: "Run", ElapsedTime: 5.0}
+	ts := setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(threadsJSON(thread))
+	})
+	_ = ts
+
+	out := captureStdout(t, func() {
+		rootCmd.SetArgs([]string{"threads", "list", "--output", "json"})
+		rootCmd.Execute()
+	})
+
+	var result []model.Thread
+	if err := json.Unmarshal([]byte(out), &result); err != nil {
+		t.Fatalf("invalid JSON output: %v\noutput: %s", err, out)
+	}
+	if len(result) != 1 {
+		t.Fatalf("expected 1 thread, got %d", len(result))
+	}
+	if result[0].ID != 42 {
+		t.Errorf("ID = %d, want 42", result[0].ID)
+	}
+	if result[0].State != "Run" {
+		t.Errorf("State = %q, want Run", result[0].State)
+	}
+}
+
+// TestThreadsListAll verifies --all disables the 50-row default cap.
+func TestThreadsListAll(t *testing.T) {
+	resetCmdFlags(t)
+	threads := make([]model.Thread, 60)
+	for i := range threads {
+		threads[i] = model.Thread{ID: int64(i + 1), Name: "user", State: "Idle"}
+	}
+	ts := setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(threadsJSON(threads...))
+	})
+	_ = ts
+
+	out := captureStdout(t, func() {
+		rootCmd.SetArgs([]string{"threads", "list", "--all"})
+		rootCmd.Execute()
+	})
+
+	if strings.Contains(out, "Showing 50 of 60") {
+		t.Error("--all should not truncate to 50, but output suggests it did")
+	}
+	if !strings.Contains(out, "Showing 60 of 60") {
+		t.Errorf("expected 'Showing 60 of 60' in output, got: %s", out)
+	}
+}

--- a/cmd/threads_test.go
+++ b/cmd/threads_test.go
@@ -255,12 +255,38 @@ func TestThreadsListTruncation(t *testing.T) {
 	})
 
 	if !strings.Contains(gotURL, "$top=") {
-		t.Errorf("expected $top in request URL to limit server fetch, got: %s", gotURL)
+		t.Errorf("expected $top in request URL when no filters active, got: %s", gotURL)
 	}
 	if !strings.Contains(cap.Stderr, "Showing 50 of 55") {
 		t.Errorf("expected truncation summary on stderr, got: %s", cap.Stderr)
 	}
 	if strings.Contains(cap.Stderr, "--filter") {
 		t.Errorf("truncation hint must not reference --filter (threads list has no such flag), got: %s", cap.Stderr)
+	}
+}
+
+// TestThreadsListFilterSkipsTop verifies $top is omitted when client-side filters are active,
+// so the full thread collection is available for filtering without silent omissions.
+func TestThreadsListFilterSkipsTop(t *testing.T) {
+	resetCmdFlags(t)
+	threads := []model.Thread{
+		{ID: 1, Name: "Admin", State: "Run"},
+		{ID: 2, Name: "UserA", State: "Idle"},
+	}
+	var gotURL string
+	ts := setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		gotURL = r.URL.String()
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(threadsJSON(threads...))
+	})
+	_ = ts
+
+	captureAll(t, func() {
+		rootCmd.SetArgs([]string{"threads", "list", "--state", "Run"})
+		rootCmd.Execute()
+	})
+
+	if strings.Contains(gotURL, "$top=") {
+		t.Errorf("$top must not be sent when --state filter is active (could silently omit matching threads), got: %s", gotURL)
 	}
 }

--- a/cmd/threads_test.go
+++ b/cmd/threads_test.go
@@ -255,4 +255,7 @@ func TestThreadsListTruncation(t *testing.T) {
 	if !strings.Contains(cap.Stderr, "Showing 50 of 55") {
 		t.Errorf("expected truncation summary on stderr, got: %s", cap.Stderr)
 	}
+	if strings.Contains(cap.Stderr, "--filter") {
+		t.Errorf("truncation hint must not reference --filter (threads list has no such flag), got: %s", cap.Stderr)
+	}
 }

--- a/cmd/threads_test.go
+++ b/cmd/threads_test.go
@@ -78,6 +78,8 @@ func TestFormatThreadDuration(t *testing.T) {
 		{1.5, "1.5s"},
 		{59.9, "59.9s"},
 		{90.0, "1m30s"},
+		{3600.0, "1h0m0s"},
+		{5400.0, "1h30m0s"},
 	}
 	for _, tt := range tests {
 		got := formatThreadDuration(model.ThreadDuration(tt.secs))

--- a/cmd/threads_test.go
+++ b/cmd/threads_test.go
@@ -231,3 +231,26 @@ func TestThreadsListAll(t *testing.T) {
 		t.Errorf("expected at least 60 data rows, got output:\n%s", cap.Stdout)
 	}
 }
+
+// TestThreadsListTruncation verifies the default 50-row cap fires and the summary goes to stderr.
+func TestThreadsListTruncation(t *testing.T) {
+	resetCmdFlags(t)
+	threads := make([]model.Thread, 55)
+	for i := range threads {
+		threads[i] = model.Thread{ID: int64(i + 1), Name: "user", State: "Idle"}
+	}
+	ts := setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(threadsJSON(threads...))
+	})
+	_ = ts
+
+	cap := captureAll(t, func() {
+		rootCmd.SetArgs([]string{"threads", "list"})
+		rootCmd.Execute()
+	})
+
+	if !strings.Contains(cap.Stderr, "Showing 50 of 55") {
+		t.Errorf("expected truncation summary on stderr, got: %s", cap.Stderr)
+	}
+}

--- a/cmd/threads_test.go
+++ b/cmd/threads_test.go
@@ -87,50 +87,6 @@ func TestFormatThreadDuration(t *testing.T) {
 	}
 }
 
-// --- Unit: parseODataDuration ---
-
-func TestParseODataDuration(t *testing.T) {
-	tests := []struct {
-		input string
-		want  float64
-	}{
-		{"PT10S", 10.0},
-		{"PT1M30S", 90.0},
-		{"PT1H0M0S", 3600.0},
-		{"duration'PT10S'", 10.0},
-		{"PT0.5S", 0.5},
-	}
-	for _, tt := range tests {
-		got := parseODataDuration(tt.input)
-		if got != tt.want {
-			t.Errorf("parseODataDuration(%q) = %v, want %v", tt.input, got, tt.want)
-		}
-	}
-}
-
-// --- Unit: ThreadDuration JSON unmarshal ---
-
-func TestThreadDurationUnmarshalJSON(t *testing.T) {
-	t.Run("float64 value", func(t *testing.T) {
-		var d model.ThreadDuration
-		if err := json.Unmarshal([]byte("5.0"), &d); err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if float64(d) != 5.0 {
-			t.Errorf("got %v, want 5.0", d)
-		}
-	})
-	t.Run("ISO duration string", func(t *testing.T) {
-		var d model.ThreadDuration
-		if err := json.Unmarshal([]byte(`"PT10S"`), &d); err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if float64(d) != 10.0 {
-			t.Errorf("got %v, want 10.0", d)
-		}
-	})
-}
-
 // --- Integration: threads list ---
 
 func TestThreadsList(t *testing.T) {
@@ -152,10 +108,9 @@ func TestThreadsList(t *testing.T) {
 			wantOut: []string{"Admin", "Run", "UserA", "Idle"},
 		},
 		{
-			name:    "empty thread list shows zero summary",
+			name:    "empty thread list produces no error",
 			args:    []string{"threads", "list"},
 			threads: []model.Thread{},
-			wantOut: []string{"Showing 0 of 0"},
 		},
 		{
 			name:    "filter by state",
@@ -263,15 +218,16 @@ func TestThreadsListAll(t *testing.T) {
 	})
 	_ = ts
 
-	out := captureStdout(t, func() {
+	cap := captureAll(t, func() {
 		rootCmd.SetArgs([]string{"threads", "list", "--all"})
 		rootCmd.Execute()
 	})
 
-	if strings.Contains(out, "Showing 50 of 60") {
-		t.Error("--all should not truncate to 50, but output suggests it did")
+	if strings.Contains(cap.Stderr, "Showing 50 of 60") {
+		t.Error("--all should not truncate to 50")
 	}
-	if !strings.Contains(out, "Showing 60 of 60") {
-		t.Errorf("expected 'Showing 60 of 60' in output, got: %s", out)
+	// 60 data rows + 1 header = at least 61 lines in the table output
+	if strings.Count(cap.Stdout, "\n") < 61 {
+		t.Errorf("expected at least 60 data rows, got output:\n%s", cap.Stdout)
 	}
 }

--- a/cmd/threads_test.go
+++ b/cmd/threads_test.go
@@ -73,6 +73,7 @@ func TestFormatThreadDuration(t *testing.T) {
 		secs float64
 		want string
 	}{
+		{-1.0, "0ms"},
 		{0.0, "0ms"},
 		{0.5, "500ms"},
 		{1.5, "1.5s"},

--- a/internal/model/thread.go
+++ b/internal/model/thread.go
@@ -26,6 +26,8 @@ func (d *ThreadDuration) UnmarshalJSON(b []byte) error {
 
 // ParseODataDuration parses ISO 8601 / OData Edm.Duration strings to seconds.
 // Handles: "PT10.5S", "PT1M30S", "PT1H0M10S", "duration'PT10S'"
+// Day components (e.g. "P1DT10S") are not supported — the day digit is discarded.
+// TM1 thread durations are always sub-day so this is not a practical concern.
 func ParseODataDuration(s string) float64 {
 	s = strings.TrimPrefix(s, "duration'")
 	s = strings.TrimSuffix(s, "'")

--- a/internal/model/thread.go
+++ b/internal/model/thread.go
@@ -44,7 +44,7 @@ func ParseODataDuration(s string) float64 {
 	} {
 		if idx := strings.Index(s, unit.suffix); idx >= 0 {
 			v, err := strconv.ParseFloat(s[:idx], 64)
-			if err == nil {
+			if err == nil { // malformed component contributes 0; intentional silent fallback
 				total += v * unit.mult
 			}
 			s = s[idx+1:]

--- a/internal/model/thread.go
+++ b/internal/model/thread.go
@@ -1,0 +1,75 @@
+package model
+
+import (
+	"encoding/json"
+	"strconv"
+	"strings"
+)
+
+// ThreadDuration represents TM1 thread elapsed/wait time in seconds.
+// TM1 may return a float64 (legacy) or an ISO 8601 / OData Edm.Duration string.
+type ThreadDuration float64
+
+func (d *ThreadDuration) UnmarshalJSON(b []byte) error {
+	var f float64
+	if err := json.Unmarshal(b, &f); err == nil {
+		*d = ThreadDuration(f)
+		return nil
+	}
+	var s string
+	if err := json.Unmarshal(b, &s); err != nil {
+		return err
+	}
+	*d = ThreadDuration(ParseODataDuration(s))
+	return nil
+}
+
+// ParseODataDuration parses ISO 8601 / OData Edm.Duration strings to seconds.
+// Handles: "PT10.5S", "PT1M30S", "PT1H0M10S", "duration'PT10S'"
+func ParseODataDuration(s string) float64 {
+	s = strings.TrimPrefix(s, "duration'")
+	s = strings.TrimSuffix(s, "'")
+	s = strings.TrimPrefix(s, "P")
+	if idx := strings.Index(s, "T"); idx >= 0 {
+		s = s[idx+1:]
+	}
+	var total float64
+	for _, unit := range []struct {
+		suffix string
+		mult   float64
+	}{
+		{"H", 3600}, {"M", 60}, {"S", 1},
+	} {
+		if idx := strings.Index(s, unit.suffix); idx >= 0 {
+			v, err := strconv.ParseFloat(s[:idx], 64)
+			if err == nil {
+				total += v * unit.mult
+			}
+			s = s[idx+1:]
+		}
+	}
+	return total
+}
+
+// Thread represents a running thread on the TM1 server.
+type Thread struct {
+	ID          int64          `json:"ID"`
+	Type        string         `json:"Type"`
+	Name        string         `json:"Name"`
+	Context     string         `json:"Context"`
+	State       string         `json:"State"`
+	Function    string         `json:"Function"`
+	ObjectType  string         `json:"ObjectType"`
+	ObjectName  string         `json:"ObjectName"`
+	RLocks      int            `json:"RLocks"`
+	IXLocks     int            `json:"IXLocks"`
+	WLocks      int            `json:"WLocks"`
+	ElapsedTime ThreadDuration `json:"ElapsedTime"`
+	WaitTime    ThreadDuration `json:"WaitTime"`
+	Info        string         `json:"Info"`
+}
+
+// ThreadResponse is the OData collection wrapper for GET /Threads.
+type ThreadResponse struct {
+	Value []Thread `json:"value"`
+}

--- a/internal/model/thread_test.go
+++ b/internal/model/thread_test.go
@@ -1,0 +1,46 @@
+package model
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestParseODataDuration(t *testing.T) {
+	tests := []struct {
+		input string
+		want  float64
+	}{
+		{"PT10S", 10.0},
+		{"PT1M30S", 90.0},
+		{"PT1H0M0S", 3600.0},
+		{"duration'PT10S'", 10.0},
+		{"PT0.5S", 0.5},
+	}
+	for _, tt := range tests {
+		got := ParseODataDuration(tt.input)
+		if got != tt.want {
+			t.Errorf("ParseODataDuration(%q) = %v, want %v", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestThreadDurationUnmarshalJSON(t *testing.T) {
+	t.Run("float64 value", func(t *testing.T) {
+		var d ThreadDuration
+		if err := json.Unmarshal([]byte("5.0"), &d); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if float64(d) != 5.0 {
+			t.Errorf("got %v, want 5.0", d)
+		}
+	})
+	t.Run("ISO duration string", func(t *testing.T) {
+		var d ThreadDuration
+		if err := json.Unmarshal([]byte(`"PT10S"`), &d); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if float64(d) != 10.0 {
+			t.Errorf("got %v, want 10.0", d)
+		}
+	})
+}

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -23,9 +23,13 @@ func PrintJSON(data interface{}) {
 	enc.Encode(data)
 }
 
-func PrintSummary(shown int, total int) {
+func PrintSummary(shown int, total int, hints ...string) {
 	if shown < total {
-		fmt.Fprintf(os.Stderr, "Showing %d of %d. Use --filter to search or --all to show everything.\n", shown, total)
+		hint := "--filter to search or --all"
+		if len(hints) > 0 && hints[0] != "" {
+			hint = hints[0]
+		}
+		fmt.Fprintf(os.Stderr, "Showing %d of %d. Use %s to show everything.\n", shown, total, hint)
 	}
 }
 

--- a/internal/output/output_test.go
+++ b/internal/output/output_test.go
@@ -205,6 +205,7 @@ func TestPrintSummary(t *testing.T) {
 		name       string
 		shown      int
 		total      int
+		hint       string
 		wantOutput bool
 		contains   string
 	}{
@@ -234,12 +235,20 @@ func TestPrintSummary(t *testing.T) {
 			wantOutput: true,
 			contains:   "--all",
 		},
+		{
+			name:       "uses custom hint when provided",
+			shown:      5,
+			total:      100,
+			hint:       "--user, --state, or --min-elapsed to filter or --all",
+			wantOutput: true,
+			contains:   "--user, --state, or --min-elapsed",
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			output := captureStderr(t, func() {
-				PrintSummary(tt.shown, tt.total)
+				PrintSummary(tt.shown, tt.total, tt.hint)
 			})
 
 			if tt.wantOutput {


### PR DESCRIPTION
## Summary

- Add `tm1cli threads list` command via `GET /Threads` with explicit `$select`
- Introduce `Thread` model with `ThreadDuration` custom JSON type that handles both legacy `float64` seconds and current PA 3.x ISO 8601 / OData `Edm.Duration` strings (`"PT10.5S"`)
- Client-side filters: `--user` (partial match on thread name), `--state` (exact match), `--min-elapsed` (duration threshold e.g. `10s`)
- Compact 7-column table output (ID, NAME, TYPE, STATE, FUNCTION, ELAPSED, WAIT); full 14-field JSON with `--output json`
- `--all` flag bypasses the default 50-row cap; `--limit` for explicit cap

## Test plan

- [x] Unit tests for `filterThreads` (no-filter, by-user, by-state, by-min-elapsed, all-filtered-out)
- [x] Unit tests for `formatThreadDuration` (ms, seconds, minutes, hours)
- [x] Model-layer tests for `ParseODataDuration` (PT10S, PT1M30S, PT1H, duration'...' OData v3 form, fractional)
- [x] Model-layer tests for `ThreadDuration.UnmarshalJSON` (float64 and ISO string paths)
- [x] Integration: table output, JSON output shape, empty list, `--state` filter, `--user` filter, `--min-elapsed` filter, `--all`, default truncation summary, invalid `--min-elapsed` error, verbose endpoint logging
- [x] 744 tests pass (`go test ./...`)

Closes #75