### PR TITLE
feat(#78): logs messages — tail & filter the TM1 message log

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,29 @@ tm1cli threads list --all                 # no 50-row limit
 tm1cli threads list --output json         # full 14-field JSON output
 ```
 
+### Logs
+
+```bash
+tm1cli logs messages                           # show last 100 message log entries (default)
+tm1cli logs messages --tail 50                 # show last 50 entries
+tm1cli logs messages --since 1h               # entries from the past hour
+tm1cli logs messages --since 2026-04-24T10:00 # entries since absolute timestamp
+tm1cli logs messages --level error            # filter by level: info, warn, error, fatal, debug
+tm1cli logs messages --user admin             # filter by user (client-side, partial match)
+tm1cli logs messages --contains "load"        # filter by message substring (case-insensitive)
+tm1cli logs messages --follow                  # stream new entries kubectl-style (Ctrl+C to stop)
+tm1cli logs messages --follow --interval 10s  # custom poll interval
+tm1cli logs messages --raw                     # raw one-line-per-entry output
+tm1cli logs messages --output json            # JSON array output
+tm1cli logs messages --follow --output json   # NDJSON stream (one object per line)
+```
+
+Levels use canonical TM1 names: `Info`, `Warning`, `Error`, `Fatal`, `Debug`, `Unknown`, `Off`.
+Aliases `warn` and `err` are also accepted.
+
+Server-side `$filter` is used for `--since` and `--level`. If the server rejects the filter
+(HTTP 400/501), tm1cli falls back to client-side filtering with a `[warn]` message.
+
 ### Export
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ tm1cli threads list --output json         # full 14-field JSON output
 tm1cli logs messages                           # show last 100 message log entries (default)
 tm1cli logs messages --tail 50                 # show last 50 entries
 tm1cli logs messages --since 1h               # entries from the past hour
-tm1cli logs messages --since 2026-04-24T10:00 # entries since absolute timestamp
+tm1cli logs messages --since 2026-04-24T10:00 # absolute timestamp (local time when no offset)
 tm1cli logs messages --level error            # filter by level: info, warn, error, fatal, debug
 tm1cli logs messages --user admin             # filter by user (client-side, partial match)
 tm1cli logs messages --contains "load"        # filter by message substring (case-insensitive)
@@ -216,6 +216,12 @@ Aliases `warn` and `err` are also accepted.
 
 Server-side `$filter` is used for `--since` and `--level`. If the server rejects the filter
 (HTTP 400/501), tm1cli falls back to client-side filtering with a `[warn]` message.
+
+`--since` accepts a Go duration (`10m`, `2h`) or an absolute timestamp. Absolute
+timestamps without a timezone offset are interpreted in your **local** time
+zone (matching `journalctl --since`). Use RFC3339 with an explicit offset
+(e.g. `2026-04-24T10:00:00+08:00` or `2026-04-24T02:00:00Z`) when you need
+unambiguous UTC.
 
 ### Export
 

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -58,6 +58,11 @@ NDJSON (one JSON object per line) instead of a JSON array.`,
 
 // parseSince accepts a duration ("10m") or absolute timestamp and returns RFC3339 UTC.
 // Empty input returns "" with no error. Negative duration returns an error.
+//
+// Timestamps without an explicit offset (e.g. "2026-04-24T10:00") are
+// interpreted in the caller's local time zone — matching journalctl's --since
+// semantics — so a TM1 admin in UTC+8 typing "10:00" gets 10:00 *their* time,
+// not UTC 10:00. RFC3339 inputs with an explicit offset are honored as written.
 func parseSince(s string, now time.Time) (string, error) {
 	if s == "" {
 		return "", nil
@@ -68,13 +73,17 @@ func parseSince(s string, now time.Time) (string, error) {
 		}
 		return now.Add(-d).UTC().Format(time.RFC3339), nil
 	}
+	// RFC3339 carries an explicit offset; parse as-is.
+	if t, err := time.Parse(time.RFC3339, s); err == nil {
+		return t.UTC().Format(time.RFC3339), nil
+	}
+	loc := now.Location()
 	for _, layout := range []string{
-		time.RFC3339,
 		"2006-01-02T15:04:05",
 		"2006-01-02T15:04",
 		"2006-01-02",
 	} {
-		if t, err := time.Parse(layout, s); err == nil {
+		if t, err := time.ParseInLocation(layout, s, loc); err == nil {
 			return t.UTC().Format(time.RFC3339), nil
 		}
 	}
@@ -530,7 +539,7 @@ func init() {
 	rootCmd.AddCommand(logsCmd)
 	logsCmd.AddCommand(logsMessagesCmd)
 
-	logsMessagesCmd.Flags().StringVar(&logsMsgSince, "since", "", "Show entries newer than duration (e.g. 10m, 2h) or timestamp (e.g. 2026-04-24T10:00)")
+	logsMessagesCmd.Flags().StringVar(&logsMsgSince, "since", "", "Show entries newer than duration (e.g. 10m, 2h) or timestamp (e.g. 2026-04-24T10:00 — interpreted as local time when no timezone is given)")
 	logsMessagesCmd.Flags().StringVar(&logsMsgLevel, "level", "", "Filter by level: info, warn, error, fatal, debug, unknown, off")
 	logsMessagesCmd.Flags().StringVar(&logsMsgUser, "user", "", "Filter by user (client-side; matches User field or message text)")
 	logsMessagesCmd.Flags().StringVar(&logsMsgContains, "contains", "", "Filter by substring in Message (case-insensitive)")

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -307,6 +307,16 @@ func boundaryIDs(entries []model.MessageLogEntry) (string, map[string]struct{}) 
 	return maxTS, ids
 }
 
+// defaultTailIfUnbounded returns 100 when no time-bound flag is set to avoid
+// unbounded reads against multi-GB message logs. Applies in --follow too:
+// kubectl-style, show the last N entries first then stream new ones.
+func defaultTailIfUnbounded(since string, tail int) int {
+	if since == "" && tail == 0 {
+		return 100
+	}
+	return tail
+}
+
 // rawMessageReplacer collapses embedded \r\n, \n, \r, \t to single spaces
 // so raw output keeps its one-line-per-entry guarantee.
 var rawMessageReplacer = strings.NewReplacer("\r\n", " ", "\n", " ", "\r", " ", "\t", " ")
@@ -425,12 +435,7 @@ func runLogsMessages(cmd *cobra.Command, args []string) error {
 		return errSilent
 	}
 
-	// Default tail of 100 when no time-bound flag is set, to avoid unbounded reads
-	// against multi-GB message logs.
-	tail := logsMsgTail
-	if logsMsgSince == "" && tail == 0 && !logsMsgFollow {
-		tail = 100
-	}
+	tail := defaultTailIfUnbounded(logsMsgSince, logsMsgTail)
 
 	cl, err := createClient(cfg)
 	if err != nil {

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -317,6 +317,21 @@ func defaultTailIfUnbounded(since string, tail int) int {
 	return tail
 }
 
+// resolveFollowWatermark picks the starting watermark for --follow polls.
+// Falls back to now (rather than empty) when no entries were seen and no
+// --since was given, so the first poll's $filter is always bounded — without
+// it, GET /MessageLogEntries would have neither $filter nor $top and could
+// return the entire message log on every tick.
+func resolveFollowWatermark(maxTS, sinceTS string, now time.Time) string {
+	if maxTS != "" {
+		return maxTS
+	}
+	if sinceTS != "" {
+		return sinceTS
+	}
+	return now.UTC().Format(time.RFC3339)
+}
+
 // rawMessageReplacer collapses embedded \r\n, \n, \r, \t to single spaces
 // so raw output keeps its one-line-per-entry guarantee.
 var rawMessageReplacer = strings.NewReplacer("\r\n", " ", "\n", " ", "\r", " ", "\t", " ")
@@ -471,10 +486,7 @@ func runLogsMessages(cmd *cobra.Command, args []string) error {
 	}
 
 	maxTS, ids := boundaryIDs(entries)
-	if maxTS == "" {
-		// No entries seen yet; start watermark at sinceTS (or empty for "from now").
-		maxTS = sinceTS
-	}
+	maxTS = resolveFollowWatermark(maxTS, sinceTS, time.Now())
 
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer stop()

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -404,6 +404,12 @@ func followMessageLogs(ctx context.Context, cl *client.Client, watermarkTS strin
 		}
 		entries = filtered
 
+		// Compute the watermark from POST-DEDUP entries (what the server actually
+		// surfaced this poll) — not from POST-client-filter entries. Otherwise
+		// --user/--contains filtering everything out leaves the watermark frozen
+		// and every subsequent poll re-fetches the same growing window.
+		seenMaxTS, seenIDs := boundaryIDs(entries)
+
 		applySince, applyLevel := "", ""
 		if fallback {
 			applySince, applyLevel = watermarkTS, level
@@ -411,16 +417,14 @@ func followMessageLogs(ctx context.Context, cl *client.Client, watermarkTS strin
 		if applySince != "" || applyLevel != "" || user != "" || contains != "" {
 			entries = applyClientFilters(entries, applySince, applyLevel, user, contains)
 		}
-		if len(entries) == 0 {
-			continue
+
+		if len(entries) > 0 {
+			sortEntriesByTimeStamp(entries)
+			printMessageLogEntries(entries, jsonMode, rawMode, true)
 		}
 
-		sortEntriesByTimeStamp(entries)
-		printMessageLogEntries(entries, jsonMode, rawMode, true)
-
-		newMaxTS, newIDs := boundaryIDs(entries)
-		if newMaxTS != "" {
-			watermarkTS, watermarkIDs = advanceWatermark(newMaxTS, newIDs)
+		if seenMaxTS != "" {
+			watermarkTS, watermarkIDs = advanceWatermark(seenMaxTS, seenIDs)
 		}
 	}
 }
@@ -504,7 +508,10 @@ func runLogsMessages(cmd *cobra.Command, args []string) error {
 		sortEntriesByTimeStamp(entries)
 	}
 
-	printMessageLogEntries(entries, jsonMode, logsMsgRaw, false)
+	// In --follow + --output json, the initial batch must also be NDJSON so the
+	// stream is uniform — otherwise downstream parsers see a JSON array followed
+	// by raw JSON objects and reject the input as invalid.
+	printMessageLogEntries(entries, jsonMode, logsMsgRaw, logsMsgFollow)
 
 	if !logsMsgFollow {
 		return nil

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -187,15 +187,40 @@ func isFilterRejection(err error) bool {
 	return false
 }
 
+// fallbackSafetyCap is used as $top when the server rejects $filter and the
+// caller did not supply --tail. Without it, --since-only queries would
+// retry as a bare GET /MessageLogEntries and pull the whole log.
+const fallbackSafetyCap = 1000
+
+// fallbackBuffer over-fetches when --tail is set, leaving room for client-side
+// filtering to still surface ~tail matching entries. Mirrors the +500 buffer
+// peer commands (cmd/process.go, cmd/cubes.go) use.
+const fallbackBuffer = 500
+
+// fallbackRetryTop returns the $top value to use on a filter-rejection retry.
+// When no --tail was given (top=0), cap at fallbackSafetyCap. When --tail is set,
+// inflate by fallbackBuffer so client-side filtering doesn't starve the result.
+func fallbackRetryTop(top int) int {
+	if top == 0 {
+		return fallbackSafetyCap
+	}
+	return top + fallbackBuffer
+}
+
 // fetchMessageLogEntries performs GET. On HTTP 400/501 with a filter-rejection body,
-// it retries without $filter (preserving $top and $orderby) and returns fallback=true.
+// it retries without $filter (with a safety-capped $top) and returns fallback=true.
 // On auth (401/403), not-found (404), or network errors the error propagates unchanged.
 func fetchMessageLogEntries(cl *client.Client, filter string, top int, orderDesc bool) ([]model.MessageLogEntry, bool, error) {
 	endpoint := buildMessageLogQuery(filter, top, orderDesc)
 	data, err := cl.Get(endpoint)
 	if err != nil {
 		if filter != "" && isFilterRejection(err) {
-			retryEndpoint := buildMessageLogQuery("", top, orderDesc)
+			retryTop := fallbackRetryTop(top)
+			// Always order DESC on fallback so the safety cap retains the most
+			// recent entries — otherwise a --since query with the cap could
+			// return the 1000 oldest entries (since epoch) instead of the 1000
+			// newest within the window.
+			retryEndpoint := buildMessageLogQuery("", retryTop, true)
 			retryData, retryErr := cl.Get(retryEndpoint)
 			if retryErr != nil {
 				return nil, false, retryErr
@@ -204,7 +229,7 @@ func fetchMessageLogEntries(cl *client.Client, filter string, top int, orderDesc
 			if jsonErr := json.Unmarshal(retryData, &resp); jsonErr != nil {
 				return nil, false, fmt.Errorf("cannot parse server response: %w", jsonErr)
 			}
-			output.PrintWarning("Server-side filter not supported, filtering locally...")
+			output.PrintWarning(fmt.Sprintf("Server-side filter not supported, filtering locally (capped at %d entries)...", retryTop))
 			return resp.Value, true, nil
 		}
 		return nil, false, err
@@ -463,7 +488,7 @@ func runLogsMessages(cmd *cobra.Command, args []string) error {
 	jsonMode := isJSONOutput(cfg)
 
 	if logsMsgRaw && jsonMode {
-		output.PrintError("--raw cannot be combined with --output json.", false)
+		output.PrintError("--raw cannot be combined with --output json.", jsonMode)
 		return errSilent
 	}
 

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -1,0 +1,487 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/url"
+	"os"
+	"os/signal"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+	"tm1cli/internal/client"
+	"tm1cli/internal/model"
+	"tm1cli/internal/output"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	logsMsgSince    string
+	logsMsgLevel    string
+	logsMsgUser     string
+	logsMsgContains string
+	logsMsgFollow   bool
+	logsMsgInterval time.Duration
+	logsMsgTail     int
+	logsMsgRaw      bool
+)
+
+var logsCmd = &cobra.Command{
+	Use:   "logs",
+	Short: "Inspect TM1 server logs",
+	Long:  `Inspect TM1 server logs (message log, etc.).`,
+}
+
+var logsMessagesCmd = &cobra.Command{
+	Use:   "messages",
+	Short: "Show and stream the TM1 message log",
+	Long: `Show and stream the TM1 message log.
+
+REST API: GET /MessageLogEntries
+
+Filter by time range, severity, user, or message content. Use --follow
+to stream new entries kubectl-style; --tail to show the last N entries.
+
+When --follow is combined with --output json, entries are emitted as
+NDJSON (one JSON object per line) instead of a JSON array.`,
+	Example: `  tm1cli logs messages --tail 50
+  tm1cli logs messages --since 10m --level error
+  tm1cli logs messages --follow --interval 10s
+  tm1cli logs messages --user admin --contains "load"
+  tm1cli logs messages --since 2026-04-24T10:00 --raw`,
+	RunE: runLogsMessages,
+}
+
+// parseSince accepts a duration ("10m") or absolute timestamp and returns RFC3339 UTC.
+// Empty input returns "" with no error. Negative duration returns an error.
+func parseSince(s string, now time.Time) (string, error) {
+	if s == "" {
+		return "", nil
+	}
+	if d, err := time.ParseDuration(s); err == nil {
+		if d <= 0 {
+			return "", fmt.Errorf("--since duration must be positive (got %q)", s)
+		}
+		return now.Add(-d).UTC().Format(time.RFC3339), nil
+	}
+	for _, layout := range []string{
+		time.RFC3339,
+		"2006-01-02T15:04:05",
+		"2006-01-02T15:04",
+		"2006-01-02",
+	} {
+		if t, err := time.Parse(layout, s); err == nil {
+			return t.UTC().Format(time.RFC3339), nil
+		}
+	}
+	return "", fmt.Errorf("--since value %q is not a duration (e.g. 10m) or timestamp (e.g. 2026-04-24T10:00)", s)
+}
+
+// validateLevel accepts a TM1 LogLevel enum case-insensitively.
+// Canonical: Info, Warning, Error, Fatal, Debug, Unknown, Off.
+// Aliases: warn → Warning, err → Error.
+// Empty returns "" with no error.
+func validateLevel(s string) (string, error) {
+	if s == "" {
+		return "", nil
+	}
+	switch strings.ToLower(s) {
+	case "info":
+		return "Info", nil
+	case "warn", "warning":
+		return "Warning", nil
+	case "err", "error":
+		return "Error", nil
+	case "fatal":
+		return "Fatal", nil
+	case "debug":
+		return "Debug", nil
+	case "unknown":
+		return "Unknown", nil
+	case "off":
+		return "Off", nil
+	default:
+		return "", fmt.Errorf("--level must be one of: info, warn, error, fatal, debug, unknown, off (got %q)", s)
+	}
+}
+
+// parseTimeStamp parses a TM1-style timestamp (RFC3339 with/without Z, optional fractional seconds).
+func parseTimeStamp(s string) (time.Time, error) {
+	for _, layout := range []string{
+		time.RFC3339Nano,
+		time.RFC3339,
+		"2006-01-02T15:04:05",
+		"2006-01-02T15:04:05.999",
+	} {
+		if t, err := time.Parse(layout, s); err == nil {
+			return t.UTC(), nil
+		}
+	}
+	return time.Time{}, fmt.Errorf("cannot parse timestamp: %q", s)
+}
+
+// buildMessageLogFilter assembles the server-side $filter from sinceTS and level only.
+// User is NEVER included — it is handled client-side.
+func buildMessageLogFilter(sinceTS, level string) string {
+	var parts []string
+	if sinceTS != "" {
+		parts = append(parts, fmt.Sprintf("TimeStamp ge %s", sinceTS))
+	}
+	if level != "" {
+		parts = append(parts, fmt.Sprintf("Level eq '%s'", level))
+	}
+	return strings.Join(parts, " and ")
+}
+
+// buildMessageLogQuery builds the full endpoint URL path with $filter, $top, and $orderby
+// using url.Values for safe encoding.
+func buildMessageLogQuery(filter string, top int, orderDesc bool) string {
+	v := url.Values{}
+	if filter != "" {
+		v.Set("$filter", filter)
+	}
+	if top > 0 {
+		v.Set("$top", strconv.Itoa(top))
+	}
+	if orderDesc {
+		v.Set("$orderby", "TimeStamp desc")
+	}
+	if len(v) == 0 {
+		return "MessageLogEntries"
+	}
+	return "MessageLogEntries?" + v.Encode()
+}
+
+// isFilterRejection returns true for HTTP 400/501 with a body referencing
+// filter/orderby/not-supported keywords.
+// Auth errors (401/403) and not-found (404) are NOT filter rejections.
+func isFilterRejection(err error) bool {
+	if errors.Is(err, client.ErrNotFound) {
+		return false
+	}
+	msg := err.Error()
+	if strings.Contains(msg, "Authentication failed") {
+		return false
+	}
+	if strings.HasPrefix(msg, "HTTP 400") || strings.HasPrefix(msg, "HTTP 501") {
+		lower := strings.ToLower(msg)
+		return strings.Contains(lower, "filter") ||
+			strings.Contains(lower, "$filter") ||
+			strings.Contains(lower, "orderby") ||
+			strings.Contains(lower, "not supported") ||
+			strings.Contains(lower, "not implemented")
+	}
+	return false
+}
+
+// fetchMessageLogEntries performs GET. On HTTP 400/501 with a filter-rejection body,
+// it retries without $filter (preserving $top and $orderby) and returns fallback=true.
+// On auth (401/403), not-found (404), or network errors the error propagates unchanged.
+func fetchMessageLogEntries(cl *client.Client, filter string, top int, orderDesc bool) ([]model.MessageLogEntry, bool, error) {
+	endpoint := buildMessageLogQuery(filter, top, orderDesc)
+	data, err := cl.Get(endpoint)
+	if err != nil {
+		if filter != "" && isFilterRejection(err) {
+			retryEndpoint := buildMessageLogQuery("", top, orderDesc)
+			retryData, retryErr := cl.Get(retryEndpoint)
+			if retryErr != nil {
+				return nil, false, retryErr
+			}
+			var resp model.MessageLogResponse
+			if jsonErr := json.Unmarshal(retryData, &resp); jsonErr != nil {
+				return nil, false, fmt.Errorf("Cannot parse server response.")
+			}
+			output.PrintWarning("Server-side filter not supported, filtering locally...")
+			return resp.Value, true, nil
+		}
+		return nil, false, err
+	}
+	var resp model.MessageLogResponse
+	if err := json.Unmarshal(data, &resp); err != nil {
+		return nil, false, fmt.Errorf("Cannot parse server response.")
+	}
+	return resp.Value, false, nil
+}
+
+// applyClientFilters applies user/contains filters always; on fallback also applies since/level.
+// User filter matches entry.User if present, else searches entry.Message (case-insensitive).
+func applyClientFilters(entries []model.MessageLogEntry, sinceTS, level, user, contains string) []model.MessageLogEntry {
+	var sinceT time.Time
+	if sinceTS != "" {
+		sinceT, _ = parseTimeStamp(sinceTS)
+	}
+	uLower := strings.ToLower(user)
+	cLower := strings.ToLower(contains)
+
+	out := make([]model.MessageLogEntry, 0, len(entries))
+	for _, e := range entries {
+		if !sinceT.IsZero() {
+			t, err := parseTimeStamp(e.TimeStamp)
+			if err != nil || t.Before(sinceT) {
+				continue
+			}
+		}
+		if level != "" && !strings.EqualFold(e.Level, level) {
+			continue
+		}
+		if user != "" {
+			matched := false
+			if e.User != "" {
+				matched = strings.Contains(strings.ToLower(e.User), uLower)
+			} else {
+				matched = strings.Contains(strings.ToLower(e.Message), uLower)
+			}
+			if !matched {
+				continue
+			}
+		}
+		if contains != "" && !strings.Contains(strings.ToLower(e.Message), cLower) {
+			continue
+		}
+		out = append(out, e)
+	}
+	return out
+}
+
+// sortEntriesByTimeStamp sorts ascending; ties are broken by ID. Unparseable timestamps go to the end stably.
+func sortEntriesByTimeStamp(entries []model.MessageLogEntry) {
+	sort.SliceStable(entries, func(i, j int) bool {
+		ti, errI := parseTimeStamp(entries[i].TimeStamp)
+		tj, errJ := parseTimeStamp(entries[j].TimeStamp)
+		switch {
+		case errI != nil && errJ != nil:
+			return false
+		case errI != nil:
+			return false
+		case errJ != nil:
+			return true
+		case ti.Equal(tj):
+			return entries[i].ID < entries[j].ID
+		default:
+			return ti.Before(tj)
+		}
+	})
+}
+
+// reverseEntries reverses entries in place.
+func reverseEntries(entries []model.MessageLogEntry) {
+	for i, j := 0, len(entries)-1; i < j; i, j = i+1, j-1 {
+		entries[i], entries[j] = entries[j], entries[i]
+	}
+}
+
+// boundaryIDs returns the set of IDs whose TimeStamp equals the max in entries,
+// and the max TimeStamp string itself. Used as the dedupe set for --follow.
+func boundaryIDs(entries []model.MessageLogEntry) (string, map[string]struct{}) {
+	if len(entries) == 0 {
+		return "", nil
+	}
+	maxT, errFirst := parseTimeStamp(entries[0].TimeStamp)
+	hasMaxT := errFirst == nil
+	maxTS := entries[0].TimeStamp
+	for _, e := range entries[1:] {
+		t, err := parseTimeStamp(e.TimeStamp)
+		if err != nil {
+			continue
+		}
+		if !hasMaxT || t.After(maxT) {
+			maxT, maxTS, hasMaxT = t, e.TimeStamp, true
+		}
+	}
+	_ = maxT
+	ids := map[string]struct{}{}
+	for _, e := range entries {
+		if e.TimeStamp == maxTS && e.ID != "" {
+			ids[e.ID] = struct{}{}
+		}
+	}
+	return maxTS, ids
+}
+
+// sanitizeRawMessage replaces embedded \r\n, \n, \r, \t with single spaces
+// to preserve the one-line-per-entry guarantee in raw output.
+func sanitizeRawMessage(msg string) string {
+	r := strings.NewReplacer("\r\n", " ", "\n", " ", "\r", " ", "\t", " ")
+	return r.Replace(msg)
+}
+
+// printMessageLogEntries renders entries in the chosen format.
+// In follow+jsonMode it emits NDJSON (one object per line).
+// In raw mode it emits one sanitized line per entry.
+func printMessageLogEntries(entries []model.MessageLogEntry, jsonMode, rawMode, isFollowChunk bool) {
+	if jsonMode {
+		if isFollowChunk {
+			for _, e := range entries {
+				data, _ := json.Marshal(e)
+				fmt.Println(string(data))
+			}
+			return
+		}
+		output.PrintJSON(entries)
+		return
+	}
+	if rawMode {
+		for _, e := range entries {
+			user := e.User
+			if user == "" {
+				user = "-"
+			}
+			fmt.Printf("%s %s [%s] %s\n", e.TimeStamp, e.Level, user, sanitizeRawMessage(e.Message))
+		}
+		return
+	}
+	headers := []string{"TIME", "LEVEL", "USER", "LOGGER", "MESSAGE"}
+	rows := make([][]string, len(entries))
+	for i, e := range entries {
+		rows[i] = []string{e.TimeStamp, e.Level, e.User, e.Logger, sanitizeRawMessage(e.Message)}
+	}
+	output.PrintTable(headers, rows)
+}
+
+// followMessageLogs is the extracted polling loop driven by ctx for testability.
+func followMessageLogs(ctx context.Context, cl *client.Client, watermarkTS string, watermarkIDs map[string]struct{}, level, user, contains string, interval time.Duration, jsonMode, rawMode bool) error {
+	if watermarkIDs == nil {
+		watermarkIDs = map[string]struct{}{}
+	}
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-time.After(interval):
+		}
+
+		filter := buildMessageLogFilter(watermarkTS, level)
+		entries, fallback, err := fetchMessageLogEntries(cl, filter, 0, false)
+		if err != nil {
+			output.PrintWarning(fmt.Sprintf("poll failed: %s", err))
+			continue
+		}
+
+		// Drop entries already shown at the boundary (clock-skew dedupe).
+		filtered := entries[:0]
+		for _, e := range entries {
+			if e.ID != "" {
+				if _, seen := watermarkIDs[e.ID]; seen {
+					continue
+				}
+			}
+			filtered = append(filtered, e)
+		}
+		entries = filtered
+
+		applySince, applyLevel := "", ""
+		if fallback {
+			applySince, applyLevel = watermarkTS, level
+		}
+		if applySince != "" || applyLevel != "" || user != "" || contains != "" {
+			entries = applyClientFilters(entries, applySince, applyLevel, user, contains)
+		}
+		if len(entries) == 0 {
+			continue
+		}
+
+		sortEntriesByTimeStamp(entries)
+		printMessageLogEntries(entries, jsonMode, rawMode, true)
+
+		newMaxTS, newIDs := boundaryIDs(entries)
+		if newMaxTS != "" {
+			watermarkTS = newMaxTS
+			watermarkIDs = newIDs
+		}
+	}
+}
+
+func runLogsMessages(cmd *cobra.Command, args []string) error {
+	cfg, err := loadConfig()
+	if err != nil {
+		output.PrintError(err.Error(), isJSONOutput(nil))
+		return errSilent
+	}
+	jsonMode := isJSONOutput(cfg)
+
+	if logsMsgRaw && jsonMode {
+		output.PrintError("--raw cannot be combined with --output json.", false)
+		return errSilent
+	}
+
+	level, err := validateLevel(logsMsgLevel)
+	if err != nil {
+		output.PrintError(err.Error(), jsonMode)
+		return errSilent
+	}
+	sinceTS, err := parseSince(logsMsgSince, time.Now())
+	if err != nil {
+		output.PrintError(err.Error(), jsonMode)
+		return errSilent
+	}
+
+	// Default: when no time-bound flag is set, tail 100 to avoid unbounded reads.
+	tail := logsMsgTail
+	if logsMsgSince == "" && tail == 0 && !logsMsgFollow {
+		tail = 100
+	}
+
+	cl, err := createClient(cfg)
+	if err != nil {
+		output.PrintError(err.Error(), jsonMode)
+		return errSilent
+	}
+
+	filter := buildMessageLogFilter(sinceTS, level)
+	entries, fallback, err := fetchMessageLogEntries(cl, filter, tail, tail > 0)
+	if err != nil {
+		output.PrintError(err.Error(), jsonMode)
+		return errSilent
+	}
+
+	// Apply client-side filters: always for user/contains; also since/level on fallback.
+	applySince, applyLevel := "", ""
+	if fallback {
+		applySince, applyLevel = sinceTS, level
+	}
+	if applySince != "" || applyLevel != "" || logsMsgUser != "" || logsMsgContains != "" {
+		entries = applyClientFilters(entries, applySince, applyLevel, logsMsgUser, logsMsgContains)
+	}
+
+	if tail > 0 {
+		// Server returned descending (newest-first); reverse for chronological display.
+		reverseEntries(entries)
+	} else {
+		sortEntriesByTimeStamp(entries)
+	}
+
+	printMessageLogEntries(entries, jsonMode, logsMsgRaw, false)
+
+	if !logsMsgFollow {
+		return nil
+	}
+
+	maxTS, ids := boundaryIDs(entries)
+	if maxTS == "" {
+		// No entries seen yet; start watermark at sinceTS (or empty for "from now").
+		maxTS = sinceTS
+	}
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
+	defer stop()
+
+	return followMessageLogs(ctx, cl, maxTS, ids, level, logsMsgUser, logsMsgContains, logsMsgInterval, jsonMode, logsMsgRaw)
+}
+
+func init() {
+	rootCmd.AddCommand(logsCmd)
+	logsCmd.AddCommand(logsMessagesCmd)
+
+	logsMessagesCmd.Flags().StringVar(&logsMsgSince, "since", "", "Show entries newer than duration (e.g. 10m, 2h) or timestamp (e.g. 2026-04-24T10:00)")
+	logsMessagesCmd.Flags().StringVar(&logsMsgLevel, "level", "", "Filter by level: info, warn, error, fatal, debug, unknown, off")
+	logsMessagesCmd.Flags().StringVar(&logsMsgUser, "user", "", "Filter by user (client-side; matches User field or message text)")
+	logsMessagesCmd.Flags().StringVar(&logsMsgContains, "contains", "", "Filter by substring in Message (case-insensitive)")
+	logsMessagesCmd.Flags().BoolVarP(&logsMsgFollow, "follow", "f", false, "Stream new entries kubectl-style (--output json emits NDJSON)")
+	logsMessagesCmd.Flags().DurationVar(&logsMsgInterval, "interval", 5*time.Second, "Polling interval when --follow is set")
+	logsMessagesCmd.Flags().IntVar(&logsMsgTail, "tail", 0, "Show last N entries (defaults to 100 when no --since/--follow)")
+	logsMessagesCmd.Flags().BoolVar(&logsMsgRaw, "raw", false, "Raw output: one line per entry")
+}

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -193,7 +193,7 @@ func fetchMessageLogEntries(cl *client.Client, filter string, top int, orderDesc
 			}
 			var resp model.MessageLogResponse
 			if jsonErr := json.Unmarshal(retryData, &resp); jsonErr != nil {
-				return nil, false, fmt.Errorf("Cannot parse server response.")
+				return nil, false, fmt.Errorf("cannot parse server response: %w", jsonErr)
 			}
 			output.PrintWarning("Server-side filter not supported, filtering locally...")
 			return resp.Value, true, nil
@@ -202,7 +202,7 @@ func fetchMessageLogEntries(cl *client.Client, filter string, top int, orderDesc
 	}
 	var resp model.MessageLogResponse
 	if err := json.Unmarshal(data, &resp); err != nil {
-		return nil, false, fmt.Errorf("Cannot parse server response.")
+		return nil, false, fmt.Errorf("cannot parse server response: %w", err)
 	}
 	return resp.Value, false, nil
 }
@@ -214,6 +214,7 @@ func applyClientFilters(entries []model.MessageLogEntry, sinceTS, level, user, c
 	if sinceTS != "" {
 		sinceT, _ = parseTimeStamp(sinceTS)
 	}
+	levelLower := strings.ToLower(level)
 	uLower := strings.ToLower(user)
 	cLower := strings.ToLower(contains)
 
@@ -225,21 +226,26 @@ func applyClientFilters(entries []model.MessageLogEntry, sinceTS, level, user, c
 				continue
 			}
 		}
-		if level != "" && !strings.EqualFold(e.Level, level) {
+		if level != "" && strings.ToLower(e.Level) != levelLower {
 			continue
+		}
+		var msgLower string
+		needsMsg := contains != "" || (user != "" && e.User == "")
+		if needsMsg {
+			msgLower = strings.ToLower(e.Message)
 		}
 		if user != "" {
 			matched := false
 			if e.User != "" {
 				matched = strings.Contains(strings.ToLower(e.User), uLower)
 			} else {
-				matched = strings.Contains(strings.ToLower(e.Message), uLower)
+				matched = strings.Contains(msgLower, uLower)
 			}
 			if !matched {
 				continue
 			}
 		}
-		if contains != "" && !strings.Contains(strings.ToLower(e.Message), cLower) {
+		if contains != "" && !strings.Contains(msgLower, cLower) {
 			continue
 		}
 		out = append(out, e)
@@ -292,7 +298,6 @@ func boundaryIDs(entries []model.MessageLogEntry) (string, map[string]struct{}) 
 			maxT, maxTS, hasMaxT = t, e.TimeStamp, true
 		}
 	}
-	_ = maxT
 	ids := map[string]struct{}{}
 	for _, e := range entries {
 		if e.TimeStamp == maxTS && e.ID != "" {
@@ -302,11 +307,12 @@ func boundaryIDs(entries []model.MessageLogEntry) (string, map[string]struct{}) 
 	return maxTS, ids
 }
 
-// sanitizeRawMessage replaces embedded \r\n, \n, \r, \t with single spaces
-// to preserve the one-line-per-entry guarantee in raw output.
+// rawMessageReplacer collapses embedded \r\n, \n, \r, \t to single spaces
+// so raw output keeps its one-line-per-entry guarantee.
+var rawMessageReplacer = strings.NewReplacer("\r\n", " ", "\n", " ", "\r", " ", "\t", " ")
+
 func sanitizeRawMessage(msg string) string {
-	r := strings.NewReplacer("\r\n", " ", "\n", " ", "\r", " ", "\t", " ")
-	return r.Replace(msg)
+	return rawMessageReplacer.Replace(msg)
 }
 
 // printMessageLogEntries renders entries in the chosen format.
@@ -419,7 +425,8 @@ func runLogsMessages(cmd *cobra.Command, args []string) error {
 		return errSilent
 	}
 
-	// Default: when no time-bound flag is set, tail 100 to avoid unbounded reads.
+	// Default tail of 100 when no time-bound flag is set, to avoid unbounded reads
+	// against multi-GB message logs.
 	tail := logsMsgTail
 	if logsMsgSince == "" && tail == 0 && !logsMsgFollow {
 		tail = 100
@@ -438,7 +445,6 @@ func runLogsMessages(cmd *cobra.Command, args []string) error {
 		return errSilent
 	}
 
-	// Apply client-side filters: always for user/contains; also since/level on fallback.
 	applySince, applyLevel := "", ""
 	if fallback {
 		applySince, applyLevel = sinceTS, level
@@ -448,7 +454,6 @@ func runLogsMessages(cmd *cobra.Command, args []string) error {
 	}
 
 	if tail > 0 {
-		// Server returned descending (newest-first); reverse for chronological display.
 		reverseEntries(entries)
 	} else {
 		sortEntriesByTimeStamp(entries)

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -420,10 +420,25 @@ func followMessageLogs(ctx context.Context, cl *client.Client, watermarkTS strin
 
 		newMaxTS, newIDs := boundaryIDs(entries)
 		if newMaxTS != "" {
-			watermarkTS = newMaxTS
-			watermarkIDs = newIDs
+			watermarkTS, watermarkIDs = advanceWatermark(newMaxTS, newIDs)
 		}
 	}
+}
+
+// advanceWatermark returns the next polling watermark + dedupe set. When the
+// boundary entries lack IDs (older TM1 versions), advance past the boundary
+// by 1ms so the inclusive `TimeStamp ge` filter doesn't re-fetch them — we
+// have nothing to dedupe them against. With sub-second resolution rare in
+// TM1 message logs, this is unlikely to skip real entries.
+func advanceWatermark(maxTS string, ids map[string]struct{}) (string, map[string]struct{}) {
+	if len(ids) > 0 {
+		return maxTS, ids
+	}
+	t, err := parseTimeStamp(maxTS)
+	if err != nil {
+		return maxTS, map[string]struct{}{}
+	}
+	return t.Add(time.Millisecond).UTC().Format(time.RFC3339Nano), map[string]struct{}{}
 }
 
 func runLogsMessages(cmd *cobra.Command, args []string) error {
@@ -436,6 +451,16 @@ func runLogsMessages(cmd *cobra.Command, args []string) error {
 
 	if logsMsgRaw && jsonMode {
 		output.PrintError("--raw cannot be combined with --output json.", false)
+		return errSilent
+	}
+
+	if logsMsgTail < 0 {
+		output.PrintError("--tail must be non-negative.", jsonMode)
+		return errSilent
+	}
+
+	if logsMsgFollow && logsMsgInterval <= 0 {
+		output.PrintError("--interval must be greater than zero (e.g. 5s).", jsonMode)
 		return errSilent
 	}
 

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -187,39 +187,27 @@ func isFilterRejection(err error) bool {
 	return false
 }
 
-// fallbackSafetyCap is used as $top when the server rejects $filter and the
-// caller did not supply --tail. Without it, --since-only queries would
-// retry as a bare GET /MessageLogEntries and pull the whole log.
+// fallbackSafetyCap bounds the fallback retry when the caller did not supply
+// --tail (top=0). Without it, a --since-only query whose $filter the server
+// rejects would retry as a bare GET /MessageLogEntries and pull the whole log.
 const fallbackSafetyCap = 1000
 
-// fallbackBuffer over-fetches when --tail is set, leaving room for client-side
-// filtering to still surface ~tail matching entries. Mirrors the +500 buffer
-// peer commands (cmd/process.go, cmd/cubes.go) use.
-const fallbackBuffer = 500
-
-// fallbackRetryTop returns the $top value to use on a filter-rejection retry.
-// When no --tail was given (top=0), cap at fallbackSafetyCap. When --tail is set,
-// inflate by fallbackBuffer so client-side filtering doesn't starve the result.
-func fallbackRetryTop(top int) int {
-	if top == 0 {
-		return fallbackSafetyCap
-	}
-	return top + fallbackBuffer
-}
-
 // fetchMessageLogEntries performs GET. On HTTP 400/501 with a filter-rejection body,
-// it retries without $filter (with a safety-capped $top) and returns fallback=true.
-// On auth (401/403), not-found (404), or network errors the error propagates unchanged.
+// it retries without $filter (capping $top at fallbackSafetyCap when no --tail was
+// given) and returns fallback=true. On auth (401/403), not-found (404), or network
+// errors the error propagates unchanged.
 func fetchMessageLogEntries(cl *client.Client, filter string, top int, orderDesc bool) ([]model.MessageLogEntry, bool, error) {
 	endpoint := buildMessageLogQuery(filter, top, orderDesc)
 	data, err := cl.Get(endpoint)
 	if err != nil {
 		if filter != "" && isFilterRejection(err) {
-			retryTop := fallbackRetryTop(top)
-			// Always order DESC on fallback so the safety cap retains the most
-			// recent entries — otherwise a --since query with the cap could
-			// return the 1000 oldest entries (since epoch) instead of the 1000
-			// newest within the window.
+			retryTop := top
+			if retryTop == 0 {
+				retryTop = fallbackSafetyCap
+			}
+			// Always order DESC on retry so the cap retains the most recent
+			// entries — otherwise a --since query could return the oldest 1000
+			// entries (since epoch) instead of the 1000 newest in the window.
 			retryEndpoint := buildMessageLogQuery("", retryTop, true)
 			retryData, retryErr := cl.Get(retryEndpoint)
 			if retryErr != nil {
@@ -229,7 +217,7 @@ func fetchMessageLogEntries(cl *client.Client, filter string, top int, orderDesc
 			if jsonErr := json.Unmarshal(retryData, &resp); jsonErr != nil {
 				return nil, false, fmt.Errorf("cannot parse server response: %w", jsonErr)
 			}
-			output.PrintWarning(fmt.Sprintf("Server-side filter not supported, filtering locally (capped at %d entries)...", retryTop))
+			output.PrintWarning("Server-side filter not supported, filtering locally...")
 			return resp.Value, true, nil
 		}
 		return nil, false, err

--- a/cmd/logs_test.go
+++ b/cmd/logs_test.go
@@ -633,6 +633,29 @@ func TestDefaultTailIfUnbounded(t *testing.T) {
 	}
 }
 
+func TestResolveFollowWatermark(t *testing.T) {
+	now := time.Date(2026, 4, 25, 12, 0, 0, 0, time.UTC)
+	const nowFormatted = "2026-04-25T12:00:00Z"
+
+	tests := []struct {
+		name    string
+		maxTS   string
+		sinceTS string
+		want    string
+	}{
+		{"maxTS wins when present", "2026-04-25T11:50:00Z", "2026-04-25T10:00:00Z", "2026-04-25T11:50:00Z"},
+		{"sinceTS used when maxTS empty", "", "2026-04-25T10:00:00Z", "2026-04-25T10:00:00Z"},
+		{"falls back to now when both empty", "", "", nowFormatted},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := resolveFollowWatermark(tt.maxTS, tt.sinceTS, now); got != tt.want {
+				t.Errorf("resolveFollowWatermark(%q, %q, now) = %q, want %q", tt.maxTS, tt.sinceTS, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestRunLogsMessages_DefaultsToTail100(t *testing.T) {
 	resetCmdFlags(t)
 
@@ -1483,6 +1506,53 @@ func TestFollowMessageLogs_NDJSONOutput(t *testing.T) {
 	}
 	if !strings.Contains(out.Stdout, "ndjson-entry") {
 		t.Errorf("stdout should contain 'ndjson-entry', got:\n%s", out.Stdout)
+	}
+}
+
+// TestFollowMessageLogs_BoundedWhenWatermarkSeededFromNow guards against the regression
+// where bare --follow (no --since, initial fetch returns 0 entries) left the watermark
+// empty and produced an unbounded GET on every poll.
+func TestFollowMessageLogs_BoundedWhenWatermarkSeededFromNow(t *testing.T) {
+	resetCmdFlags(t)
+
+	var pollCount int32
+	var firstFilter string
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&pollCount, 1)
+		if n == 1 {
+			decoded, _ := decodedQuery(r.URL.RawQuery)
+			firstFilter = decoded
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(messageLogJSON())
+	})
+
+	cfg, _ := loadConfig()
+	cl, _ := createClient(cfg)
+
+	watermark := resolveFollowWatermark("", "", time.Now())
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	captureAll(t, func() {
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			followMessageLogs(ctx, cl, watermark, nil, "", "", "", 5*time.Millisecond, false, false)
+		}()
+
+		for i := 0; i < 100; i++ {
+			if atomic.LoadInt32(&pollCount) >= 1 {
+				break
+			}
+			time.Sleep(5 * time.Millisecond)
+		}
+		cancel()
+		<-done
+	})
+
+	if !strings.Contains(firstFilter, "$filter=TimeStamp ge ") {
+		t.Errorf("first follow poll should carry $filter=TimeStamp ge ..., got query: %q", firstFilter)
 	}
 }
 

--- a/cmd/logs_test.go
+++ b/cmd/logs_test.go
@@ -633,6 +633,118 @@ func TestDefaultTailIfUnbounded(t *testing.T) {
 	}
 }
 
+func TestAdvanceWatermark(t *testing.T) {
+	t.Run("returns inputs unchanged when ids present", func(t *testing.T) {
+		ids := map[string]struct{}{"a": {}}
+		gotTS, gotIDs := advanceWatermark("2026-04-25T10:00:00Z", ids)
+		if gotTS != "2026-04-25T10:00:00Z" {
+			t.Errorf("ts = %q, want unchanged", gotTS)
+		}
+		if len(gotIDs) != 1 {
+			t.Errorf("ids should be unchanged, got %v", gotIDs)
+		}
+	})
+	t.Run("advances by 1ms when ids empty", func(t *testing.T) {
+		gotTS, gotIDs := advanceWatermark("2026-04-25T10:00:00Z", map[string]struct{}{})
+		if gotTS != "2026-04-25T10:00:00.001Z" {
+			t.Errorf("ts = %q, want 2026-04-25T10:00:00.001Z", gotTS)
+		}
+		if len(gotIDs) != 0 {
+			t.Errorf("ids should be empty, got %v", gotIDs)
+		}
+	})
+	t.Run("advances by 1ms when ids nil", func(t *testing.T) {
+		gotTS, _ := advanceWatermark("2026-04-25T10:00:00Z", nil)
+		if gotTS != "2026-04-25T10:00:00.001Z" {
+			t.Errorf("ts = %q, want 2026-04-25T10:00:00.001Z", gotTS)
+		}
+	})
+	t.Run("returns input ts unchanged when unparseable", func(t *testing.T) {
+		gotTS, gotIDs := advanceWatermark("not-a-timestamp", nil)
+		if gotTS != "not-a-timestamp" {
+			t.Errorf("ts = %q, want unchanged", gotTS)
+		}
+		if gotIDs == nil {
+			t.Error("ids should be non-nil empty map, got nil")
+		}
+	})
+}
+
+func TestRunLogsMessages_NegativeTailRejected(t *testing.T) {
+	resetCmdFlags(t)
+	logsMsgTail = -1
+
+	var requestCount int32
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&requestCount, 1)
+		w.WriteHeader(http.StatusOK)
+		w.Write(messageLogJSON())
+	})
+
+	out := captureAll(t, func() {
+		err := runLogsMessages(logsMessagesCmd, nil)
+		if err != errSilent {
+			t.Fatalf("expected errSilent, got: %v", err)
+		}
+	})
+
+	if !strings.Contains(out.Stderr, "--tail must be non-negative") {
+		t.Errorf("stderr should reject negative --tail, got: %q", out.Stderr)
+	}
+	if got := atomic.LoadInt32(&requestCount); got != 0 {
+		t.Errorf("expected 0 HTTP requests, got %d", got)
+	}
+}
+
+func TestRunLogsMessages_ZeroIntervalWithFollowRejected(t *testing.T) {
+	resetCmdFlags(t)
+	logsMsgFollow = true
+	logsMsgInterval = 0
+
+	var requestCount int32
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&requestCount, 1)
+		w.WriteHeader(http.StatusOK)
+		w.Write(messageLogJSON())
+	})
+
+	out := captureAll(t, func() {
+		err := runLogsMessages(logsMessagesCmd, nil)
+		if err != errSilent {
+			t.Fatalf("expected errSilent, got: %v", err)
+		}
+	})
+
+	if !strings.Contains(out.Stderr, "--interval must be greater than zero") {
+		t.Errorf("stderr should reject zero --interval, got: %q", out.Stderr)
+	}
+	if got := atomic.LoadInt32(&requestCount); got != 0 {
+		t.Errorf("expected 0 HTTP requests, got %d", got)
+	}
+}
+
+func TestRunLogsMessages_NegativeIntervalWithFollowRejected(t *testing.T) {
+	resetCmdFlags(t)
+	logsMsgFollow = true
+	logsMsgInterval = -5 * time.Second
+
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write(messageLogJSON())
+	})
+
+	out := captureAll(t, func() {
+		err := runLogsMessages(logsMessagesCmd, nil)
+		if err != errSilent {
+			t.Fatalf("expected errSilent, got: %v", err)
+		}
+	})
+
+	if !strings.Contains(out.Stderr, "--interval must be greater than zero") {
+		t.Errorf("stderr should reject negative --interval, got: %q", out.Stderr)
+	}
+}
+
 func TestResolveFollowWatermark(t *testing.T) {
 	now := time.Date(2026, 4, 25, 12, 0, 0, 0, time.UTC)
 	const nowFormatted = "2026-04-25T12:00:00Z"
@@ -1369,6 +1481,57 @@ func TestFollowMessageLogs_DropsDuplicateIDsAtBoundary(t *testing.T) {
 	}
 }
 
+func TestFollowMessageLogs_DedupesAtBoundaryWhenIDsMissing(t *testing.T) {
+	resetCmdFlags(t)
+
+	var pollCount int32
+	idLessEntry := model.MessageLogEntry{TimeStamp: "2026-04-25T10:01:00Z", Level: "Info", Message: "no-id-entry"}
+
+	// Simulate real TM1 server-side $filter behavior: parse `TimeStamp ge ...`
+	// from the query and only include the entry when its timestamp passes the
+	// filter. This is the behavior advanceWatermark relies on for ID-less entries.
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&pollCount, 1)
+		decoded, _ := decodedQuery(r.URL.RawQuery)
+		w.Header().Set("Content-Type", "application/json")
+
+		entryTS, _ := parseTimeStamp(idLessEntry.TimeStamp)
+		threshold, ok := extractTimeStampGe(decoded)
+		if ok && entryTS.Before(threshold) {
+			w.Write(messageLogJSON())
+			return
+		}
+		w.Write(messageLogJSON(idLessEntry))
+	})
+
+	cfg, _ := loadConfig()
+	cl, _ := createClient(cfg)
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	out := captureAll(t, func() {
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			followMessageLogs(ctx, cl, "2026-04-25T10:00:00Z", nil, "", "", "", 5*time.Millisecond, false, false)
+		}()
+
+		for i := 0; i < 100; i++ {
+			if atomic.LoadInt32(&pollCount) >= 3 {
+				break
+			}
+			time.Sleep(5 * time.Millisecond)
+		}
+		cancel()
+		<-done
+	})
+
+	count := strings.Count(out.Stdout, "no-id-entry")
+	if count != 1 {
+		t.Errorf("'no-id-entry' should appear exactly once (advanceWatermark moves past boundary by 1ms), got %d times in:\n%s", count, out.Stdout)
+	}
+}
+
 func TestFollowMessageLogs_ContextCancellationStopsLoop(t *testing.T) {
 	resetCmdFlags(t)
 
@@ -1563,4 +1726,25 @@ func TestFollowMessageLogs_BoundedWhenWatermarkSeededFromNow(t *testing.T) {
 // decodedQuery URL-decodes the raw query string for readable assertions.
 func decodedQuery(raw string) (string, error) {
 	return url.QueryUnescape(raw)
+}
+
+// extractTimeStampGe pulls the timestamp out of a query containing
+// `$filter=TimeStamp ge <ts>...` so test mocks can simulate TM1's
+// server-side filter. Returns ok=false when no such filter is present.
+func extractTimeStampGe(decoded string) (time.Time, bool) {
+	const marker = "TimeStamp ge "
+	idx := strings.Index(decoded, marker)
+	if idx < 0 {
+		return time.Time{}, false
+	}
+	rest := decoded[idx+len(marker):]
+	end := strings.IndexAny(rest, " &")
+	if end >= 0 {
+		rest = rest[:end]
+	}
+	t, err := parseTimeStamp(rest)
+	if err != nil {
+		return time.Time{}, false
+	}
+	return t, true
 }

--- a/cmd/logs_test.go
+++ b/cmd/logs_test.go
@@ -979,6 +979,17 @@ func TestRunLogsMessages_RawWithJSONRejected(t *testing.T) {
 	if !strings.Contains(out.Stderr, "--raw cannot be combined with --output json") {
 		t.Errorf("stderr should contain conflict message, got: %q", out.Stderr)
 	}
+	// Per project convention, errors must be JSON when --output json is set —
+	// even for flag-conflict errors that prevent JSON output of the actual data.
+	var errObj struct {
+		Error string `json:"error"`
+	}
+	stderrTrimmed := strings.TrimSpace(out.Stderr)
+	if err := json.Unmarshal([]byte(stderrTrimmed), &errObj); err != nil {
+		t.Errorf("stderr should be JSON when --output json is set, got plain text: %q (parse error: %v)", out.Stderr, err)
+	} else if !strings.Contains(errObj.Error, "--raw cannot be combined") {
+		t.Errorf("JSON error.error should mention conflict, got: %q", errObj.Error)
+	}
 }
 
 func TestRunLogsMessages_TailOrdering(t *testing.T) {
@@ -1207,6 +1218,64 @@ func TestRunLogsMessages_UserClientSide_FromMessage(t *testing.T) {
 // Integration Tests — filter fallback
 // ============================================================
 
+// TestRunLogsMessages_FilterFallbackWithSinceCapsTop guards against an
+// unbounded fallback retry when --since is set without --tail. Without the
+// safety cap, the retry would issue GET /MessageLogEntries with neither
+// $filter nor $top — pulling the entire log on busy servers.
+func TestRunLogsMessages_FilterFallbackWithSinceCapsTop(t *testing.T) {
+	resetCmdFlags(t)
+	logsMsgSince = "2026-04-24T10:00:00Z"
+
+	var requestCount int32
+	var retryQuery string
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&requestCount, 1)
+		query := r.URL.RawQuery
+		if strings.Contains(query, "%24filter") || strings.Contains(query, "$filter") {
+			w.WriteHeader(http.StatusBadRequest)
+			w.Write([]byte("$filter not supported"))
+			return
+		}
+		retryQuery = query
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(messageLogJSON())
+	})
+
+	captureAll(t, func() {
+		err := runLogsMessages(logsMessagesCmd, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	decoded, _ := decodedQuery(retryQuery)
+	if !strings.Contains(decoded, "$top=1000") {
+		t.Errorf("fallback retry with --since but no --tail should cap at $top=1000, got: %q", decoded)
+	}
+	if !strings.Contains(decoded, "$orderby=TimeStamp desc") {
+		t.Errorf("fallback retry should order desc to capture most-recent within cap, got: %q", decoded)
+	}
+}
+
+func TestFallbackRetryTop(t *testing.T) {
+	tests := []struct {
+		name string
+		top  int
+		want int
+	}{
+		{"zero top → safety cap", 0, 1000},
+		{"explicit top → buffered", 100, 600},
+		{"large top → buffered", 5000, 5500},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := fallbackRetryTop(tt.top); got != tt.want {
+				t.Errorf("fallbackRetryTop(%d) = %d, want %d", tt.top, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestRunLogsMessages_FilterFallback(t *testing.T) {
 	resetCmdFlags(t)
 	logsMsgLevel = "error"
@@ -1248,10 +1317,15 @@ func TestRunLogsMessages_FilterFallback(t *testing.T) {
 	if strings.Contains(out.Stdout, "info msg") {
 		t.Errorf("stdout should NOT contain 'info msg' (client-filtered), got:\n%s", out.Stdout)
 	}
-	// Fallback request must preserve $top=100 and $orderby
+	// Fallback retry must over-fetch (tail 100 + 500 buffer) so client-side
+	// filtering doesn't starve the visible result, and must order desc so the
+	// buffer captures the most recent entries.
 	decodedSecond, _ := decodedQuery(secondQuery)
-	if !strings.Contains(decodedSecond, "$top=100") {
-		t.Errorf("fallback query %q should still contain $top=100", decodedSecond)
+	if !strings.Contains(decodedSecond, "$top=600") {
+		t.Errorf("fallback query %q should contain $top=600 (tail 100 + 500 buffer)", decodedSecond)
+	}
+	if !strings.Contains(decodedSecond, "$orderby=TimeStamp desc") {
+		t.Errorf("fallback query %q should order by TimeStamp desc to preserve newest entries", decodedSecond)
 	}
 }
 

--- a/cmd/logs_test.go
+++ b/cmd/logs_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -1614,6 +1615,124 @@ func TestFollowMessageLogs_TransientErrorContinues(t *testing.T) {
 	}
 	if !strings.Contains(out.Stdout, "recovery-entry") {
 		t.Errorf("stdout should contain 'recovery-entry' from poll 2, got:\n%s", out.Stdout)
+	}
+}
+
+// TestPrintMessageLogEntries_FollowJSONIsNDJSON guards against the regression
+// where the initial batch in --follow --output json mode was emitted as a
+// JSON array (via output.PrintJSON) while subsequent chunks were NDJSON,
+// producing an invalid stream that downstream parsers cannot consume.
+func TestPrintMessageLogEntries_FollowJSONIsNDJSON(t *testing.T) {
+	entries := []model.MessageLogEntry{
+		{ID: "1", TimeStamp: "2026-04-25T10:01:00Z", Level: "Info", Message: "first"},
+		{ID: "2", TimeStamp: "2026-04-25T10:02:00Z", Level: "Info", Message: "second"},
+	}
+
+	out := captureStdout(t, func() {
+		printMessageLogEntries(entries, true, false, true)
+	})
+
+	trimmed := strings.TrimRight(out, "\n")
+	if strings.HasPrefix(trimmed, "[") {
+		t.Fatalf("follow+JSON initial batch must be NDJSON, but stdout starts with array '[':\n%s", out)
+	}
+	lines := strings.Split(trimmed, "\n")
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 NDJSON lines, got %d:\n%s", len(lines), out)
+	}
+	for i, line := range lines {
+		var e model.MessageLogEntry
+		if err := json.Unmarshal([]byte(line), &e); err != nil {
+			t.Errorf("line %d is not valid JSON object: %v\nline: %q", i, err, line)
+		}
+	}
+}
+
+// TestFollowMessageLogs_AdvancesWatermarkWhenAllClientFiltered guards the
+// follow loop against a poll-amplification bug: when --user/--contains
+// filters every server-returned entry, the watermark must still advance
+// off the post-dedup boundary so the next poll's $filter doesn't keep
+// re-fetching the same growing window.
+func TestFollowMessageLogs_AdvancesWatermarkWhenAllClientFiltered(t *testing.T) {
+	resetCmdFlags(t)
+
+	var pollCount int32
+	var capturedFilters []string
+	var mu sync.Mutex
+
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&pollCount, 1)
+		decoded, _ := decodedQuery(r.URL.RawQuery)
+		mu.Lock()
+		capturedFilters = append(capturedFilters, decoded)
+		mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+
+		// Server-side TimeStamp ge filter: only return entry if its timestamp
+		// passes the filter threshold (mirrors real TM1 server behavior).
+		entry := model.MessageLogEntry{
+			ID:        fmt.Sprintf("e%d", n),
+			TimeStamp: "2026-04-25T10:01:00Z",
+			Level:     "Info",
+			User:      "bob",
+			Message:   "bob entry",
+		}
+		entryTS, _ := parseTimeStamp(entry.TimeStamp)
+		if threshold, ok := extractTimeStampGe(decoded); ok && entryTS.Before(threshold) {
+			w.Write(messageLogJSON())
+			return
+		}
+		w.Write(messageLogJSON(entry))
+	})
+
+	cfg, _ := loadConfig()
+	cl, _ := createClient(cfg)
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	out := captureAll(t, func() {
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			// --user "alice" filters out all bob entries client-side
+			followMessageLogs(ctx, cl, "2026-04-25T10:00:00Z", nil, "", "alice", "", 5*time.Millisecond, false, false)
+		}()
+
+		for i := 0; i < 100; i++ {
+			if atomic.LoadInt32(&pollCount) >= 3 {
+				break
+			}
+			time.Sleep(5 * time.Millisecond)
+		}
+		cancel()
+		<-done
+	})
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	if len(capturedFilters) < 2 {
+		t.Fatalf("expected at least 2 polls, got %d", len(capturedFilters))
+	}
+
+	// Nothing should print — every entry is client-filtered.
+	if strings.Contains(out.Stdout, "bob entry") {
+		t.Errorf("stdout should be empty (all entries client-filtered), got:\n%s", out.Stdout)
+	}
+
+	// The first poll filter starts from the seed watermark.
+	if !strings.Contains(capturedFilters[0], "TimeStamp ge 2026-04-25T10:00:00Z") {
+		t.Errorf("first poll filter unexpected: %q", capturedFilters[0])
+	}
+	// The second poll filter MUST advance — otherwise the watermark is frozen
+	// and we re-fetch the same data on every tick.
+	if capturedFilters[0] == capturedFilters[1] {
+		t.Errorf("watermark should advance after a poll where client filters dropped everything; both polls used: %q", capturedFilters[0])
+	}
+	// The advanced filter should now reference the post-dedup boundary timestamp.
+	if !strings.Contains(capturedFilters[1], "2026-04-25T10:01:00") {
+		t.Errorf("second poll should advance past T1 boundary, got: %q", capturedFilters[1])
 	}
 }
 

--- a/cmd/logs_test.go
+++ b/cmd/logs_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -997,22 +998,19 @@ func TestRunLogsMessages_FilterFallback(t *testing.T) {
 	var requestCount int32
 	var secondQuery string
 	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
-		n := atomic.AddInt32(&requestCount, 1)
+		atomic.AddInt32(&requestCount, 1)
 		query := r.URL.RawQuery
 		if strings.Contains(query, "%24filter") || strings.Contains(query, "$filter") {
-			// First request: reject the filter
 			w.WriteHeader(http.StatusBadRequest)
 			w.Write([]byte("$filter not supported"))
 			return
 		}
-		// Second request: return full list
 		secondQuery = query
 		w.Header().Set("Content-Type", "application/json")
 		w.Write(messageLogJSON(
 			model.MessageLogEntry{ID: "1", TimeStamp: "2026-04-25T10:00:00Z", Level: "Info", Message: "info msg"},
 			model.MessageLogEntry{ID: "2", TimeStamp: "2026-04-25T10:01:00Z", Level: "Error", Message: "error msg"},
 		))
-		_ = n
 	})
 
 	out := captureAll(t, func() {
@@ -1216,7 +1214,7 @@ func TestFollowMessageLogs_PollsAndAdvancesWatermark(t *testing.T) {
 	var pollCount int32
 	var capturedFilters []string
 
-	ts := setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
 		n := int(atomic.AddInt32(&pollCount, 1))
 		decoded, _ := decodedQuery(r.URL.RawQuery)
 		capturedFilters = append(capturedFilters, decoded)
@@ -1235,7 +1233,6 @@ func TestFollowMessageLogs_PollsAndAdvancesWatermark(t *testing.T) {
 			w.Write(messageLogJSON())
 		}
 	})
-	_ = ts
 
 	cfg, _ := loadConfig()
 	cl, _ := createClient(cfg)
@@ -1273,7 +1270,7 @@ func TestFollowMessageLogs_DropsDuplicateIDsAtBoundary(t *testing.T) {
 
 	var pollCount int32
 
-	ts := setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
 		n := int(atomic.AddInt32(&pollCount, 1))
 		w.Header().Set("Content-Type", "application/json")
 		switch n {
@@ -1292,7 +1289,6 @@ func TestFollowMessageLogs_DropsDuplicateIDsAtBoundary(t *testing.T) {
 			w.Write(messageLogJSON())
 		}
 	})
-	_ = ts
 
 	cfg, _ := loadConfig()
 	cl, _ := createClient(cfg)
@@ -1332,11 +1328,10 @@ func TestFollowMessageLogs_DropsDuplicateIDsAtBoundary(t *testing.T) {
 func TestFollowMessageLogs_ContextCancellationStopsLoop(t *testing.T) {
 	resetCmdFlags(t)
 
-	ts := setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.Write(messageLogJSON())
 	})
-	_ = ts
 
 	cfg, _ := loadConfig()
 	cl, _ := createClient(cfg)
@@ -1365,7 +1360,7 @@ func TestFollowMessageLogs_TransientErrorContinues(t *testing.T) {
 
 	var pollCount int32
 
-	ts := setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
 		n := int(atomic.AddInt32(&pollCount, 1))
 		switch n {
 		case 1:
@@ -1383,7 +1378,6 @@ func TestFollowMessageLogs_TransientErrorContinues(t *testing.T) {
 			w.Write(messageLogJSON())
 		}
 	})
-	_ = ts
 
 	cfg, _ := loadConfig()
 	cl, _ := createClient(cfg)
@@ -1421,7 +1415,7 @@ func TestFollowMessageLogs_NDJSONOutput(t *testing.T) {
 
 	var pollCount int32
 
-	ts := setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
 		n := int(atomic.AddInt32(&pollCount, 1))
 		w.Header().Set("Content-Type", "application/json")
 		if n == 1 {
@@ -1432,7 +1426,6 @@ func TestFollowMessageLogs_NDJSONOutput(t *testing.T) {
 			w.Write(messageLogJSON())
 		}
 	})
-	_ = ts
 
 	cfg, _ := loadConfig()
 	cl, _ := createClient(cfg)
@@ -1478,27 +1471,5 @@ func TestFollowMessageLogs_NDJSONOutput(t *testing.T) {
 
 // decodedQuery URL-decodes the raw query string for readable assertions.
 func decodedQuery(raw string) (string, error) {
-	decoded := raw
-	// Replace %XX with their actual characters for comparison
-	replaced := strings.ReplaceAll(decoded, "+", " ")
-	var err error
-	// Simple iterative percent-decode
-	for strings.Contains(replaced, "%") {
-		prev := replaced
-		for i := 0; i < len(replaced)-2; i++ {
-			if replaced[i] == '%' {
-				hex := replaced[i+1 : i+3]
-				var b byte
-				_, parseErr := fmt.Sscanf(hex, "%X", &b)
-				if parseErr == nil {
-					replaced = replaced[:i] + string(b) + replaced[i+3:]
-					break
-				}
-			}
-		}
-		if replaced == prev {
-			break
-		}
-	}
-	return replaced, err
+	return url.QueryUnescape(raw)
 }

--- a/cmd/logs_test.go
+++ b/cmd/logs_test.go
@@ -18,6 +18,62 @@ import (
 // Unit Tests — parseSince
 // ============================================================
 
+// TestParseSince_TimezoneLessUsesLocal proves that absolute timestamps without
+// an explicit offset are interpreted in the caller's local time zone, not UTC.
+// Regression guard: a TM1 admin in UTC+8 typing "10:00" gets local 10:00, not
+// UTC 10:00 (off by 8 hours).
+func TestParseSince_TimezoneLessUsesLocal(t *testing.T) {
+	loc, err := time.LoadLocation("Asia/Taipei")
+	if err != nil {
+		t.Fatalf("cannot load Asia/Taipei: %v", err)
+	}
+	now := time.Date(2026, 4, 25, 12, 0, 0, 0, loc)
+
+	tests := []struct {
+		name  string
+		input string
+		want  string // expected RFC3339 UTC output
+	}{
+		{
+			name:  "date-time without seconds → local time UTC-shifted",
+			input: "2026-04-24T10:00",
+			want:  "2026-04-24T02:00:00Z", // 10:00 +08:00 = 02:00 UTC
+		},
+		{
+			name:  "date-time with seconds → local time UTC-shifted",
+			input: "2026-04-24T10:00:00",
+			want:  "2026-04-24T02:00:00Z",
+		},
+		{
+			name:  "date-only → local midnight UTC-shifted",
+			input: "2026-04-24",
+			want:  "2026-04-23T16:00:00Z", // 00:00 +08:00 = 16:00 UTC prior day
+		},
+		{
+			name:  "RFC3339 with explicit offset honored as written",
+			input: "2026-04-24T10:00:00+09:00",
+			want:  "2026-04-24T01:00:00Z",
+		},
+		{
+			name:  "RFC3339 with Z stays UTC regardless of caller location",
+			input: "2026-04-24T10:00:00Z",
+			want:  "2026-04-24T10:00:00Z",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseSince(tt.input, now)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("parseSince(%q, now in Asia/Taipei) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestParseSince(t *testing.T) {
 	now := time.Date(2026, 4, 25, 12, 0, 0, 0, time.UTC)
 
@@ -1025,7 +1081,10 @@ func TestRunLogsMessages_SinceDuration(t *testing.T) {
 
 func TestRunLogsMessages_SinceAbsolute(t *testing.T) {
 	resetCmdFlags(t)
-	logsMsgSince = "2026-04-24T10:00"
+	// Use an explicit Z so the assertion is portable across CI/dev time zones —
+	// TZ-less inputs are now interpreted in local time, exercised separately
+	// in TestParseSince_TimezoneLessUsesLocal.
+	logsMsgSince = "2026-04-24T10:00:00Z"
 
 	var capturedQuery string
 	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {

--- a/cmd/logs_test.go
+++ b/cmd/logs_test.go
@@ -612,6 +612,27 @@ func TestIsFilterRejection(t *testing.T) {
 // Integration Tests — output and basic flow
 // ============================================================
 
+func TestDefaultTailIfUnbounded(t *testing.T) {
+	tests := []struct {
+		name  string
+		since string
+		tail  int
+		want  int
+	}{
+		{"no flags defaults to 100", "", 0, 100},
+		{"explicit tail preserved", "", 50, 50},
+		{"since set, tail stays 0", "2026-04-25T10:00:00Z", 0, 0},
+		{"both set", "2026-04-25T10:00:00Z", 50, 50},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := defaultTailIfUnbounded(tt.since, tt.tail); got != tt.want {
+				t.Errorf("defaultTailIfUnbounded(%q, %d) = %d, want %d", tt.since, tt.tail, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestRunLogsMessages_DefaultsToTail100(t *testing.T) {
 	resetCmdFlags(t)
 

--- a/cmd/logs_test.go
+++ b/cmd/logs_test.go
@@ -1,0 +1,1504 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+	"tm1cli/internal/model"
+)
+
+// ============================================================
+// Unit Tests — parseSince
+// ============================================================
+
+func TestParseSince(t *testing.T) {
+	now := time.Date(2026, 4, 25, 12, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name    string
+		input   string
+		want    string
+		wantErr string
+	}{
+		{
+			name:  "empty input returns empty",
+			input: "",
+			want:  "",
+		},
+		{
+			name:  "parse 10m duration",
+			input: "10m",
+			want:  "2026-04-25T11:50:00Z",
+		},
+		{
+			name:  "parse 2h duration",
+			input: "2h",
+			want:  "2026-04-25T10:00:00Z",
+		},
+		{
+			name:  "parse RFC3339 absolute",
+			input: "2026-04-24T10:00:00Z",
+			want:  "2026-04-24T10:00:00Z",
+		},
+		{
+			name:  "parse short timestamp without seconds",
+			input: "2026-04-24T10:00",
+			want:  "2026-04-24T10:00:00Z",
+		},
+		{
+			name:  "parse date-only",
+			input: "2026-04-24",
+			want:  "2026-04-24T00:00:00Z",
+		},
+		{
+			name:    "error on garbage",
+			input:   "garbage",
+			wantErr: "not a duration",
+		},
+		{
+			name:    "error on negative duration",
+			input:   "-5m",
+			wantErr: "positive",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseSince(tt.input, now)
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tt.wantErr)
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Errorf("error = %q, want it to contain %q", err.Error(), tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("parseSince(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+// ============================================================
+// Unit Tests — validateLevel
+// ============================================================
+
+func TestValidateLevel(t *testing.T) {
+	tests := []struct {
+		input   string
+		want    string
+		wantErr string
+	}{
+		{"info", "Info", ""},
+		{"INFO", "Info", ""},
+		{"Info", "Info", ""},
+		{"warn", "Warning", ""},
+		{"warning", "Warning", ""},
+		{"WARNING", "Warning", ""},
+		{"error", "Error", ""},
+		{"err", "Error", ""},
+		{"ERROR", "Error", ""},
+		{"fatal", "Fatal", ""},
+		{"FATAL", "Fatal", ""},
+		{"debug", "Debug", ""},
+		{"DEBUG", "Debug", ""},
+		{"unknown", "Unknown", ""},
+		{"UNKNOWN", "Unknown", ""},
+		{"off", "Off", ""},
+		{"OFF", "Off", ""},
+		{"", "", ""},
+		{"trace", "", "info, warn, error"},
+		{"verbose", "", "info, warn, error"},
+	}
+
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("input=%q", tt.input), func(t *testing.T) {
+			got, err := validateLevel(tt.input)
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tt.wantErr)
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Errorf("error = %q, want it to contain %q", err.Error(), tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("validateLevel(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+// ============================================================
+// Unit Tests — parseTimeStamp
+// ============================================================
+
+func TestParseTimeStamp(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantUTC string
+		wantErr bool
+	}{
+		{
+			name:    "RFC3339 with Z",
+			input:   "2026-04-25T10:00:00Z",
+			wantUTC: "2026-04-25T10:00:00Z",
+		},
+		{
+			name:    "RFC3339 with positive offset",
+			input:   "2026-04-25T18:00:00+08:00",
+			wantUTC: "2026-04-25T10:00:00Z",
+		},
+		{
+			name:    "RFC3339Nano with fractional seconds",
+			input:   "2026-04-25T10:00:00.123456789Z",
+			wantUTC: "2026-04-25T10:00:00.123456789Z",
+		},
+		{
+			name:    "no-Z timestamp",
+			input:   "2026-04-25T10:00:00",
+			wantUTC: "2026-04-25T10:00:00Z",
+		},
+		{
+			name:    "invalid",
+			input:   "not-a-time",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseTimeStamp(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got time %v", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			wantT, _ := time.Parse(time.RFC3339Nano, tt.wantUTC)
+			if !got.Equal(wantT) {
+				t.Errorf("parseTimeStamp(%q) = %v, want %v", tt.input, got.UTC(), wantT.UTC())
+			}
+		})
+	}
+}
+
+// ============================================================
+// Unit Tests — buildMessageLogFilter
+// ============================================================
+
+func TestBuildMessageLogFilter(t *testing.T) {
+	tests := []struct {
+		name    string
+		sinceTS string
+		level   string
+		want    string
+	}{
+		{
+			name:    "empty inputs returns empty",
+			sinceTS: "",
+			level:   "",
+			want:    "",
+		},
+		{
+			name:    "sinceTS only",
+			sinceTS: "2026-04-25T10:00:00Z",
+			level:   "",
+			want:    "TimeStamp ge 2026-04-25T10:00:00Z",
+		},
+		{
+			name:    "level only",
+			sinceTS: "",
+			level:   "Error",
+			want:    "Level eq 'Error'",
+		},
+		{
+			name:    "both sinceTS and level",
+			sinceTS: "2026-04-25T10:00:00Z",
+			level:   "Error",
+			want:    "TimeStamp ge 2026-04-25T10:00:00Z and Level eq 'Error'",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildMessageLogFilter(tt.sinceTS, tt.level)
+			if got != tt.want {
+				t.Errorf("buildMessageLogFilter(%q, %q) = %q, want %q", tt.sinceTS, tt.level, got, tt.want)
+			}
+			// Regression guard: User must NEVER appear in the filter.
+			if strings.Contains(got, "User") {
+				t.Errorf("filter must not include 'User', got %q", got)
+			}
+		})
+	}
+}
+
+// ============================================================
+// Unit Tests — buildMessageLogQuery
+// ============================================================
+
+func TestBuildMessageLogQuery(t *testing.T) {
+	tests := []struct {
+		name      string
+		filter    string
+		top       int
+		orderDesc bool
+		wantParts []string
+	}{
+		{
+			name: "no flags returns base endpoint only",
+		},
+		{
+			name:      "filter only",
+			filter:    "TimeStamp ge 2026-04-25T10:00:00Z",
+			wantParts: []string{"$filter="},
+		},
+		{
+			name:      "all three: filter top orderDesc",
+			filter:    "Level eq 'Error'",
+			top:       50,
+			orderDesc: true,
+			wantParts: []string{"$filter=", "$top=50", "$orderby="},
+		},
+		{
+			name:      "top only",
+			top:       100,
+			orderDesc: false,
+			wantParts: []string{"$top=100"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildMessageLogQuery(tt.filter, tt.top, tt.orderDesc)
+			if !strings.HasPrefix(got, "MessageLogEntries") {
+				t.Errorf("query should start with 'MessageLogEntries', got %q", got)
+			}
+			if tt.filter == "" && tt.top == 0 && !tt.orderDesc {
+				if got != "MessageLogEntries" {
+					t.Errorf("got %q, want 'MessageLogEntries'", got)
+				}
+				return
+			}
+			// Decode the URL-encoded query for readable assertions.
+			decoded, _ := decodedQuery(got)
+			for _, part := range tt.wantParts {
+				if !strings.Contains(decoded, part) {
+					t.Errorf("decoded query %q should contain %q", decoded, part)
+				}
+			}
+		})
+	}
+}
+
+// ============================================================
+// Unit Tests — applyClientFilters
+// ============================================================
+
+func TestApplyClientFilters(t *testing.T) {
+	baseEntries := []model.MessageLogEntry{
+		{ID: "1", TimeStamp: "2026-04-25T10:00:00Z", Level: "Info", User: "alice", Message: "foo bar"},
+		{ID: "2", TimeStamp: "2026-04-25T11:00:00Z", Level: "Error", User: "bob", Message: "BAR baz"},
+		{ID: "3", TimeStamp: "2026-04-25T12:00:00Z", Level: "Warning", User: "alice", Message: "barbaz qux"},
+		{ID: "4", TimeStamp: "2026-04-25T09:00:00Z", Level: "Info", User: "", Message: "alice did X"},
+		{ID: "5", TimeStamp: "2026-04-25T09:30:00Z", Level: "Info", User: "", Message: "bob did Y"},
+	}
+
+	t.Run("contains matches case-insensitively", func(t *testing.T) {
+		got := applyClientFilters(baseEntries, "", "", "", "bar")
+		if len(got) != 3 {
+			t.Fatalf("got %d entries, want 3", len(got))
+		}
+		ids := map[string]bool{}
+		for _, e := range got {
+			ids[e.ID] = true
+		}
+		for _, id := range []string{"1", "2", "3"} {
+			if !ids[id] {
+				t.Errorf("expected ID %q in results", id)
+			}
+		}
+	})
+
+	t.Run("user matches User field when present", func(t *testing.T) {
+		got := applyClientFilters(baseEntries, "", "", "alice", "")
+		// Should match ID 1 (User=alice), 3 (User=alice), and 4 (User="" but Message has "alice")
+		if len(got) != 3 {
+			t.Fatalf("got %d entries, want 3", len(got))
+		}
+	})
+
+	t.Run("user matches Message when User field is empty", func(t *testing.T) {
+		// Only entries with User="" should fall through to message match
+		entries := []model.MessageLogEntry{
+			{ID: "4", TimeStamp: "2026-04-25T09:00:00Z", Level: "Info", User: "", Message: "alice did X"},
+			{ID: "5", TimeStamp: "2026-04-25T09:30:00Z", Level: "Info", User: "", Message: "bob did Y"},
+		}
+		got := applyClientFilters(entries, "", "", "alice", "")
+		if len(got) != 1 || got[0].ID != "4" {
+			t.Errorf("expected only entry 4, got %v", got)
+		}
+	})
+
+	t.Run("since (fallback) drops older entries", func(t *testing.T) {
+		// entries 4 and 5 are at 09:00 and 09:30; since 10:00 should drop them
+		got := applyClientFilters(baseEntries, "2026-04-25T10:00:00Z", "", "", "")
+		for _, e := range got {
+			if e.ID == "4" || e.ID == "5" {
+				t.Errorf("entry %q should have been dropped by since filter", e.ID)
+			}
+		}
+	})
+
+	t.Run("level (fallback) keeps only matching", func(t *testing.T) {
+		got := applyClientFilters(baseEntries, "", "Error", "", "")
+		if len(got) != 1 || got[0].ID != "2" {
+			t.Errorf("expected only ID=2 (Error), got %v", got)
+		}
+	})
+
+	t.Run("all four together keeps only matching entries", func(t *testing.T) {
+		// All four: since=10:00, level=Error, user=bob, contains=bar
+		got := applyClientFilters(baseEntries, "2026-04-25T10:00:00Z", "Error", "bob", "bar")
+		if len(got) != 1 || got[0].ID != "2" {
+			t.Errorf("expected only ID=2, got %v", got)
+		}
+	})
+}
+
+// ============================================================
+// Unit Tests — sortEntriesByTimeStamp
+// ============================================================
+
+func TestSortEntriesByTimeStamp(t *testing.T) {
+	t.Run("sorts ascending by parsed time", func(t *testing.T) {
+		entries := []model.MessageLogEntry{
+			{ID: "3", TimeStamp: "2026-04-25T12:00:00Z"},
+			{ID: "1", TimeStamp: "2026-04-25T10:00:00Z"},
+			{ID: "2", TimeStamp: "2026-04-25T11:00:00Z"},
+		}
+		sortEntriesByTimeStamp(entries)
+		wantIDs := []string{"1", "2", "3"}
+		for i, id := range wantIDs {
+			if entries[i].ID != id {
+				t.Errorf("entries[%d].ID = %q, want %q", i, entries[i].ID, id)
+			}
+		}
+	})
+
+	t.Run("ties broken by ID ascending", func(t *testing.T) {
+		entries := []model.MessageLogEntry{
+			{ID: "b", TimeStamp: "2026-04-25T10:00:00Z"},
+			{ID: "a", TimeStamp: "2026-04-25T10:00:00Z"},
+			{ID: "c", TimeStamp: "2026-04-25T10:00:00Z"},
+		}
+		sortEntriesByTimeStamp(entries)
+		if entries[0].ID != "a" || entries[1].ID != "b" || entries[2].ID != "c" {
+			t.Errorf("expected [a, b, c], got [%s, %s, %s]", entries[0].ID, entries[1].ID, entries[2].ID)
+		}
+	})
+
+	t.Run("entries with unparseable timestamps go to the end", func(t *testing.T) {
+		entries := []model.MessageLogEntry{
+			{ID: "bad", TimeStamp: "not-a-time"},
+			{ID: "good1", TimeStamp: "2026-04-25T10:00:00Z"},
+			{ID: "good2", TimeStamp: "2026-04-25T11:00:00Z"},
+		}
+		sortEntriesByTimeStamp(entries)
+		if entries[0].ID != "good1" {
+			t.Errorf("expected good1 first, got %q", entries[0].ID)
+		}
+		if entries[1].ID != "good2" {
+			t.Errorf("expected good2 second, got %q", entries[1].ID)
+		}
+		if entries[2].ID != "bad" {
+			t.Errorf("expected bad last, got %q", entries[2].ID)
+		}
+	})
+}
+
+// ============================================================
+// Unit Tests — reverseEntries
+// ============================================================
+
+func TestReverseEntries(t *testing.T) {
+	t.Run("reverses 3 entries in place", func(t *testing.T) {
+		entries := []model.MessageLogEntry{
+			{ID: "1"},
+			{ID: "2"},
+			{ID: "3"},
+		}
+		reverseEntries(entries)
+		if entries[0].ID != "3" || entries[1].ID != "2" || entries[2].ID != "1" {
+			t.Errorf("expected [3,2,1], got [%s,%s,%s]", entries[0].ID, entries[1].ID, entries[2].ID)
+		}
+	})
+
+	t.Run("empty slice no-op", func(t *testing.T) {
+		entries := []model.MessageLogEntry{}
+		reverseEntries(entries)
+		if len(entries) != 0 {
+			t.Errorf("expected empty slice, got %v", entries)
+		}
+	})
+}
+
+// ============================================================
+// Unit Tests — sanitizeRawMessage
+// ============================================================
+
+func TestSanitizeRawMessage(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"a\nb", "a b"},
+		{"a\r\nb", "a b"},
+		{"a\tb", "a b"},
+		{"no special chars", "no special chars"},
+		{"", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("input=%q", tt.input), func(t *testing.T) {
+			got := sanitizeRawMessage(tt.input)
+			if got != tt.want {
+				t.Errorf("sanitizeRawMessage(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+// ============================================================
+// Unit Tests — boundaryIDs
+// ============================================================
+
+func TestBoundaryIDs(t *testing.T) {
+	t.Run("empty returns empty", func(t *testing.T) {
+		maxTS, ids := boundaryIDs(nil)
+		if maxTS != "" {
+			t.Errorf("maxTS = %q, want empty", maxTS)
+		}
+		if ids != nil {
+			t.Errorf("ids should be nil, got %v", ids)
+		}
+	})
+
+	t.Run("single entry returns its TS and ID", func(t *testing.T) {
+		entries := []model.MessageLogEntry{
+			{ID: "abc", TimeStamp: "2026-04-25T10:00:00Z"},
+		}
+		maxTS, ids := boundaryIDs(entries)
+		if maxTS != "2026-04-25T10:00:00Z" {
+			t.Errorf("maxTS = %q, want 2026-04-25T10:00:00Z", maxTS)
+		}
+		if _, ok := ids["abc"]; !ok {
+			t.Error("expected 'abc' in boundary IDs")
+		}
+	})
+
+	t.Run("multiple distinct timestamps returns max TS and its IDs", func(t *testing.T) {
+		entries := []model.MessageLogEntry{
+			{ID: "1", TimeStamp: "2026-04-25T10:00:00Z"},
+			{ID: "2", TimeStamp: "2026-04-25T12:00:00Z"},
+			{ID: "3", TimeStamp: "2026-04-25T11:00:00Z"},
+		}
+		maxTS, ids := boundaryIDs(entries)
+		if maxTS != "2026-04-25T12:00:00Z" {
+			t.Errorf("maxTS = %q, want 2026-04-25T12:00:00Z", maxTS)
+		}
+		if _, ok := ids["2"]; !ok {
+			t.Error("expected '2' in boundary IDs")
+		}
+		if _, ok := ids["1"]; ok {
+			t.Error("'1' should NOT be in boundary IDs")
+		}
+	})
+
+	t.Run("multiple entries at same max TS — all their IDs in set", func(t *testing.T) {
+		entries := []model.MessageLogEntry{
+			{ID: "a", TimeStamp: "2026-04-25T12:00:00Z"},
+			{ID: "b", TimeStamp: "2026-04-25T12:00:00Z"},
+			{ID: "c", TimeStamp: "2026-04-25T10:00:00Z"},
+		}
+		maxTS, ids := boundaryIDs(entries)
+		if maxTS != "2026-04-25T12:00:00Z" {
+			t.Errorf("maxTS = %q, want 2026-04-25T12:00:00Z", maxTS)
+		}
+		for _, id := range []string{"a", "b"} {
+			if _, ok := ids[id]; !ok {
+				t.Errorf("expected %q in boundary IDs", id)
+			}
+		}
+		if _, ok := ids["c"]; ok {
+			t.Error("'c' should NOT be in boundary IDs")
+		}
+	})
+}
+
+// ============================================================
+// Unit Tests — isFilterRejection
+// ============================================================
+
+func TestIsFilterRejection(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "HTTP 400 with $filter body is rejection",
+			err:  fmt.Errorf("HTTP 400: Invalid $filter expression"),
+			want: true,
+		},
+		{
+			name: "HTTP 400 with orderby not supported",
+			err:  fmt.Errorf("HTTP 400: orderby not supported"),
+			want: true,
+		},
+		{
+			name: "HTTP 501 Not implemented",
+			err:  fmt.Errorf("HTTP 501: Not implemented"),
+			want: true,
+		},
+		{
+			name: "Authentication failed is not rejection",
+			err:  fmt.Errorf("Authentication failed."),
+			want: false,
+		},
+		{
+			name: "HTTP 500 server error is not rejection",
+			err:  fmt.Errorf("HTTP 500: Internal server error"),
+			want: false,
+		},
+		{
+			name: "HTTP 400 without filter keywords is not rejection",
+			err:  fmt.Errorf("HTTP 400: Bad request"),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isFilterRejection(tt.err)
+			if got != tt.want {
+				t.Errorf("isFilterRejection(%q) = %v, want %v", tt.err.Error(), got, tt.want)
+			}
+		})
+	}
+}
+
+// ============================================================
+// Integration Tests — output and basic flow
+// ============================================================
+
+func TestRunLogsMessages_DefaultsToTail100(t *testing.T) {
+	resetCmdFlags(t)
+
+	var capturedURL string
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		capturedURL = r.URL.RawQuery
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(messageLogJSON(
+			model.MessageLogEntry{ID: "1", TimeStamp: "2026-04-25T10:00:00Z", Level: "Info", Message: "first"},
+			model.MessageLogEntry{ID: "2", TimeStamp: "2026-04-25T10:01:00Z", Level: "Info", Message: "second"},
+			model.MessageLogEntry{ID: "3", TimeStamp: "2026-04-25T10:02:00Z", Level: "Info", Message: "third"},
+		))
+	})
+
+	out := captureAll(t, func() {
+		err := runLogsMessages(logsMessagesCmd, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	decoded, err := decodedQuery(capturedURL)
+	if err != nil {
+		t.Fatalf("cannot decode query: %v", err)
+	}
+	if !strings.Contains(decoded, "$top=100") {
+		t.Errorf("URL query %q should contain $top=100", decoded)
+	}
+	if !strings.Contains(decoded, "$orderby=TimeStamp desc") {
+		t.Errorf("URL query %q should contain $orderby=TimeStamp desc", decoded)
+	}
+	// Entries reversed for chronological display
+	if !strings.Contains(out.Stdout, "first") {
+		t.Errorf("stdout should contain 'first'")
+	}
+}
+
+func TestRunLogsMessages_TableOutput(t *testing.T) {
+	resetCmdFlags(t)
+
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(messageLogJSON(
+			model.MessageLogEntry{ID: "1", TimeStamp: "2026-04-25T10:00:00Z", Level: "Info", User: "alice", Logger: "System", Message: "msg1"},
+			model.MessageLogEntry{ID: "2", TimeStamp: "2026-04-25T10:01:00Z", Level: "Error", User: "bob", Logger: "App", Message: "msg2"},
+			model.MessageLogEntry{ID: "3", TimeStamp: "2026-04-25T10:02:00Z", Level: "Warning", User: "carol", Logger: "DB", Message: "msg3"},
+		))
+	})
+
+	out := captureAll(t, func() {
+		err := runLogsMessages(logsMessagesCmd, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	for _, header := range []string{"TIME", "LEVEL", "USER", "LOGGER", "MESSAGE"} {
+		if !strings.Contains(out.Stdout, header) {
+			t.Errorf("stdout missing header %q", header)
+		}
+	}
+	for _, msg := range []string{"msg1", "msg2", "msg3"} {
+		if !strings.Contains(out.Stdout, msg) {
+			t.Errorf("stdout missing %q", msg)
+		}
+	}
+}
+
+func TestRunLogsMessages_JSONOutput(t *testing.T) {
+	resetCmdFlags(t)
+	flagOutput = "json"
+
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(messageLogJSON(
+			model.MessageLogEntry{ID: "1", TimeStamp: "2026-04-25T10:00:00Z", Level: "Info", Message: "hello"},
+			model.MessageLogEntry{ID: "2", TimeStamp: "2026-04-25T10:01:00Z", Level: "Error", Message: "world"},
+		))
+	})
+
+	out := captureAll(t, func() {
+		err := runLogsMessages(logsMessagesCmd, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	var result []model.MessageLogEntry
+	if err := json.Unmarshal([]byte(out.Stdout), &result); err != nil {
+		t.Fatalf("stdout is not valid JSON array: %v\noutput: %s", err, out.Stdout)
+	}
+	if len(result) != 2 {
+		t.Errorf("got %d entries, want 2", len(result))
+	}
+}
+
+func TestRunLogsMessages_RawOutput(t *testing.T) {
+	resetCmdFlags(t)
+	logsMsgRaw = true
+
+	// Mock returns entries in descending order (newest-first) as TM1 does for --tail.
+	// After reverseEntries, the earlier entry (alice, with embedded newline) comes first.
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(messageLogJSON(
+			model.MessageLogEntry{ID: "2", TimeStamp: "2026-04-25T10:01:00Z", Level: "Error", User: "bob", Message: "normal"},
+			model.MessageLogEntry{ID: "1", TimeStamp: "2026-04-25T10:00:00Z", Level: "Info", User: "alice", Message: "line1\nline2"},
+		))
+	})
+
+	out := captureAll(t, func() {
+		err := runLogsMessages(logsMessagesCmd, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	lines := strings.Split(strings.TrimRight(out.Stdout, "\n"), "\n")
+	// Should have exactly 2 lines (embedded newline sanitized to space)
+	if len(lines) != 2 {
+		t.Errorf("expected 2 lines in raw output, got %d:\n%s", len(lines), out.Stdout)
+	}
+	// After reversal: chronological — alice (T1=10:00) first, bob (T2=10:01) second.
+	// Embedded newline replaced with space.
+	if !strings.Contains(lines[0], "line1 line2") {
+		t.Errorf("line[0] should contain 'line1 line2' (sanitized newline), got %q", lines[0])
+	}
+	// Raw format check: <time> <level> [<user>] <msg>
+	if !strings.Contains(lines[0], "[alice]") {
+		t.Errorf("line[0] should contain '[alice]', got %q", lines[0])
+	}
+}
+
+func TestRunLogsMessages_RawWithJSONRejected(t *testing.T) {
+	resetCmdFlags(t)
+	logsMsgRaw = true
+	flagOutput = "json"
+
+	// No mock server needed — should error before making requests.
+	// We need a config to exist so loadConfig succeeds.
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("should not make any HTTP request")
+	})
+
+	out := captureAll(t, func() {
+		err := runLogsMessages(logsMessagesCmd, nil)
+		if err != errSilent {
+			t.Fatalf("expected errSilent, got: %v", err)
+		}
+	})
+
+	if !strings.Contains(out.Stderr, "--raw cannot be combined with --output json") {
+		t.Errorf("stderr should contain conflict message, got: %q", out.Stderr)
+	}
+}
+
+func TestRunLogsMessages_TailOrdering(t *testing.T) {
+	resetCmdFlags(t)
+	logsMsgTail = 2
+
+	var capturedQuery string
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		capturedQuery = r.URL.RawQuery
+		// Return descending: newest first
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(messageLogJSON(
+			model.MessageLogEntry{ID: "3", TimeStamp: "2026-04-25T12:00:00Z", Level: "Info", Message: "third"},
+			model.MessageLogEntry{ID: "2", TimeStamp: "2026-04-25T11:00:00Z", Level: "Info", Message: "second"},
+		))
+	})
+
+	out := captureAll(t, func() {
+		err := runLogsMessages(logsMessagesCmd, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	decoded, _ := decodedQuery(capturedQuery)
+	if !strings.Contains(decoded, "$top=2") {
+		t.Errorf("query %q should contain $top=2", decoded)
+	}
+	if !strings.Contains(decoded, "$orderby=TimeStamp desc") {
+		t.Errorf("query %q should contain $orderby=TimeStamp desc", decoded)
+	}
+
+	// Chronological order in output: "second" should appear before "third"
+	idxSecond := strings.Index(out.Stdout, "second")
+	idxThird := strings.Index(out.Stdout, "third")
+	if idxSecond == -1 || idxThird == -1 {
+		t.Fatalf("stdout should contain both 'second' and 'third', got:\n%s", out.Stdout)
+	}
+	if idxSecond > idxThird {
+		t.Errorf("'second' should appear before 'third' in chronological output")
+	}
+}
+
+func TestRunLogsMessages_LevelFilter_ServerSide(t *testing.T) {
+	resetCmdFlags(t)
+	logsMsgLevel = "error"
+
+	var capturedQuery string
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		capturedQuery = r.URL.RawQuery
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(messageLogJSON(
+			model.MessageLogEntry{ID: "1", TimeStamp: "2026-04-25T10:00:00Z", Level: "Error", Message: "oops"},
+		))
+	})
+
+	captureAll(t, func() {
+		err := runLogsMessages(logsMessagesCmd, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	decoded, _ := decodedQuery(capturedQuery)
+	if !strings.Contains(decoded, "$filter=") {
+		t.Errorf("query should contain $filter, got %q", decoded)
+	}
+	if !strings.Contains(decoded, "Level eq 'Error'") {
+		t.Errorf("filter should contain Level eq 'Error', got %q", decoded)
+	}
+}
+
+func TestRunLogsMessages_SinceDuration(t *testing.T) {
+	resetCmdFlags(t)
+	logsMsgSince = "1h"
+
+	var capturedQuery string
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		capturedQuery = r.URL.RawQuery
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(messageLogJSON())
+	})
+
+	captureAll(t, func() {
+		err := runLogsMessages(logsMessagesCmd, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	decoded, _ := decodedQuery(capturedQuery)
+	if !strings.Contains(decoded, "TimeStamp ge ") {
+		t.Errorf("filter should contain 'TimeStamp ge ', got %q", decoded)
+	}
+	// Should be an RFC3339 UTC timestamp roughly 1h before now
+	if !strings.Contains(decoded, "T") || !strings.Contains(decoded, "Z") {
+		t.Errorf("filter should contain an RFC3339 UTC timestamp, got %q", decoded)
+	}
+}
+
+func TestRunLogsMessages_SinceAbsolute(t *testing.T) {
+	resetCmdFlags(t)
+	logsMsgSince = "2026-04-24T10:00"
+
+	var capturedQuery string
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		capturedQuery = r.URL.RawQuery
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(messageLogJSON())
+	})
+
+	captureAll(t, func() {
+		err := runLogsMessages(logsMessagesCmd, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	decoded, _ := decodedQuery(capturedQuery)
+	if !strings.Contains(decoded, "TimeStamp ge 2026-04-24T10:00:00Z") {
+		t.Errorf("filter should contain 'TimeStamp ge 2026-04-24T10:00:00Z', got %q", decoded)
+	}
+}
+
+func TestRunLogsMessages_ContainsClientSide(t *testing.T) {
+	resetCmdFlags(t)
+	logsMsgContains = "bar"
+
+	var capturedQuery string
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		capturedQuery = r.URL.RawQuery
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(messageLogJSON(
+			model.MessageLogEntry{ID: "1", TimeStamp: "2026-04-25T10:00:00Z", Level: "Info", Message: "foo"},
+			model.MessageLogEntry{ID: "2", TimeStamp: "2026-04-25T10:01:00Z", Level: "Info", Message: "BAR baz"},
+			model.MessageLogEntry{ID: "3", TimeStamp: "2026-04-25T10:02:00Z", Level: "Info", Message: "barbaz"},
+		))
+	})
+
+	out := captureAll(t, func() {
+		err := runLogsMessages(logsMessagesCmd, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	decoded, _ := decodedQuery(capturedQuery)
+	if strings.Contains(decoded, "contains(") {
+		t.Errorf("server-side filter should NOT include contains(), got %q", decoded)
+	}
+	if !strings.Contains(out.Stdout, "BAR") {
+		t.Errorf("stdout should contain 'BAR', got:\n%s", out.Stdout)
+	}
+	if !strings.Contains(out.Stdout, "barbaz") {
+		t.Errorf("stdout should contain 'barbaz', got:\n%s", out.Stdout)
+	}
+	if strings.Contains(out.Stdout, "foo") {
+		t.Errorf("stdout should NOT contain 'foo' (filtered out), got:\n%s", out.Stdout)
+	}
+}
+
+func TestRunLogsMessages_UserClientSide_FromUserField(t *testing.T) {
+	resetCmdFlags(t)
+	logsMsgUser = "alice"
+
+	var capturedQuery string
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		capturedQuery = r.URL.RawQuery
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(messageLogJSON(
+			model.MessageLogEntry{ID: "1", TimeStamp: "2026-04-25T10:00:00Z", Level: "Info", User: "alice", Message: "msg1"},
+			model.MessageLogEntry{ID: "2", TimeStamp: "2026-04-25T10:01:00Z", Level: "Info", User: "bob", Message: "msg2"},
+		))
+	})
+
+	out := captureAll(t, func() {
+		err := runLogsMessages(logsMessagesCmd, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	decoded, _ := decodedQuery(capturedQuery)
+	if strings.Contains(decoded, "User eq") {
+		t.Errorf("server-side filter should NOT include User eq, got %q", decoded)
+	}
+	if !strings.Contains(out.Stdout, "msg1") {
+		t.Errorf("stdout should contain 'msg1' (alice), got:\n%s", out.Stdout)
+	}
+	if strings.Contains(out.Stdout, "msg2") {
+		t.Errorf("stdout should NOT contain 'msg2' (bob), got:\n%s", out.Stdout)
+	}
+}
+
+func TestRunLogsMessages_UserClientSide_FromMessage(t *testing.T) {
+	resetCmdFlags(t)
+	logsMsgUser = "alice"
+
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(messageLogJSON(
+			model.MessageLogEntry{ID: "1", TimeStamp: "2026-04-25T10:00:00Z", Level: "Info", User: "", Message: "alice did X"},
+			model.MessageLogEntry{ID: "2", TimeStamp: "2026-04-25T10:01:00Z", Level: "Info", User: "", Message: "bob did Y"},
+		))
+	})
+
+	out := captureAll(t, func() {
+		err := runLogsMessages(logsMessagesCmd, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	if !strings.Contains(out.Stdout, "alice did X") {
+		t.Errorf("stdout should contain 'alice did X', got:\n%s", out.Stdout)
+	}
+	if strings.Contains(out.Stdout, "bob did Y") {
+		t.Errorf("stdout should NOT contain 'bob did Y', got:\n%s", out.Stdout)
+	}
+}
+
+// ============================================================
+// Integration Tests — filter fallback
+// ============================================================
+
+func TestRunLogsMessages_FilterFallback(t *testing.T) {
+	resetCmdFlags(t)
+	logsMsgLevel = "error"
+
+	var requestCount int32
+	var secondQuery string
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&requestCount, 1)
+		query := r.URL.RawQuery
+		if strings.Contains(query, "%24filter") || strings.Contains(query, "$filter") {
+			// First request: reject the filter
+			w.WriteHeader(http.StatusBadRequest)
+			w.Write([]byte("$filter not supported"))
+			return
+		}
+		// Second request: return full list
+		secondQuery = query
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(messageLogJSON(
+			model.MessageLogEntry{ID: "1", TimeStamp: "2026-04-25T10:00:00Z", Level: "Info", Message: "info msg"},
+			model.MessageLogEntry{ID: "2", TimeStamp: "2026-04-25T10:01:00Z", Level: "Error", Message: "error msg"},
+		))
+		_ = n
+	})
+
+	out := captureAll(t, func() {
+		err := runLogsMessages(logsMessagesCmd, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	if !strings.Contains(out.Stderr, "[warn]") {
+		t.Errorf("stderr should contain [warn] message, got: %q", out.Stderr)
+	}
+	if !strings.Contains(out.Stderr, "filtering locally") {
+		t.Errorf("stderr should mention 'filtering locally', got: %q", out.Stderr)
+	}
+	if !strings.Contains(out.Stdout, "error msg") {
+		t.Errorf("stdout should contain 'error msg', got:\n%s", out.Stdout)
+	}
+	if strings.Contains(out.Stdout, "info msg") {
+		t.Errorf("stdout should NOT contain 'info msg' (client-filtered), got:\n%s", out.Stdout)
+	}
+	// Fallback request must preserve $top=100 and $orderby
+	decodedSecond, _ := decodedQuery(secondQuery)
+	if !strings.Contains(decodedSecond, "$top=100") {
+		t.Errorf("fallback query %q should still contain $top=100", decodedSecond)
+	}
+}
+
+func TestRunLogsMessages_NoFallbackOn401(t *testing.T) {
+	resetCmdFlags(t)
+
+	var requestCount int32
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&requestCount, 1)
+		w.WriteHeader(http.StatusUnauthorized)
+		w.Write([]byte("Unauthorized"))
+	})
+
+	out := captureAll(t, func() {
+		err := runLogsMessages(logsMessagesCmd, nil)
+		if err != errSilent {
+			t.Fatalf("expected errSilent, got: %v", err)
+		}
+	})
+
+	count := atomic.LoadInt32(&requestCount)
+	if count != 1 {
+		t.Errorf("expected exactly 1 request (no retry on 401), got %d", count)
+	}
+	if !strings.Contains(out.Stderr, "Authentication failed") {
+		t.Errorf("stderr should contain auth error, got: %q", out.Stderr)
+	}
+}
+
+func TestRunLogsMessages_NoFallbackOn404(t *testing.T) {
+	resetCmdFlags(t)
+
+	var requestCount int32
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&requestCount, 1)
+		w.WriteHeader(http.StatusNotFound)
+		w.Write([]byte("Not found"))
+	})
+
+	out := captureAll(t, func() {
+		err := runLogsMessages(logsMessagesCmd, nil)
+		if err != errSilent {
+			t.Fatalf("expected errSilent, got: %v", err)
+		}
+	})
+
+	count := atomic.LoadInt32(&requestCount)
+	if count != 1 {
+		t.Errorf("expected exactly 1 request (no retry on 404), got %d", count)
+	}
+	if !strings.Contains(out.Stderr, "Not found") {
+		t.Errorf("stderr should contain 'Not found', got: %q", out.Stderr)
+	}
+}
+
+// ============================================================
+// Integration Tests — validation errors
+// ============================================================
+
+func TestRunLogsMessages_InvalidLevel(t *testing.T) {
+	resetCmdFlags(t)
+	logsMsgLevel = "trace"
+
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("should not make any HTTP request for invalid level")
+	})
+
+	out := captureAll(t, func() {
+		err := runLogsMessages(logsMessagesCmd, nil)
+		if err != errSilent {
+			t.Fatalf("expected errSilent, got: %v", err)
+		}
+	})
+
+	if !strings.Contains(out.Stderr, "info, warn, error") {
+		t.Errorf("stderr should contain level help, got: %q", out.Stderr)
+	}
+}
+
+func TestRunLogsMessages_InvalidSince(t *testing.T) {
+	resetCmdFlags(t)
+	logsMsgSince = "yesterday"
+
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("should not make any HTTP request for invalid since")
+	})
+
+	out := captureAll(t, func() {
+		err := runLogsMessages(logsMessagesCmd, nil)
+		if err != errSilent {
+			t.Fatalf("expected errSilent, got: %v", err)
+		}
+	})
+
+	if !strings.Contains(out.Stderr, "not a duration") {
+		t.Errorf("stderr should contain 'not a duration', got: %q", out.Stderr)
+	}
+}
+
+// ============================================================
+// Integration Tests — empty / edge cases
+// ============================================================
+
+func TestRunLogsMessages_EmptyResponse(t *testing.T) {
+	resetCmdFlags(t)
+
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(messageLogJSON())
+	})
+
+	out := captureAll(t, func() {
+		err := runLogsMessages(logsMessagesCmd, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	// Should still print headers
+	if !strings.Contains(out.Stdout, "TIME") {
+		t.Errorf("stdout should contain 'TIME' header even for empty response, got:\n%s", out.Stdout)
+	}
+}
+
+func TestRunLogsMessages_MissingUserField(t *testing.T) {
+	resetCmdFlags(t)
+
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		// Entry has no User field
+		w.Write(messageLogJSON(
+			model.MessageLogEntry{ID: "1", TimeStamp: "2026-04-25T10:00:00Z", Level: "Info", Message: "test message"},
+		))
+	})
+
+	t.Run("table renders empty user", func(t *testing.T) {
+		out := captureAll(t, func() {
+			err := runLogsMessages(logsMessagesCmd, nil)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+		if !strings.Contains(out.Stdout, "test message") {
+			t.Errorf("table should contain 'test message', got:\n%s", out.Stdout)
+		}
+	})
+
+	t.Run("raw renders dash for missing user", func(t *testing.T) {
+		resetCmdFlags(t)
+		logsMsgRaw = true
+		setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write(messageLogJSON(
+				model.MessageLogEntry{ID: "1", TimeStamp: "2026-04-25T10:00:00Z", Level: "Info", Message: "test message"},
+			))
+		})
+		out := captureAll(t, func() {
+			err := runLogsMessages(logsMessagesCmd, nil)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+		if !strings.Contains(out.Stdout, "[-]") {
+			t.Errorf("raw output should show '[-]' for missing user, got:\n%s", out.Stdout)
+		}
+	})
+}
+
+// ============================================================
+// Integration Tests — follow-loop (no real signals)
+// ============================================================
+
+func TestFollowMessageLogs_PollsAndAdvancesWatermark(t *testing.T) {
+	resetCmdFlags(t)
+
+	var pollCount int32
+	var capturedFilters []string
+
+	ts := setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		n := int(atomic.AddInt32(&pollCount, 1))
+		decoded, _ := decodedQuery(r.URL.RawQuery)
+		capturedFilters = append(capturedFilters, decoded)
+
+		w.Header().Set("Content-Type", "application/json")
+		switch n {
+		case 1:
+			w.Write(messageLogJSON(
+				model.MessageLogEntry{ID: "a", TimeStamp: "2026-04-25T10:01:00Z", Level: "Info", Message: "entry-T1"},
+			))
+		case 2:
+			w.Write(messageLogJSON(
+				model.MessageLogEntry{ID: "b", TimeStamp: "2026-04-25T10:02:00Z", Level: "Info", Message: "entry-T2"},
+			))
+		default:
+			w.Write(messageLogJSON())
+		}
+	})
+	_ = ts
+
+	cfg, _ := loadConfig()
+	cl, _ := createClient(cfg)
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	out := captureAll(t, func() {
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			followMessageLogs(ctx, cl, "2026-04-25T10:00:00Z", nil, "", "", "", 5*time.Millisecond, false, false)
+		}()
+
+		// Wait until we get at least 3 polls then cancel
+		for i := 0; i < 100; i++ {
+			if atomic.LoadInt32(&pollCount) >= 3 {
+				break
+			}
+			time.Sleep(5 * time.Millisecond)
+		}
+		cancel()
+		<-done
+	})
+
+	if !strings.Contains(out.Stdout, "entry-T1") {
+		t.Errorf("stdout should contain 'entry-T1', got:\n%s", out.Stdout)
+	}
+	if !strings.Contains(out.Stdout, "entry-T2") {
+		t.Errorf("stdout should contain 'entry-T2', got:\n%s", out.Stdout)
+	}
+}
+
+func TestFollowMessageLogs_DropsDuplicateIDsAtBoundary(t *testing.T) {
+	resetCmdFlags(t)
+
+	var pollCount int32
+
+	ts := setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		n := int(atomic.AddInt32(&pollCount, 1))
+		w.Header().Set("Content-Type", "application/json")
+		switch n {
+		case 1:
+			// Poll 1: entry "a" at T1
+			w.Write(messageLogJSON(
+				model.MessageLogEntry{ID: "a", TimeStamp: "2026-04-25T10:01:00Z", Level: "Info", Message: "entry-A"},
+			))
+		case 2:
+			// Poll 2: "a" at T1 (duplicate boundary) + "b" at T2 (new)
+			w.Write(messageLogJSON(
+				model.MessageLogEntry{ID: "a", TimeStamp: "2026-04-25T10:01:00Z", Level: "Info", Message: "entry-A"},
+				model.MessageLogEntry{ID: "b", TimeStamp: "2026-04-25T10:02:00Z", Level: "Info", Message: "entry-B"},
+			))
+		default:
+			w.Write(messageLogJSON())
+		}
+	})
+	_ = ts
+
+	cfg, _ := loadConfig()
+	cl, _ := createClient(cfg)
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	out := captureAll(t, func() {
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			followMessageLogs(ctx, cl, "2026-04-25T10:00:00Z", nil, "", "", "", 5*time.Millisecond, false, false)
+		}()
+
+		// Wait until at least 3 polls then cancel
+		for i := 0; i < 100; i++ {
+			if atomic.LoadInt32(&pollCount) >= 3 {
+				break
+			}
+			time.Sleep(5 * time.Millisecond)
+		}
+		cancel()
+		<-done
+	})
+
+	// "entry-A" should appear exactly once (duplicate dropped on poll 2)
+	countA := strings.Count(out.Stdout, "entry-A")
+	if countA != 1 {
+		t.Errorf("'entry-A' should appear exactly once, got %d times in:\n%s", countA, out.Stdout)
+	}
+	// "entry-B" should appear exactly once
+	countB := strings.Count(out.Stdout, "entry-B")
+	if countB != 1 {
+		t.Errorf("'entry-B' should appear exactly once, got %d times in:\n%s", countB, out.Stdout)
+	}
+}
+
+func TestFollowMessageLogs_ContextCancellationStopsLoop(t *testing.T) {
+	resetCmdFlags(t)
+
+	ts := setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(messageLogJSON())
+	})
+	_ = ts
+
+	cfg, _ := loadConfig()
+	cl, _ := createClient(cfg)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Cancel immediately before first interval
+
+	done := make(chan error, 1)
+	go func() {
+		err := followMessageLogs(ctx, cl, "", nil, "", "", "", 5*time.Millisecond, false, false)
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Errorf("followMessageLogs should return nil on context cancel, got: %v", err)
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Error("followMessageLogs did not stop within 100ms after context cancellation")
+	}
+}
+
+func TestFollowMessageLogs_TransientErrorContinues(t *testing.T) {
+	resetCmdFlags(t)
+
+	var pollCount int32
+
+	ts := setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		n := int(atomic.AddInt32(&pollCount, 1))
+		switch n {
+		case 1:
+			// Transient error
+			w.WriteHeader(http.StatusInternalServerError)
+			w.Write([]byte("Internal Server Error"))
+		case 2:
+			// Normal entry on second poll
+			w.Header().Set("Content-Type", "application/json")
+			w.Write(messageLogJSON(
+				model.MessageLogEntry{ID: "1", TimeStamp: "2026-04-25T10:01:00Z", Level: "Info", Message: "recovery-entry"},
+			))
+		default:
+			w.Header().Set("Content-Type", "application/json")
+			w.Write(messageLogJSON())
+		}
+	})
+	_ = ts
+
+	cfg, _ := loadConfig()
+	cl, _ := createClient(cfg)
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	out := captureAll(t, func() {
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			followMessageLogs(ctx, cl, "", nil, "", "", "", 5*time.Millisecond, false, false)
+		}()
+
+		// Wait until at least 3 polls then cancel
+		for i := 0; i < 100; i++ {
+			if atomic.LoadInt32(&pollCount) >= 3 {
+				break
+			}
+			time.Sleep(5 * time.Millisecond)
+		}
+		cancel()
+		<-done
+	})
+
+	if !strings.Contains(out.Stderr, "[warn] poll failed") {
+		t.Errorf("stderr should contain '[warn] poll failed', got: %q", out.Stderr)
+	}
+	if !strings.Contains(out.Stdout, "recovery-entry") {
+		t.Errorf("stdout should contain 'recovery-entry' from poll 2, got:\n%s", out.Stdout)
+	}
+}
+
+func TestFollowMessageLogs_NDJSONOutput(t *testing.T) {
+	resetCmdFlags(t)
+
+	var pollCount int32
+
+	ts := setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		n := int(atomic.AddInt32(&pollCount, 1))
+		w.Header().Set("Content-Type", "application/json")
+		if n == 1 {
+			w.Write(messageLogJSON(
+				model.MessageLogEntry{ID: "1", TimeStamp: "2026-04-25T10:01:00Z", Level: "Info", Message: "ndjson-entry"},
+			))
+		} else {
+			w.Write(messageLogJSON())
+		}
+	})
+	_ = ts
+
+	cfg, _ := loadConfig()
+	cl, _ := createClient(cfg)
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	out := captureAll(t, func() {
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			followMessageLogs(ctx, cl, "", nil, "", "", "", 5*time.Millisecond, true, false)
+		}()
+
+		for i := 0; i < 100; i++ {
+			if atomic.LoadInt32(&pollCount) >= 2 {
+				break
+			}
+			time.Sleep(5 * time.Millisecond)
+		}
+		cancel()
+		<-done
+	})
+
+	// Each follow chunk in JSON mode emits one JSON object per line (NDJSON)
+	lines := strings.Split(strings.TrimRight(out.Stdout, "\n"), "\n")
+	for _, line := range lines {
+		if line == "" {
+			continue
+		}
+		var entry model.MessageLogEntry
+		if err := json.Unmarshal([]byte(line), &entry); err != nil {
+			t.Errorf("each stdout line should be valid JSON object, got %q: %v", line, err)
+		}
+	}
+	if !strings.Contains(out.Stdout, "ndjson-entry") {
+		t.Errorf("stdout should contain 'ndjson-entry', got:\n%s", out.Stdout)
+	}
+}
+
+// ============================================================
+// Helpers
+// ============================================================
+
+// decodedQuery URL-decodes the raw query string for readable assertions.
+func decodedQuery(raw string) (string, error) {
+	decoded := raw
+	// Replace %XX with their actual characters for comparison
+	replaced := strings.ReplaceAll(decoded, "+", " ")
+	var err error
+	// Simple iterative percent-decode
+	for strings.Contains(replaced, "%") {
+		prev := replaced
+		for i := 0; i < len(replaced)-2; i++ {
+			if replaced[i] == '%' {
+				hex := replaced[i+1 : i+3]
+				var b byte
+				_, parseErr := fmt.Sscanf(hex, "%X", &b)
+				if parseErr == nil {
+					replaced = replaced[:i] + string(b) + replaced[i+3:]
+					break
+				}
+			}
+		}
+		if replaced == prev {
+			break
+		}
+	}
+	return replaced, err
+}

--- a/cmd/logs_test.go
+++ b/cmd/logs_test.go
@@ -1257,25 +1257,6 @@ func TestRunLogsMessages_FilterFallbackWithSinceCapsTop(t *testing.T) {
 	}
 }
 
-func TestFallbackRetryTop(t *testing.T) {
-	tests := []struct {
-		name string
-		top  int
-		want int
-	}{
-		{"zero top → safety cap", 0, 1000},
-		{"explicit top → buffered", 100, 600},
-		{"large top → buffered", 5000, 5500},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := fallbackRetryTop(tt.top); got != tt.want {
-				t.Errorf("fallbackRetryTop(%d) = %d, want %d", tt.top, got, tt.want)
-			}
-		})
-	}
-}
-
 func TestRunLogsMessages_FilterFallback(t *testing.T) {
 	resetCmdFlags(t)
 	logsMsgLevel = "error"
@@ -1317,15 +1298,14 @@ func TestRunLogsMessages_FilterFallback(t *testing.T) {
 	if strings.Contains(out.Stdout, "info msg") {
 		t.Errorf("stdout should NOT contain 'info msg' (client-filtered), got:\n%s", out.Stdout)
 	}
-	// Fallback retry must over-fetch (tail 100 + 500 buffer) so client-side
-	// filtering doesn't starve the visible result, and must order desc so the
-	// buffer captures the most recent entries.
+	// Fallback retry preserves the user's --tail and orders desc so the cap
+	// retains the most recent entries.
 	decodedSecond, _ := decodedQuery(secondQuery)
-	if !strings.Contains(decodedSecond, "$top=600") {
-		t.Errorf("fallback query %q should contain $top=600 (tail 100 + 500 buffer)", decodedSecond)
+	if !strings.Contains(decodedSecond, "$top=100") {
+		t.Errorf("fallback query %q should preserve $top=100 from --tail default", decodedSecond)
 	}
 	if !strings.Contains(decodedSecond, "$orderby=TimeStamp desc") {
-		t.Errorf("fallback query %q should order by TimeStamp desc to preserve newest entries", decodedSecond)
+		t.Errorf("fallback query %q should order by TimeStamp desc to retain newest entries", decodedSecond)
 	}
 }
 

--- a/cmd/testhelpers_test.go
+++ b/cmd/testhelpers_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 	"tm1cli/internal/config"
 	"tm1cli/internal/model"
 
@@ -219,6 +220,14 @@ func zeroAllFlags() {
 	threadsMinElapsed = ""
 	threadsLimit = 0
 	threadsAll = false
+	logsMsgSince = ""
+	logsMsgLevel = ""
+	logsMsgUser = ""
+	logsMsgContains = ""
+	logsMsgFollow = false
+	logsMsgInterval = 5 * time.Second
+	logsMsgTail = 0
+	logsMsgRaw = false
 }
 
 // cubesJSON returns JSON for a TM1 Cubes response.
@@ -389,6 +398,18 @@ func threadsJSON(threads ...model.Thread) []byte {
 	}{Value: threads}
 	if resp.Value == nil {
 		resp.Value = []model.Thread{}
+	}
+	data, _ := json.Marshal(resp)
+	return data
+}
+
+// messageLogJSON returns JSON for a TM1 MessageLogEntries response.
+func messageLogJSON(entries ...model.MessageLogEntry) []byte {
+	resp := struct {
+		Value []model.MessageLogEntry `json:"value"`
+	}{Value: entries}
+	if resp.Value == nil {
+		resp.Value = []model.MessageLogEntry{}
 	}
 	data, _ := json.Marshal(resp)
 	return data

--- a/internal/model/messagelog.go
+++ b/internal/model/messagelog.go
@@ -1,0 +1,17 @@
+package model
+
+// MessageLogEntry represents a single entry in the TM1 message log.
+// User is omitempty because older TM1 versions may not include the field.
+type MessageLogEntry struct {
+	ID        string `json:"ID,omitempty"`
+	TimeStamp string `json:"TimeStamp"`
+	Logger    string `json:"Logger,omitempty"`
+	Level     string `json:"Level"`
+	Message   string `json:"Message"`
+	User      string `json:"User,omitempty"`
+}
+
+// MessageLogResponse is the OData collection wrapper for GET /MessageLogEntries.
+type MessageLogResponse struct {
+	Value []MessageLogEntry `json:"value"`
+}


### PR DESCRIPTION
## Summary
- Adds `tm1cli logs messages` to fetch and stream TM1's `/MessageLogEntries` with kubectl-style `--follow`.
- Filters: `--since` (duration or absolute timestamp), `--level`, `--user`, `--contains`, `--tail`, `--raw`.
- Three output formats: table (default), JSON, raw (one line per entry); `--follow` + `--output json` emits NDJSON.

## Design
- Server-side `$filter` carries TimeStamp + Level only; `User` and `--contains` are always client-side (TM1's User field availability varies by version).
- Filter-rejection fallback: HTTP 400/501 with filter/orderby/not-supported keywords retries WITHOUT `$filter` while preserving `$top` and `$orderby`. Auth (401/403), `ErrNotFound` (404), and other errors propagate unchanged.
- Default `--tail 100` when no time-bound flag is set, applied even with `--follow` (kubectl-style: show last N first, then stream new ones). Prevents accidental multi-GB log pulls.
- `--follow` watermark = max `TimeStamp` from the response plus a boundary-ID dedupe set; subsequent polls use `TimeStamp ge <watermark>`. Never compares to client wall time after the first request, so server clock skew can't drop or duplicate entries.
- SIGINT handled via `signal.NotifyContext(ctx, os.Interrupt)` (matches `cmd/watch.go` pattern); polling loop is extracted as `followMessageLogs(ctx, …)` for testability.
- Raw output sanitizes embedded `\r`, `\n`, `\t` to spaces to preserve the one-line-per-entry guarantee.
- `--raw` + `--output json` rejected before any HTTP request.

## Files Changed
- NEW `internal/model/messagelog.go` — `MessageLogEntry`, `MessageLogResponse` types.
- NEW `cmd/logs.go` — `logs` parent command + `logs messages` subcommand, all helpers, follow loop.
- NEW `cmd/logs_test.go` — 36 tests covering parsing, filter assembly, client-side filtering, sort/reverse, follow-loop polling, boundary-ID dedupe, context-cancel exit, transient-error resilience, NDJSON output, raw sanitization, missing-User edge case, 401/404 no-retry, filter-fallback with `$top` preservation.
- MODIFIED `cmd/testhelpers_test.go` — added `messageLogJSON` helper, registered new flag resets in `zeroAllFlags()`.
- MODIFIED `README.md` — `Logs` section documenting the new command.

## Test Plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` — 855 tests pass across 6 packages
- [x] `go test -race ./cmd/...` — race-detector clean on follow-loop tests
- [x] Acceptance criterion 1 (filter combinations): covered by `TestApplyClientFilters` (since + level + user + contains together) and integration tests for server-side / client-side / fallback paths.
- [x] Acceptance criterion 2 (`--follow` clean SIGINT): `TestFollowMessageLogs_ContextCancellationStopsLoop` proves immediate `ctx.Done()` returns within 100ms.
- [x] Acceptance criterion 3 (server clock skew via response timestamps): `TestFollowMessageLogs_DropsDuplicateIDsAtBoundary` proves boundary-ID dedupe works when server returns entries at the same TimeStamp.

## Review History
- Internal review (Opus, full checklist): APPROVED, no P0/P1.
- External review round 1 (Sonnet, fresh context): NEEDS_CHANGES — 1 P1 (bare `--follow` skipped default-tail guard, risk of unbounded GET).
- Round 1 fix (`49b7d8e`): extracted `defaultTailIfUnbounded` helper, removed the `--follow` carve-out, added unit test covering 4 cases.
- External review round 2 (Sonnet, fresh context): APPROVED, no P0/P1; remaining P2 suggestions are optional.

Closes #78