### PR TITLE
feat(#79): logs tx — query the TM1 transaction log

### DIFF
--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -213,6 +213,17 @@ func fallbackRetryTop(top int) int {
 	return top * fallbackTailMultiplier
 }
 
+// warnIfPaginated emits a one-shot warning when the server response carries
+// an OData @odata.nextLink. The fetch path does not follow continuations,
+// so without this warning the result set would silently truncate at the
+// first server page — a particular hazard for long --since/--until windows.
+func warnIfPaginated(nextLink string) {
+	if nextLink == "" {
+		return
+	}
+	output.PrintWarning("Server returned a paginated response; results may be truncated. Narrow --since/--until or set --tail to widen the visible window.")
+}
+
 // emitFallbackWarning prints the disclosure shown when the server rejects
 // $filter and the client retries unfiltered. retryTop is the over-fetch
 // window (always disclosed so users know the local filter is bounded);

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -192,19 +192,38 @@ func isFilterRejection(err error) bool {
 // rejects would retry as a bare GET /MessageLogEntries and pull the whole log.
 const fallbackSafetyCap = 1000
 
+// fallbackTailMultiplier widens the fallback retry window when --tail is set
+// alongside a content filter (--level/--user/--contains for messages,
+// --cube/--user for tx). Without the buffer, retrying with raw $top=tail
+// returns the latest N globally and client-filtering can leave near-zero
+// matches even when many matching entries exist just past the window. The
+// retry is capped at fallbackSafetyCap; callers must truncate the post-filter
+// result back to the user-requested --tail.
+const fallbackTailMultiplier = 10
+
+// fallbackRetryTop returns the over-fetch window for a $filter-rejection
+// retry. If --tail was unset (top=0), use the safety cap. If --tail was set,
+// over-fetch by fallbackTailMultiplier capped at the safety cap.
+func fallbackRetryTop(top int) int {
+	if top == 0 {
+		return fallbackSafetyCap
+	}
+	if buffered := top * fallbackTailMultiplier; buffered < fallbackSafetyCap {
+		return buffered
+	}
+	return fallbackSafetyCap
+}
+
 // fetchMessageLogEntries performs GET. On HTTP 400/501 with a filter-rejection body,
-// it retries without $filter (capping $top at fallbackSafetyCap when no --tail was
-// given) and returns fallback=true. On auth (401/403), not-found (404), or network
-// errors the error propagates unchanged.
+// it retries without $filter (over-fetching via fallbackRetryTop when --tail is
+// set so client-side filtering has room to find matches) and returns fallback=true.
+// On auth (401/403), not-found (404), or network errors the error propagates unchanged.
 func fetchMessageLogEntries(cl *client.Client, filter string, top int, orderDesc bool) ([]model.MessageLogEntry, bool, error) {
 	endpoint := buildMessageLogQuery(filter, top, orderDesc)
 	data, err := cl.Get(endpoint)
 	if err != nil {
 		if filter != "" && isFilterRejection(err) {
-			retryTop := top
-			if retryTop == 0 {
-				retryTop = fallbackSafetyCap
-			}
+			retryTop := fallbackRetryTop(top)
 			// Always order DESC on retry so the cap retains the most recent
 			// entries — otherwise a --since query could return the oldest 1000
 			// entries (since epoch) instead of the 1000 newest in the window.
@@ -522,6 +541,13 @@ func runLogsMessages(cmd *cobra.Command, args []string) error {
 	}
 	if applySince != "" || applyLevel != "" || logsMsgUser != "" || logsMsgContains != "" {
 		entries = applyClientFilters(entries, applySince, applyLevel, logsMsgUser, logsMsgContains)
+	}
+
+	// Fallback over-fetches via fallbackTailMultiplier so client-side filtering
+	// has room to find matches; trim back to the user-requested --tail before
+	// display. Server-returned entries are DESC, so [:tail] keeps the newest.
+	if fallback && tail > 0 && len(entries) > tail {
+		entries = entries[:tail]
 	}
 
 	if tail > 0 {

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -203,15 +203,14 @@ const fallbackTailMultiplier = 10
 
 // fallbackRetryTop returns the over-fetch window for a $filter-rejection
 // retry. If --tail was unset (top=0), use the safety cap. If --tail was set,
-// over-fetch by fallbackTailMultiplier capped at the safety cap.
+// over-fetch by fallbackTailMultiplier capped at the safety cap. The
+// short-circuit when `top >= fallbackSafetyCap/fallbackTailMultiplier` also
+// guards against int overflow on extreme --tail values.
 func fallbackRetryTop(top int) int {
-	if top == 0 {
+	if top == 0 || top >= fallbackSafetyCap/fallbackTailMultiplier {
 		return fallbackSafetyCap
 	}
-	if buffered := top * fallbackTailMultiplier; buffered < fallbackSafetyCap {
-		return buffered
-	}
-	return fallbackSafetyCap
+	return top * fallbackTailMultiplier
 }
 
 // fetchMessageLogEntries performs GET. On HTTP 400/501 with a filter-rejection body,

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -213,6 +213,24 @@ func fallbackRetryTop(top int) int {
 	return top * fallbackTailMultiplier
 }
 
+// emitFallbackWarning prints the disclosure shown when the server rejects
+// $filter and the client retries unfiltered. retryTop is the over-fetch
+// window (always disclosed so users know the local filter is bounded);
+// gotRows is the row count the retry returned. When gotRows >= retryTop
+// the cap was hit, so an additional warning flags likely truncation.
+func emitFallbackWarning(retryTop, gotRows int) {
+	output.PrintWarning(fmt.Sprintf(
+		"Server-side filter not supported; filtering locally over the most recent %d entries — results may be incomplete",
+		retryTop,
+	))
+	if gotRows >= retryTop {
+		output.PrintWarning(fmt.Sprintf(
+			"Hit fallback cap of %d entries; narrow --since/--until or increase --tail to widen the window",
+			retryTop,
+		))
+	}
+}
+
 // fetchMessageLogEntries performs GET. On HTTP 400/501 with a filter-rejection body,
 // it retries without $filter (over-fetching via fallbackRetryTop when --tail is
 // set so client-side filtering has room to find matches) and returns fallback=true.
@@ -235,7 +253,7 @@ func fetchMessageLogEntries(cl *client.Client, filter string, top int, orderDesc
 			if jsonErr := json.Unmarshal(retryData, &resp); jsonErr != nil {
 				return nil, false, fmt.Errorf("cannot parse server response: %w", jsonErr)
 			}
-			output.PrintWarning("Server-side filter not supported, filtering locally...")
+			emitFallbackWarning(retryTop, len(resp.Value))
 			return resp.Value, true, nil
 		}
 		return nil, false, err

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -347,11 +347,19 @@ func boundaryIDs(entries []model.MessageLogEntry) (string, map[string]struct{}) 
 	return maxTS, ids
 }
 
-// defaultTailIfUnbounded returns 100 when no time-bound flag is set to avoid
-// unbounded reads against multi-GB message logs. Applies in --follow too:
-// kubectl-style, show the last N entries first then stream new ones.
-func defaultTailIfUnbounded(since string, tail int) int {
-	if since == "" && tail == 0 {
+// defaultTailIfUnbounded returns 100 when neither a time bound nor an
+// explicit --tail is set, to avoid unbounded reads against multi-GB logs.
+// Applies in --follow too: kubectl-style, show the last N entries first
+// then stream new ones.
+//
+// `bounded` is true when ANY time-bound flag is set by the caller — for
+// `logs messages` that's just --since, for `logs tx` it's --since OR
+// --until. Treating --until as a bound prevents silent truncation of
+// queries like `tm1cli logs tx --until 2026-04-24T18:00:00Z` where the
+// user has explicitly bounded the upper end and expects all matching
+// entries.
+func defaultTailIfUnbounded(bounded bool, tail int) int {
+	if !bounded && tail == 0 {
 		return 100
 	}
 	return tail
@@ -519,7 +527,7 @@ func runLogsMessages(cmd *cobra.Command, args []string) error {
 		return errSilent
 	}
 
-	tail := defaultTailIfUnbounded(logsMsgSince, logsMsgTail)
+	tail := defaultTailIfUnbounded(logsMsgSince != "", logsMsgTail)
 
 	cl, err := createClient(cfg)
 	if err != nil {

--- a/cmd/logs_test.go
+++ b/cmd/logs_test.go
@@ -671,20 +671,20 @@ func TestIsFilterRejection(t *testing.T) {
 
 func TestDefaultTailIfUnbounded(t *testing.T) {
 	tests := []struct {
-		name  string
-		since string
-		tail  int
-		want  int
+		name    string
+		bounded bool
+		tail    int
+		want    int
 	}{
-		{"no flags defaults to 100", "", 0, 100},
-		{"explicit tail preserved", "", 50, 50},
-		{"since set, tail stays 0", "2026-04-25T10:00:00Z", 0, 0},
-		{"both set", "2026-04-25T10:00:00Z", 50, 50},
+		{"no bound, no tail defaults to 100", false, 0, 100},
+		{"no bound, explicit tail preserved", false, 50, 50},
+		{"bounded by time, tail stays 0", true, 0, 0},
+		{"bounded by time + tail set", true, 50, 50},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := defaultTailIfUnbounded(tt.since, tt.tail); got != tt.want {
-				t.Errorf("defaultTailIfUnbounded(%q, %d) = %d, want %d", tt.since, tt.tail, got, tt.want)
+			if got := defaultTailIfUnbounded(tt.bounded, tt.tail); got != tt.want {
+				t.Errorf("defaultTailIfUnbounded(%v, %d) = %d, want %d", tt.bounded, tt.tail, got, tt.want)
 			}
 		})
 	}

--- a/cmd/logs_test.go
+++ b/cmd/logs_test.go
@@ -1298,14 +1298,80 @@ func TestRunLogsMessages_FilterFallback(t *testing.T) {
 	if strings.Contains(out.Stdout, "info msg") {
 		t.Errorf("stdout should NOT contain 'info msg' (client-filtered), got:\n%s", out.Stdout)
 	}
-	// Fallback retry preserves the user's --tail and orders desc so the cap
-	// retains the most recent entries.
+	// Fallback retry buffers the user's --tail (default 100) by
+	// fallbackTailMultiplier so client-side filtering has room to find
+	// matches. 100 * 10 = 1000 == fallbackSafetyCap.
 	decodedSecond, _ := decodedQuery(secondQuery)
-	if !strings.Contains(decodedSecond, "$top=100") {
-		t.Errorf("fallback query %q should preserve $top=100 from --tail default", decodedSecond)
+	wantBuffered := 100 * fallbackTailMultiplier
+	if wantBuffered > fallbackSafetyCap {
+		wantBuffered = fallbackSafetyCap
+	}
+	if !strings.Contains(decodedSecond, fmt.Sprintf("$top=%d", wantBuffered)) {
+		t.Errorf("fallback query %q should buffer to $top=%d (=tail*multiplier capped)", decodedSecond, wantBuffered)
 	}
 	if !strings.Contains(decodedSecond, "$orderby=TimeStamp desc") {
 		t.Errorf("fallback query %q should order by TimeStamp desc to retain newest entries", decodedSecond)
+	}
+}
+
+// TestRunLogsMessages_FilterFallbackBuffersTailForLevelFilter mirrors the
+// fix for the parity issue called out in tm1cli-issue-79's review: --tail
+// combined with a content filter (--level here) on a server without $filter
+// support must over-fetch so client-side filtering can find tail-many
+// matches, then truncate back to the user's --tail.
+func TestRunLogsMessages_FilterFallbackBuffersTailForLevelFilter(t *testing.T) {
+	resetCmdFlags(t)
+	logsMsgTail = 3
+	logsMsgLevel = "error"
+
+	const wantBuffered = 3 * fallbackTailMultiplier // 30
+
+	var capturedRetryQuery string
+	var requestCount int32
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&requestCount, 1)
+		query := r.URL.RawQuery
+		if strings.Contains(query, "%24filter") {
+			w.WriteHeader(http.StatusBadRequest)
+			w.Write([]byte("$filter not supported"))
+			return
+		}
+		capturedRetryQuery = query
+		w.Header().Set("Content-Type", "application/json")
+		// Sparse error matches: 30 entries, only 5 are Error.
+		entries := make([]model.MessageLogEntry, 0, 30)
+		for i := 0; i < 30; i++ {
+			level := "Info"
+			if i < 5 {
+				level = "Error"
+			}
+			entries = append(entries, model.MessageLogEntry{
+				ID:        fmt.Sprintf("%d", i+1),
+				TimeStamp: time.Date(2026, 4, 25, 10, 0, i, 0, time.UTC).Format(time.RFC3339),
+				Level:     level,
+				Message:   fmt.Sprintf("msg-%d", i+1),
+			})
+		}
+		w.Write(messageLogJSON(entries...))
+	})
+
+	out := captureAll(t, func() {
+		if err := runLogsMessages(logsMessagesCmd, nil); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	decoded, _ := decodedQuery(capturedRetryQuery)
+	if !strings.Contains(decoded, fmt.Sprintf("$top=%d", wantBuffered)) {
+		t.Errorf("retry query %q should buffer $top to %d (=tail*multiplier)", decoded, wantBuffered)
+	}
+	// 5 Error matches truncated to --tail=3 in DESC order.
+	errorCount := strings.Count(out.Stdout, "Error")
+	if errorCount != 3 {
+		t.Errorf("expected exactly 3 Error rows after truncation, got %d:\n%s", errorCount, out.Stdout)
+	}
+	if strings.Count(out.Stdout, "Info") != 0 {
+		t.Errorf("Info rows should be filtered out, got:\n%s", out.Stdout)
 	}
 }
 

--- a/cmd/logs_tx.go
+++ b/cmd/logs_tx.go
@@ -162,7 +162,7 @@ func fetchTxEntries(cl *client.Client, filter string, top int, orderDesc bool) (
 			if jerr := json.Unmarshal(retryData, &resp); jerr != nil {
 				return nil, false, fmt.Errorf("cannot parse server response: %w", jerr)
 			}
-			output.PrintWarning("Server-side filter not supported, filtering locally...")
+			emitFallbackWarning(retryTop, len(resp.Value))
 			return resp.Value, true, nil
 		}
 		return nil, false, err

--- a/cmd/logs_tx.go
+++ b/cmd/logs_tx.go
@@ -270,6 +270,17 @@ func boundaryTxIDs(entries []model.TransactionLogEntry) (string, map[string]stru
 	return maxTS, ids
 }
 
+// initialFollowWatermark composes boundaryTxIDs + advanceWatermark +
+// resolveFollowWatermark to produce the starting (watermarkTS, watermarkIDs)
+// pair for follow polls. The advanceWatermark step is critical when TM1
+// omits ID (older versions): with no IDs to dedupe against, the inclusive
+// `TimeStamp ge` filter on the first poll would re-emit the boundary entry.
+func initialFollowWatermark(entries []model.TransactionLogEntry, sinceTS string, now time.Time) (string, map[string]struct{}) {
+	maxTS, ids := boundaryTxIDs(entries)
+	maxTS, ids = advanceWatermark(maxTS, ids)
+	return resolveFollowWatermark(maxTS, sinceTS, now), ids
+}
+
 // printTxEntries renders entries in the chosen format. In follow+jsonMode it
 // emits NDJSON (one object per line). In raw mode every string field is
 // passed through sanitizeRawMessage so each entry stays on a single line.
@@ -468,8 +479,7 @@ func runLogsTx(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	maxTS, ids := boundaryTxIDs(entries)
-	maxTS = resolveFollowWatermark(maxTS, sinceTS, time.Now())
+	maxTS, ids := initialFollowWatermark(entries, sinceTS, time.Now())
 
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer stop()

--- a/cmd/logs_tx.go
+++ b/cmd/logs_tx.go
@@ -187,15 +187,15 @@ func applyTxClientFilters(entries []model.TransactionLogEntry, sinceTS, untilTS,
 
 	out := make([]model.TransactionLogEntry, 0, len(entries))
 	for _, e := range entries {
-		if !sinceT.IsZero() {
+		if !sinceT.IsZero() || !untilT.IsZero() {
 			t, err := parseTimeStamp(e.TimeStamp)
-			if err != nil || t.Before(sinceT) {
+			if err != nil {
 				continue
 			}
-		}
-		if !untilT.IsZero() {
-			t, err := parseTimeStamp(e.TimeStamp)
-			if err != nil || t.After(untilT) {
+			if !sinceT.IsZero() && t.Before(sinceT) {
+				continue
+			}
+			if !untilT.IsZero() && t.After(untilT) {
 				continue
 			}
 		}

--- a/cmd/logs_tx.go
+++ b/cmd/logs_tx.go
@@ -88,13 +88,30 @@ func formatTxValue(raw json.RawMessage) string {
 	return trimmed
 }
 
-// txIDKey returns the dedupe map key for a transaction-log entry. Zero means
-// the server omitted ID — those entries skip dedupe registration.
-func txIDKey(id int64) string {
-	if id == 0 {
-		return ""
+// txIDKey returns the dedupe key for a transaction-log entry. When TM1
+// supplies ID we use it directly. When ID is omitted (older versions) we
+// synthesize a key from the observable fields so same-timestamp entries
+// can be distinguished — important for tx logs where batch writes / TI
+// processes commonly emit multiple changes at the same exact timestamp.
+// Two functionally identical events (same content, same timestamp) hash
+// to the same key, which is the right behavior — they are indistinguishable.
+func txIDKey(e model.TransactionLogEntry) string {
+	if e.ID != 0 {
+		return strconv.FormatInt(e.ID, 10)
 	}
-	return strconv.FormatInt(id, 10)
+	// 0x1f (unit separator) is illegal in TM1 names and OData strings, so
+	// it cannot appear inside any field — safe as a delimiter.
+	const sep = "\x1f"
+	return strings.Join([]string{
+		"syn",
+		e.TimeStamp,
+		e.User,
+		e.Cube,
+		strings.Join(e.Tuple, sep),
+		string(e.OldValue),
+		string(e.NewValue),
+		e.StatusMessage,
+	}, sep)
 }
 
 // tupleString renders a TM1 cell coordinate as colon-joined elements, matching
@@ -163,6 +180,7 @@ func fetchTxEntries(cl *client.Client, filter string, top int, orderDesc bool) (
 				return nil, false, fmt.Errorf("cannot parse server response: %w", jerr)
 			}
 			emitFallbackWarning(retryTop, len(resp.Value))
+			warnIfPaginated(resp.NextLink)
 			return resp.Value, true, nil
 		}
 		return nil, false, err
@@ -171,6 +189,7 @@ func fetchTxEntries(cl *client.Client, filter string, top int, orderDesc bool) (
 	if err := json.Unmarshal(data, &resp); err != nil {
 		return nil, false, fmt.Errorf("cannot parse server response: %w", err)
 	}
+	warnIfPaginated(resp.NextLink)
 	return resp.Value, false, nil
 }
 
@@ -263,18 +282,17 @@ func boundaryTxIDs(entries []model.TransactionLogEntry) (string, map[string]stru
 		if e.TimeStamp != maxTS {
 			continue
 		}
-		if key := txIDKey(e.ID); key != "" {
-			ids[key] = struct{}{}
-		}
+		ids[txIDKey(e)] = struct{}{}
 	}
 	return maxTS, ids
 }
 
 // initialFollowWatermark composes boundaryTxIDs + advanceWatermark +
 // resolveFollowWatermark to produce the starting (watermarkTS, watermarkIDs)
-// pair for follow polls. The advanceWatermark step is critical when TM1
-// omits ID (older versions): with no IDs to dedupe against, the inclusive
-// `TimeStamp ge` filter on the first poll would re-emit the boundary entry.
+// pair for follow polls. txIDKey synthesizes content-based keys when TM1
+// omits ID, so boundaryTxIDs returns a non-empty dedup set for any
+// non-empty entries — making advanceWatermark a defensive no-op in that
+// case. It still runs to handle the truly-empty (no entries) edge case.
 func initialFollowWatermark(entries []model.TransactionLogEntry, sinceTS string, now time.Time) (string, map[string]struct{}) {
 	maxTS, ids := boundaryTxIDs(entries)
 	maxTS, ids = advanceWatermark(maxTS, ids)
@@ -348,10 +366,8 @@ func followTxLogs(ctx context.Context, cl *client.Client, watermarkTS string, wa
 		// Drop boundary duplicates first (clock-skew dedupe).
 		filtered := entries[:0]
 		for _, e := range entries {
-			if key := txIDKey(e.ID); key != "" {
-				if _, seen := watermarkIDs[key]; seen {
-					continue
-				}
+			if _, seen := watermarkIDs[txIDKey(e)]; seen {
+				continue
 			}
 			filtered = append(filtered, e)
 		}
@@ -376,7 +392,17 @@ func followTxLogs(ctx context.Context, cl *client.Client, watermarkTS string, wa
 		}
 
 		if seenMaxTS != "" {
-			watermarkTS, watermarkIDs = advanceWatermark(seenMaxTS, seenIDs)
+			// When the new boundary timestamp matches the prior watermark,
+			// MERGE the new IDs into the existing dedup set. Replacing would
+			// drop prior boundary IDs and re-emit them on the next poll if
+			// the server keeps returning them at the same TimeStamp.
+			if seenMaxTS == watermarkTS {
+				for k, v := range seenIDs {
+					watermarkIDs[k] = v
+				}
+			} else {
+				watermarkTS, watermarkIDs = advanceWatermark(seenMaxTS, seenIDs)
+			}
 		}
 	}
 }

--- a/cmd/logs_tx.go
+++ b/cmd/logs_tx.go
@@ -70,7 +70,10 @@ func parseTimeFlag(name, value string, now time.Time) (string, error) {
 
 // formatTxValue renders a TM1 Edm.PrimitiveType value (string, number, bool,
 // or null) for table/raw output. JSON strings are unquoted; everything else
-// is rendered as the trimmed raw bytes; null and empty become "".
+// is rendered as the trimmed raw bytes; null and empty become "". When raw
+// looks like a JSON string but Unmarshal fails (malformed escape, etc.), we
+// fall through to the trimmed raw bytes — surfacing the corruption rather
+// than swallowing it with an error column.
 func formatTxValue(raw json.RawMessage) string {
 	trimmed := strings.TrimSpace(string(raw))
 	if trimmed == "" || trimmed == "null" {
@@ -430,6 +433,9 @@ func runLogsTx(cmd *cobra.Command, args []string) error {
 	// On fallback, apply all four filters client-side. On the success path,
 	// still apply --until client-side as defense in depth — TM1 may round
 	// timestamps server-side and surface entries slightly outside the window.
+	// We do NOT re-apply --since here: server-side `TimeStamp ge` is inclusive
+	// and any rounding would only widen the lower bound by surfacing entries
+	// at or near sinceTS, which is exactly what the user asked for.
 	applySince, applyUntil, applyCube, applyUser := "", "", "", ""
 	if fallback {
 		applySince, applyUntil, applyCube, applyUser = sinceTS, untilTS, logsTxCube, logsTxUser

--- a/cmd/logs_tx.go
+++ b/cmd/logs_tx.go
@@ -284,6 +284,30 @@ func sortTxByTimeStamp(entries []model.TransactionLogEntry) {
 	})
 }
 
+// sortTxByTimeStampDesc sorts descending; ties are broken by ID (descending).
+// Unparseable timestamps go to the end stably. Used when fallback truncation
+// must keep the LATEST --tail N entries — raw lexicographic compare on the
+// TimeStamp string disagrees with chronological order whenever TM1 mixes
+// precision (e.g. 10:00:00Z vs 10:00:00.9Z) or offsets.
+func sortTxByTimeStampDesc(entries []model.TransactionLogEntry) {
+	sort.SliceStable(entries, func(i, j int) bool {
+		ti, errI := parseTimeStamp(entries[i].TimeStamp)
+		tj, errJ := parseTimeStamp(entries[j].TimeStamp)
+		switch {
+		case errI != nil && errJ != nil:
+			return false
+		case errI != nil:
+			return false
+		case errJ != nil:
+			return true
+		case ti.Equal(tj):
+			return entries[i].ID > entries[j].ID
+		default:
+			return ti.After(tj)
+		}
+	})
+}
+
 // reverseTxEntries reverses entries in place.
 func reverseTxEntries(entries []model.TransactionLogEntry) {
 	for i, j := 0, len(entries)-1; i < j; i, j = i+1, j-1 {
@@ -532,10 +556,11 @@ func runLogsTx(cmd *cobra.Command, args []string) error {
 	// retry order is conditional (DESC for --since/default, ASC for
 	// --until-only forensic queries), so a naive [:tail] would otherwise
 	// silently keep the OLDEST N under ASC retry, violating --tail semantics.
+	// Use sortTxByTimeStampDesc (parse + time.After + ID tiebreak) rather
+	// than a raw string compare — TM1 mixes timestamp precision/offsets and
+	// lexicographic order can disagree with chronological order.
 	if fallback && tail > 0 && len(entries) > tail {
-		sort.SliceStable(entries, func(i, j int) bool {
-			return entries[i].TimeStamp > entries[j].TimeStamp
-		})
+		sortTxByTimeStampDesc(entries)
 		entries = entries[:tail]
 	}
 

--- a/cmd/logs_tx.go
+++ b/cmd/logs_tx.go
@@ -140,9 +140,17 @@ func buildTxFilter(sinceTS, untilTS, cube, user string) string {
 	return strings.Join(parts, " and ")
 }
 
+// orderBy values accepted by buildTxQuery. Empty string means no $orderby
+// clause (server default).
+const (
+	orderTimeStampAsc  = "TimeStamp asc"
+	orderTimeStampDesc = "TimeStamp desc"
+)
+
 // buildTxQuery builds the endpoint URL with $filter, $top, $orderby using
-// url.Values for safe encoding.
-func buildTxQuery(filter string, top int, orderDesc bool) string {
+// url.Values for safe encoding. orderBy must be "", orderTimeStampAsc, or
+// orderTimeStampDesc — empty means no $orderby clause (use server default).
+func buildTxQuery(filter string, top int, orderBy string) string {
 	v := url.Values{}
 	if filter != "" {
 		v.Set("$filter", filter)
@@ -150,8 +158,8 @@ func buildTxQuery(filter string, top int, orderDesc bool) string {
 	if top > 0 {
 		v.Set("$top", strconv.Itoa(top))
 	}
-	if orderDesc {
-		v.Set("$orderby", "TimeStamp desc")
+	if orderBy != "" {
+		v.Set("$orderby", orderBy)
 	}
 	if len(v) == 0 {
 		return "TransactionLogEntries"
@@ -178,16 +186,22 @@ func buildTxQuery(filter string, top int, orderDesc bool) string {
 // emitted: --until cannot be enforced server-side without $filter, so
 // historical entries past the retry window will be missed.
 func fetchTxEntries(cl *client.Client, filter string, top int, orderDesc, sinceSet, untilSet bool) ([]model.TransactionLogEntry, bool, error) {
-	endpoint := buildTxQuery(filter, top, orderDesc)
+	successOrderBy := ""
+	if orderDesc {
+		successOrderBy = orderTimeStampDesc
+	}
+	endpoint := buildTxQuery(filter, top, successOrderBy)
 	data, err := cl.Get(endpoint)
 	if err != nil {
 		if filter != "" && isFilterRejection(err) {
 			retryTop := fallbackRetryTop(top)
-			retryDesc := true
+			// Explicit ASC/DESC — never relying on server default, which is
+			// undefined for TransactionLogEntries and version-dependent.
+			retryOrderBy := orderTimeStampDesc
 			if untilSet && !sinceSet {
-				retryDesc = false
+				retryOrderBy = orderTimeStampAsc
 			}
-			retryData, retryErr := cl.Get(buildTxQuery("", retryTop, retryDesc))
+			retryData, retryErr := cl.Get(buildTxQuery("", retryTop, retryOrderBy))
 			if retryErr != nil {
 				return nil, false, retryErr
 			}

--- a/cmd/logs_tx.go
+++ b/cmd/logs_tx.go
@@ -163,15 +163,31 @@ func buildTxQuery(filter string, top int, orderDesc bool) string {
 // it retries without $filter (over-fetching via fallbackRetryTop when --tail
 // is set so client-side filtering has room to find matches) and returns
 // fallback=true. On auth/not-found/network errors the error propagates unchanged.
-func fetchTxEntries(cl *client.Client, filter string, top int, orderDesc bool) ([]model.TransactionLogEntry, bool, error) {
+//
+// sinceSet/untilSet steer the retry order so the cap captures the right slice
+// of the log:
+//   - --until alone (forensic / audit) → retry ASC; the OLDEST entries are
+//     most likely to fall before untilTS, whereas DESC would return the
+//     latest N rows (all newer than untilTS) and silently produce empty output.
+//   - --since (with or without --until) → retry DESC so the cap retains the
+//     latest entries within the window; the user normally cares about recent
+//     data filtered by --since.
+//   - neither → retry DESC (latest rows by default).
+//
+// When untilSet is true and the fallback fires, an additional warning is
+// emitted: --until cannot be enforced server-side without $filter, so
+// historical entries past the retry window will be missed.
+func fetchTxEntries(cl *client.Client, filter string, top int, orderDesc, sinceSet, untilSet bool) ([]model.TransactionLogEntry, bool, error) {
 	endpoint := buildTxQuery(filter, top, orderDesc)
 	data, err := cl.Get(endpoint)
 	if err != nil {
 		if filter != "" && isFilterRejection(err) {
 			retryTop := fallbackRetryTop(top)
-			// Force DESC on retry so the cap retains the most recent entries —
-			// otherwise a --since query could return the oldest 1000 since epoch.
-			retryData, retryErr := cl.Get(buildTxQuery("", retryTop, true))
+			retryDesc := true
+			if untilSet && !sinceSet {
+				retryDesc = false
+			}
+			retryData, retryErr := cl.Get(buildTxQuery("", retryTop, retryDesc))
 			if retryErr != nil {
 				return nil, false, retryErr
 			}
@@ -180,6 +196,9 @@ func fetchTxEntries(cl *client.Client, filter string, top int, orderDesc bool) (
 				return nil, false, fmt.Errorf("cannot parse server response: %w", jerr)
 			}
 			emitFallbackWarning(retryTop, len(resp.Value))
+			if untilSet {
+				output.PrintWarning("--until cannot be enforced server-side under fallback; historical entries past the retry window will be missed. Narrow --tail, set --since, or accept the limitation.")
+			}
 			warnIfPaginated(resp.NextLink)
 			return resp.Value, true, nil
 		}
@@ -357,7 +376,9 @@ func followTxLogs(ctx context.Context, cl *client.Client, watermarkTS string, wa
 		}
 
 		filter := buildTxFilter(watermarkTS, "", cube, user)
-		entries, fallback, err := fetchTxEntries(cl, filter, 0, false)
+		// --until is mutually exclusive with --follow, so untilSet is false.
+		// sinceSet is true because the watermark itself is a since-anchor.
+		entries, fallback, err := fetchTxEntries(cl, filter, 0, false, true, false)
 		if err != nil {
 			output.PrintWarning(fmt.Sprintf("poll failed: %s", err))
 			continue
@@ -461,7 +482,7 @@ func runLogsTx(cmd *cobra.Command, args []string) error {
 	}
 
 	filter := buildTxFilter(sinceTS, untilTS, logsTxCube, logsTxUser)
-	entries, fallback, err := fetchTxEntries(cl, filter, tail, tail > 0)
+	entries, fallback, err := fetchTxEntries(cl, filter, tail, tail > 0, sinceTS != "", untilTS != "")
 	if err != nil {
 		output.PrintError(err.Error(), jsonMode)
 		return errSilent

--- a/cmd/logs_tx.go
+++ b/cmd/logs_tx.go
@@ -413,17 +413,25 @@ func followTxLogs(ctx context.Context, cl *client.Client, watermarkTS string, wa
 		}
 
 		if seenMaxTS != "" {
-			// When the new boundary timestamp matches the prior watermark,
-			// MERGE the new IDs into the existing dedup set. Replacing would
-			// drop prior boundary IDs and re-emit them on the next poll if
-			// the server keeps returning them at the same TimeStamp.
+			// The watermark must be MONOTONIC — never regress. Under fallback,
+			// the server returns the unfiltered log; dedupe can strip the
+			// latest rows leaving older entries whose seenMaxTS is BEFORE
+			// watermarkTS. Accepting that would forget the prior boundary IDs
+			// and re-emit the original entries on the next poll, indefinitely.
+			seenT, seenErr := parseTimeStamp(seenMaxTS)
+			curT, curErr := parseTimeStamp(watermarkTS)
 			if seenMaxTS == watermarkTS {
+				// Same boundary: MERGE new IDs into the existing dedup set.
+				// Replacing would drop prior boundary IDs and re-emit them
+				// next poll if the server keeps returning them at this TS.
 				for k, v := range seenIDs {
 					watermarkIDs[k] = v
 				}
-			} else {
+			} else if seenErr == nil && (curErr != nil || seenT.After(curT)) {
+				// Strictly later boundary: advance.
 				watermarkTS, watermarkIDs = advanceWatermark(seenMaxTS, seenIDs)
 			}
+			// else: seenMaxTS is older than watermarkTS — ignore (do not regress).
 		}
 	}
 }
@@ -506,8 +514,14 @@ func runLogsTx(cmd *cobra.Command, args []string) error {
 
 	// Fallback over-fetches via fallbackTailMultiplier so client-side filtering
 	// has room to find matches; trim back to the user-requested --tail before
-	// display. Server-returned entries are DESC, so [:tail] keeps the newest.
+	// display. We sort DESC first so [:tail] always keeps the LATEST N — the
+	// retry order is conditional (DESC for --since/default, ASC for
+	// --until-only forensic queries), so a naive [:tail] would otherwise
+	// silently keep the OLDEST N under ASC retry, violating --tail semantics.
 	if fallback && tail > 0 && len(entries) > tail {
+		sort.SliceStable(entries, func(i, j int) bool {
+			return entries[i].TimeStamp > entries[j].TimeStamp
+		})
 		entries = entries[:tail]
 	}
 

--- a/cmd/logs_tx.go
+++ b/cmd/logs_tx.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/url"
 	"os"
@@ -62,7 +63,7 @@ func odataEscape(s string) string {
 func parseTimeFlag(name, value string, now time.Time) (string, error) {
 	ts, err := parseSince(value, now)
 	if err != nil {
-		return "", fmt.Errorf("%s", strings.Replace(err.Error(), "--since", name, 1))
+		return "", errors.New(strings.Replace(err.Error(), "--since", name, 1))
 	}
 	return ts, nil
 }

--- a/cmd/logs_tx.go
+++ b/cmd/logs_tx.go
@@ -1,0 +1,480 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"os"
+	"os/signal"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+	"tm1cli/internal/client"
+	"tm1cli/internal/model"
+	"tm1cli/internal/output"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	logsTxSince    string
+	logsTxUntil    string
+	logsTxCube     string
+	logsTxUser     string
+	logsTxFollow   bool
+	logsTxInterval time.Duration
+	logsTxTail     int
+	logsTxRaw      bool
+)
+
+var logsTxCmd = &cobra.Command{
+	Use:   "tx",
+	Short: "Show and stream the TM1 transaction log",
+	Long: `Show and stream the TM1 transaction log (cell-value changes).
+
+REST API: GET /TransactionLogEntries
+
+Filter by time range, cube, or user. Use --follow to stream new entries
+kubectl-style; --tail to show the last N entries.
+
+--cube and --user are matched case-sensitively (server-side OData eq); when
+the server cannot apply $filter, the client falls back to the same
+case-sensitive equality.
+
+When --follow is combined with --output json, entries are emitted as NDJSON
+(one JSON object per line) instead of a JSON array.`,
+	Example: `  tm1cli logs tx --tail 50
+  tm1cli logs tx --since 10m --cube Sales
+  tm1cli logs tx --user admin --follow
+  tm1cli logs tx --since 2026-04-24T10:00 --until 2026-04-24T18:00 --raw`,
+	RunE: runLogsTx,
+}
+
+// odataEscape doubles embedded single quotes per OData v4 string literal rules.
+func odataEscape(s string) string {
+	return strings.ReplaceAll(s, "'", "''")
+}
+
+// parseTimeFlag wraps parseSince so error messages name the originating flag
+// (e.g. "--until value ..." instead of "--since value ...").
+func parseTimeFlag(name, value string, now time.Time) (string, error) {
+	ts, err := parseSince(value, now)
+	if err != nil {
+		return "", fmt.Errorf("%s", strings.Replace(err.Error(), "--since", name, 1))
+	}
+	return ts, nil
+}
+
+// formatTxValue renders a TM1 Edm.PrimitiveType value (string, number, bool,
+// or null) for table/raw output. JSON strings are unquoted; everything else
+// is rendered as the trimmed raw bytes; null and empty become "".
+func formatTxValue(raw json.RawMessage) string {
+	trimmed := strings.TrimSpace(string(raw))
+	if trimmed == "" || trimmed == "null" {
+		return ""
+	}
+	if strings.HasPrefix(trimmed, "\"") {
+		var s string
+		if err := json.Unmarshal(raw, &s); err == nil {
+			return s
+		}
+	}
+	return trimmed
+}
+
+// txIDKey returns the dedupe map key for a transaction-log entry. Zero means
+// the server omitted ID — those entries skip dedupe registration.
+func txIDKey(id int64) string {
+	if id == 0 {
+		return ""
+	}
+	return strconv.FormatInt(id, 10)
+}
+
+// tupleString renders a TM1 cell coordinate as colon-joined elements, matching
+// the cellset coord convention used elsewhere in the project.
+func tupleString(t []string) string {
+	return strings.Join(t, ":")
+}
+
+// buildTxFilter assembles the OData $filter from time bounds and exact-match
+// cube/user. Empty inputs are skipped. User and Cube use OData eq with
+// odata-escaped string literals.
+func buildTxFilter(sinceTS, untilTS, cube, user string) string {
+	var parts []string
+	if sinceTS != "" {
+		parts = append(parts, fmt.Sprintf("TimeStamp ge %s", sinceTS))
+	}
+	if untilTS != "" {
+		parts = append(parts, fmt.Sprintf("TimeStamp le %s", untilTS))
+	}
+	if cube != "" {
+		parts = append(parts, fmt.Sprintf("Cube eq '%s'", odataEscape(cube)))
+	}
+	if user != "" {
+		parts = append(parts, fmt.Sprintf("User eq '%s'", odataEscape(user)))
+	}
+	return strings.Join(parts, " and ")
+}
+
+// buildTxQuery builds the endpoint URL with $filter, $top, $orderby using
+// url.Values for safe encoding.
+func buildTxQuery(filter string, top int, orderDesc bool) string {
+	v := url.Values{}
+	if filter != "" {
+		v.Set("$filter", filter)
+	}
+	if top > 0 {
+		v.Set("$top", strconv.Itoa(top))
+	}
+	if orderDesc {
+		v.Set("$orderby", "TimeStamp desc")
+	}
+	if len(v) == 0 {
+		return "TransactionLogEntries"
+	}
+	return "TransactionLogEntries?" + v.Encode()
+}
+
+// fetchTxEntries performs GET. On HTTP 400/501 with a filter-rejection body,
+// it retries without $filter (capping $top at fallbackSafetyCap when no
+// --tail was given) and returns fallback=true. On auth/not-found/network
+// errors the error propagates unchanged.
+func fetchTxEntries(cl *client.Client, filter string, top int, orderDesc bool) ([]model.TransactionLogEntry, bool, error) {
+	endpoint := buildTxQuery(filter, top, orderDesc)
+	data, err := cl.Get(endpoint)
+	if err != nil {
+		if filter != "" && isFilterRejection(err) {
+			retryTop := top
+			if retryTop == 0 {
+				retryTop = fallbackSafetyCap
+			}
+			// Force DESC on retry so the cap retains the most recent entries —
+			// otherwise a --since query could return the oldest 1000 since epoch.
+			retryData, retryErr := cl.Get(buildTxQuery("", retryTop, true))
+			if retryErr != nil {
+				return nil, false, retryErr
+			}
+			var resp model.TransactionLogResponse
+			if jerr := json.Unmarshal(retryData, &resp); jerr != nil {
+				return nil, false, fmt.Errorf("cannot parse server response: %w", jerr)
+			}
+			output.PrintWarning("Server-side filter not supported, filtering locally...")
+			return resp.Value, true, nil
+		}
+		return nil, false, err
+	}
+	var resp model.TransactionLogResponse
+	if err := json.Unmarshal(data, &resp); err != nil {
+		return nil, false, fmt.Errorf("cannot parse server response: %w", err)
+	}
+	return resp.Value, false, nil
+}
+
+// applyTxClientFilters drops entries outside the [sinceTS, untilTS] window
+// and any whose Cube/User don't match exactly (case-sensitive — matches
+// server eq semantics).
+func applyTxClientFilters(entries []model.TransactionLogEntry, sinceTS, untilTS, cube, user string) []model.TransactionLogEntry {
+	var sinceT, untilT time.Time
+	if sinceTS != "" {
+		sinceT, _ = parseTimeStamp(sinceTS)
+	}
+	if untilTS != "" {
+		untilT, _ = parseTimeStamp(untilTS)
+	}
+
+	out := make([]model.TransactionLogEntry, 0, len(entries))
+	for _, e := range entries {
+		if !sinceT.IsZero() {
+			t, err := parseTimeStamp(e.TimeStamp)
+			if err != nil || t.Before(sinceT) {
+				continue
+			}
+		}
+		if !untilT.IsZero() {
+			t, err := parseTimeStamp(e.TimeStamp)
+			if err != nil || t.After(untilT) {
+				continue
+			}
+		}
+		if cube != "" && e.Cube != cube {
+			continue
+		}
+		if user != "" && e.User != user {
+			continue
+		}
+		out = append(out, e)
+	}
+	return out
+}
+
+// sortTxByTimeStamp sorts ascending; ties are broken by ID. Unparseable
+// timestamps go to the end stably.
+func sortTxByTimeStamp(entries []model.TransactionLogEntry) {
+	sort.SliceStable(entries, func(i, j int) bool {
+		ti, errI := parseTimeStamp(entries[i].TimeStamp)
+		tj, errJ := parseTimeStamp(entries[j].TimeStamp)
+		switch {
+		case errI != nil && errJ != nil:
+			return false
+		case errI != nil:
+			return false
+		case errJ != nil:
+			return true
+		case ti.Equal(tj):
+			return entries[i].ID < entries[j].ID
+		default:
+			return ti.Before(tj)
+		}
+	})
+}
+
+// reverseTxEntries reverses entries in place.
+func reverseTxEntries(entries []model.TransactionLogEntry) {
+	for i, j := 0, len(entries)-1; i < j; i, j = i+1, j-1 {
+		entries[i], entries[j] = entries[j], entries[i]
+	}
+}
+
+// boundaryTxIDs returns the maximum TimeStamp string in entries and the set
+// of dedupe keys whose timestamp equals it. Used by --follow to drop
+// boundary duplicates across polls.
+func boundaryTxIDs(entries []model.TransactionLogEntry) (string, map[string]struct{}) {
+	if len(entries) == 0 {
+		return "", nil
+	}
+	maxT, errFirst := parseTimeStamp(entries[0].TimeStamp)
+	hasMaxT := errFirst == nil
+	maxTS := entries[0].TimeStamp
+	for _, e := range entries[1:] {
+		t, err := parseTimeStamp(e.TimeStamp)
+		if err != nil {
+			continue
+		}
+		if !hasMaxT || t.After(maxT) {
+			maxT, maxTS, hasMaxT = t, e.TimeStamp, true
+		}
+	}
+	ids := map[string]struct{}{}
+	for _, e := range entries {
+		if e.TimeStamp != maxTS {
+			continue
+		}
+		if key := txIDKey(e.ID); key != "" {
+			ids[key] = struct{}{}
+		}
+	}
+	return maxTS, ids
+}
+
+// printTxEntries renders entries in the chosen format. In follow+jsonMode it
+// emits NDJSON (one object per line). In raw mode every string field is
+// passed through sanitizeRawMessage so each entry stays on a single line.
+func printTxEntries(entries []model.TransactionLogEntry, jsonMode, rawMode, isFollowChunk bool) {
+	if jsonMode {
+		if isFollowChunk {
+			for _, e := range entries {
+				data, _ := json.Marshal(e)
+				fmt.Println(string(data))
+			}
+			return
+		}
+		output.PrintJSON(entries)
+		return
+	}
+	if rawMode {
+		for _, e := range entries {
+			fmt.Printf("%s %s %s:%s %s -> %s %s\n",
+				e.TimeStamp,
+				sanitizeRawMessage(e.User),
+				sanitizeRawMessage(e.Cube),
+				sanitizeRawMessage(tupleString(e.Tuple)),
+				sanitizeRawMessage(formatTxValue(e.OldValue)),
+				sanitizeRawMessage(formatTxValue(e.NewValue)),
+				sanitizeRawMessage(e.StatusMessage),
+			)
+		}
+		return
+	}
+	headers := []string{"TIME", "USER", "CUBE", "TUPLE", "OLD", "NEW", "STATUS"}
+	rows := make([][]string, len(entries))
+	for i, e := range entries {
+		rows[i] = []string{
+			e.TimeStamp,
+			sanitizeRawMessage(e.User),
+			sanitizeRawMessage(e.Cube),
+			sanitizeRawMessage(tupleString(e.Tuple)),
+			sanitizeRawMessage(formatTxValue(e.OldValue)),
+			sanitizeRawMessage(formatTxValue(e.NewValue)),
+			sanitizeRawMessage(e.StatusMessage),
+		}
+	}
+	output.PrintTable(headers, rows)
+}
+
+// followTxLogs is the polling loop driven by ctx for testability.
+func followTxLogs(ctx context.Context, cl *client.Client, watermarkTS string, watermarkIDs map[string]struct{}, cube, user string, interval time.Duration, jsonMode, rawMode bool) error {
+	if watermarkIDs == nil {
+		watermarkIDs = map[string]struct{}{}
+	}
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-time.After(interval):
+		}
+
+		filter := buildTxFilter(watermarkTS, "", cube, user)
+		entries, fallback, err := fetchTxEntries(cl, filter, 0, false)
+		if err != nil {
+			output.PrintWarning(fmt.Sprintf("poll failed: %s", err))
+			continue
+		}
+
+		// Drop boundary duplicates first (clock-skew dedupe).
+		filtered := entries[:0]
+		for _, e := range entries {
+			if key := txIDKey(e.ID); key != "" {
+				if _, seen := watermarkIDs[key]; seen {
+					continue
+				}
+			}
+			filtered = append(filtered, e)
+		}
+		entries = filtered
+
+		// Compute next watermark from POST-DEDUP entries (what the server
+		// actually surfaced this poll), not from POST-client-filter — otherwise
+		// --cube/--user filtering everything out leaves the watermark frozen.
+		seenMaxTS, seenIDs := boundaryTxIDs(entries)
+
+		applySince, applyCube, applyUser := "", "", ""
+		if fallback {
+			applySince, applyCube, applyUser = watermarkTS, cube, user
+		}
+		if applySince != "" || applyCube != "" || applyUser != "" {
+			entries = applyTxClientFilters(entries, applySince, "", applyCube, applyUser)
+		}
+
+		if len(entries) > 0 {
+			sortTxByTimeStamp(entries)
+			printTxEntries(entries, jsonMode, rawMode, true)
+		}
+
+		if seenMaxTS != "" {
+			watermarkTS, watermarkIDs = advanceWatermark(seenMaxTS, seenIDs)
+		}
+	}
+}
+
+func runLogsTx(cmd *cobra.Command, args []string) error {
+	cfg, err := loadConfig()
+	if err != nil {
+		output.PrintError(err.Error(), isJSONOutput(nil))
+		return errSilent
+	}
+	jsonMode := isJSONOutput(cfg)
+
+	if logsTxRaw && jsonMode {
+		output.PrintError("--raw cannot be combined with --output json.", jsonMode)
+		return errSilent
+	}
+	if logsTxTail < 0 {
+		output.PrintError("--tail must be non-negative.", jsonMode)
+		return errSilent
+	}
+	if logsTxFollow && logsTxInterval <= 0 {
+		output.PrintError("--interval must be greater than zero (e.g. 5s).", jsonMode)
+		return errSilent
+	}
+	if logsTxFollow && logsTxUntil != "" {
+		output.PrintError("--until cannot be combined with --follow.", jsonMode)
+		return errSilent
+	}
+
+	now := time.Now()
+	sinceTS, err := parseTimeFlag("--since", logsTxSince, now)
+	if err != nil {
+		output.PrintError(err.Error(), jsonMode)
+		return errSilent
+	}
+	untilTS, err := parseTimeFlag("--until", logsTxUntil, now)
+	if err != nil {
+		output.PrintError(err.Error(), jsonMode)
+		return errSilent
+	}
+	if sinceTS != "" && untilTS != "" {
+		sinceT, _ := parseTimeStamp(sinceTS)
+		untilT, _ := parseTimeStamp(untilTS)
+		if untilT.Before(sinceT) {
+			output.PrintError("--since must be earlier than --until.", jsonMode)
+			return errSilent
+		}
+	}
+
+	tail := defaultTailIfUnbounded(logsTxSince, logsTxTail)
+
+	cl, err := createClient(cfg)
+	if err != nil {
+		output.PrintError(err.Error(), jsonMode)
+		return errSilent
+	}
+
+	filter := buildTxFilter(sinceTS, untilTS, logsTxCube, logsTxUser)
+	entries, fallback, err := fetchTxEntries(cl, filter, tail, tail > 0)
+	if err != nil {
+		output.PrintError(err.Error(), jsonMode)
+		return errSilent
+	}
+
+	// On fallback, apply all four filters client-side. On the success path,
+	// still apply --until client-side as defense in depth — TM1 may round
+	// timestamps server-side and surface entries slightly outside the window.
+	applySince, applyUntil, applyCube, applyUser := "", "", "", ""
+	if fallback {
+		applySince, applyUntil, applyCube, applyUser = sinceTS, untilTS, logsTxCube, logsTxUser
+	} else if untilTS != "" {
+		applyUntil = untilTS
+	}
+	if applySince != "" || applyUntil != "" || applyCube != "" || applyUser != "" {
+		entries = applyTxClientFilters(entries, applySince, applyUntil, applyCube, applyUser)
+	}
+
+	if tail > 0 {
+		reverseTxEntries(entries)
+	} else {
+		sortTxByTimeStamp(entries)
+	}
+
+	// In --follow + --output json, the initial batch is also NDJSON so the
+	// stream is uniform — otherwise downstream parsers see a JSON array
+	// followed by raw objects and reject the input as invalid.
+	printTxEntries(entries, jsonMode, logsTxRaw, logsTxFollow)
+
+	if !logsTxFollow {
+		return nil
+	}
+
+	maxTS, ids := boundaryTxIDs(entries)
+	maxTS = resolveFollowWatermark(maxTS, sinceTS, time.Now())
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
+	defer stop()
+
+	return followTxLogs(ctx, cl, maxTS, ids, logsTxCube, logsTxUser, logsTxInterval, jsonMode, logsTxRaw)
+}
+
+func init() {
+	logsCmd.AddCommand(logsTxCmd)
+
+	logsTxCmd.Flags().StringVar(&logsTxSince, "since", "", "Show entries newer than duration (e.g. 10m, 2h) or timestamp (e.g. 2026-04-24T10:00 — interpreted as local time when no timezone is given)")
+	logsTxCmd.Flags().StringVar(&logsTxUntil, "until", "", "Show entries older than duration or timestamp (same syntax as --since)")
+	logsTxCmd.Flags().StringVar(&logsTxCube, "cube", "", "Filter by cube name (server-side; case-sensitive)")
+	logsTxCmd.Flags().StringVar(&logsTxUser, "user", "", "Filter by user name (server-side; case-sensitive)")
+	logsTxCmd.Flags().BoolVarP(&logsTxFollow, "follow", "f", false, "Stream new entries kubectl-style (--output json emits NDJSON)")
+	logsTxCmd.Flags().DurationVar(&logsTxInterval, "interval", 5*time.Second, "Polling interval when --follow is set")
+	logsTxCmd.Flags().IntVar(&logsTxTail, "tail", 0, "Show last N entries (defaults to 100 when no --since/--follow)")
+	logsTxCmd.Flags().BoolVar(&logsTxRaw, "raw", false, "Raw output: one line per entry (control characters in fields are collapsed to spaces)")
+}

--- a/cmd/logs_tx.go
+++ b/cmd/logs_tx.go
@@ -415,7 +415,7 @@ func runLogsTx(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	tail := defaultTailIfUnbounded(logsTxSince, logsTxTail)
+	tail := defaultTailIfUnbounded(logsTxSince != "" || logsTxUntil != "", logsTxTail)
 
 	cl, err := createClient(cfg)
 	if err != nil {

--- a/cmd/logs_tx.go
+++ b/cmd/logs_tx.go
@@ -140,18 +140,15 @@ func buildTxQuery(filter string, top int, orderDesc bool) string {
 }
 
 // fetchTxEntries performs GET. On HTTP 400/501 with a filter-rejection body,
-// it retries without $filter (capping $top at fallbackSafetyCap when no
-// --tail was given) and returns fallback=true. On auth/not-found/network
-// errors the error propagates unchanged.
+// it retries without $filter (over-fetching via fallbackRetryTop when --tail
+// is set so client-side filtering has room to find matches) and returns
+// fallback=true. On auth/not-found/network errors the error propagates unchanged.
 func fetchTxEntries(cl *client.Client, filter string, top int, orderDesc bool) ([]model.TransactionLogEntry, bool, error) {
 	endpoint := buildTxQuery(filter, top, orderDesc)
 	data, err := cl.Get(endpoint)
 	if err != nil {
 		if filter != "" && isFilterRejection(err) {
-			retryTop := top
-			if retryTop == 0 {
-				retryTop = fallbackSafetyCap
-			}
+			retryTop := fallbackRetryTop(top)
 			// Force DESC on retry so the cap retains the most recent entries —
 			// otherwise a --since query could return the oldest 1000 since epoch.
 			retryData, retryErr := cl.Get(buildTxQuery("", retryTop, true))
@@ -441,6 +438,13 @@ func runLogsTx(cmd *cobra.Command, args []string) error {
 	}
 	if applySince != "" || applyUntil != "" || applyCube != "" || applyUser != "" {
 		entries = applyTxClientFilters(entries, applySince, applyUntil, applyCube, applyUser)
+	}
+
+	// Fallback over-fetches via fallbackTailMultiplier so client-side filtering
+	// has room to find matches; trim back to the user-requested --tail before
+	// display. Server-returned entries are DESC, so [:tail] keeps the newest.
+	if fallback && tail > 0 && len(entries) > tail {
+		entries = entries[:tail]
 	}
 
 	if tail > 0 {

--- a/cmd/logs_tx_test.go
+++ b/cmd/logs_tx_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math"
 	"net/http"
 	"strings"
 	"sync/atomic"
@@ -1168,6 +1169,8 @@ func TestFallbackRetryTop(t *testing.T) {
 		{"top at half-cap stays buffered", 99, 990},
 		{"top equal to cap clamps to cap", fallbackSafetyCap / fallbackTailMultiplier, fallbackSafetyCap},
 		{"top above cap clamps to cap", 5000, fallbackSafetyCap},
+		// Regression guard: very large --tail must not overflow the multiply.
+		{"top near math.MaxInt32 clamps without overflow", math.MaxInt32, fallbackSafetyCap},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/cmd/logs_tx_test.go
+++ b/cmd/logs_tx_test.go
@@ -1156,6 +1156,51 @@ func TestRunLogsTx_FilterFallbackBuffersTailForCubeFilter(t *testing.T) {
 	}
 }
 
+// TestInitialFollowWatermark_AdvancesPastBoundaryWhenIDsOmitted is a
+// regression guard for older TM1 versions where TransactionLogEntries omits
+// the ID field. boundaryTxIDs then returns an empty dedupe set, and the
+// inclusive `TimeStamp ge` filter on the first follow poll would re-emit
+// the boundary entry. initialFollowWatermark must advance the watermark
+// past the boundary so the first poll's filter excludes it.
+func TestInitialFollowWatermark_AdvancesPastBoundaryWhenIDsOmitted(t *testing.T) {
+	boundaryTS := "2026-04-25T10:01:00Z"
+	entries := []model.TransactionLogEntry{
+		{ID: 0, TimeStamp: boundaryTS, User: "u", Cube: "C", Tuple: []string{"x"},
+			OldValue: json.RawMessage(`0`), NewValue: json.RawMessage(`1`)},
+	}
+	maxTS, ids := initialFollowWatermark(entries, "", time.Now())
+	if len(ids) != 0 {
+		t.Errorf("expected empty dedupe set when ID omitted, got %v", ids)
+	}
+	boundary, _ := parseTimeStamp(boundaryTS)
+	advanced, err := parseTimeStamp(maxTS)
+	if err != nil {
+		t.Fatalf("watermark unparseable: %v", err)
+	}
+	if !advanced.After(boundary) {
+		t.Errorf("watermark %s should be after boundary %s — first poll would re-emit it", maxTS, boundaryTS)
+	}
+}
+
+// TestInitialFollowWatermark_KeepsBoundaryWhenIDsPresent verifies the
+// happy-path: when TM1 supplies IDs, the watermark stays at the boundary
+// (so an entry that arrived at the same exact timestamp on the next poll
+// is fetched, then dropped via the dedupe set).
+func TestInitialFollowWatermark_KeepsBoundaryWhenIDsPresent(t *testing.T) {
+	boundaryTS := "2026-04-25T10:01:00Z"
+	entries := []model.TransactionLogEntry{
+		{ID: 42, TimeStamp: boundaryTS, User: "u", Cube: "C", Tuple: []string{"x"},
+			OldValue: json.RawMessage(`0`), NewValue: json.RawMessage(`1`)},
+	}
+	maxTS, ids := initialFollowWatermark(entries, "", time.Now())
+	if maxTS != boundaryTS {
+		t.Errorf("watermark should stay at boundary %s, got %s", boundaryTS, maxTS)
+	}
+	if _, ok := ids["42"]; !ok {
+		t.Errorf("dedupe set should contain ID 42, got %v", ids)
+	}
+}
+
 // TestRunLogsTx_FallbackWarningDisclosesCap verifies the fallback warning
 // states the row cap so users know the local filter is bounded. Without
 // disclosure, a --since query that hits the cap silently drops matching

--- a/cmd/logs_tx_test.go
+++ b/cmd/logs_tx_test.go
@@ -1156,6 +1156,118 @@ func TestRunLogsTx_FilterFallbackBuffersTailForCubeFilter(t *testing.T) {
 	}
 }
 
+// TestRunLogsTx_FallbackWarningDisclosesCap verifies the fallback warning
+// states the row cap so users know the local filter is bounded. Without
+// disclosure, a --since query that hits the cap silently drops matching
+// entries while the warning falsely implies a complete local filter.
+func TestRunLogsTx_FallbackWarningDisclosesCap(t *testing.T) {
+	resetCmdFlags(t)
+	logsTxSince = "2026-04-25T10:00:00Z"
+	logsTxCube = "Sales"
+
+	var requestCount int32
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&requestCount, 1)
+		w.Header().Set("Content-Type", "application/json")
+		if n == 1 {
+			w.WriteHeader(http.StatusBadRequest)
+			fmt.Fprint(w, `{"error":"$filter not supported"}`)
+			return
+		}
+		w.Write(transactionLogJSON())
+	})
+
+	out := captureAll(t, func() {
+		if err := runLogsTx(logsTxCmd, nil); err != nil {
+			t.Fatalf("unexpected: %v", err)
+		}
+	})
+
+	wantCap := fmt.Sprintf("most recent %d entries", fallbackSafetyCap)
+	if !strings.Contains(out.Stderr, wantCap) {
+		t.Errorf("fallback warning should disclose row cap %q, got: %q", wantCap, out.Stderr)
+	}
+}
+
+// TestRunLogsTx_FallbackAtCapWarnsTruncation verifies the second warning
+// fires when the retry returns exactly retryTop rows — a strong signal the
+// cap was hit and matches likely exist beyond the window.
+func TestRunLogsTx_FallbackAtCapWarnsTruncation(t *testing.T) {
+	resetCmdFlags(t)
+	logsTxTail = 5
+	logsTxCube = "Sales"
+
+	const retryTop = 5 * fallbackTailMultiplier // 50, matches fallbackRetryTop(5)
+
+	var requestCount int32
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&requestCount, 1)
+		w.Header().Set("Content-Type", "application/json")
+		if n == 1 {
+			w.WriteHeader(http.StatusBadRequest)
+			fmt.Fprint(w, `{"error":"$filter not supported"}`)
+			return
+		}
+		entries := make([]model.TransactionLogEntry, 0, retryTop)
+		for i := 0; i < retryTop; i++ {
+			entries = append(entries, model.TransactionLogEntry{
+				ID:        int64(i + 1),
+				TimeStamp: time.Date(2026, 4, 25, 10, 0, i, 0, time.UTC).Format(time.RFC3339),
+				User:      "u",
+				Cube:      "Sales",
+				Tuple:     []string{"x"},
+				OldValue:  json.RawMessage(`0`),
+				NewValue:  json.RawMessage(`1`),
+			})
+		}
+		w.Write(transactionLogJSON(entries...))
+	})
+
+	out := captureAll(t, func() {
+		if err := runLogsTx(logsTxCmd, nil); err != nil {
+			t.Fatalf("unexpected: %v", err)
+		}
+	})
+
+	wantCapMsg := fmt.Sprintf("Hit fallback cap of %d", retryTop)
+	if !strings.Contains(out.Stderr, wantCapMsg) {
+		t.Errorf("at-cap retry should emit truncation warning %q, got: %q", wantCapMsg, out.Stderr)
+	}
+}
+
+// TestRunLogsTx_FallbackBelowCapNoTruncationWarning verifies the second
+// warning does NOT fire when the retry returns fewer rows than retryTop —
+// in that case there are no entries beyond the window, so warning the user
+// about truncation would be misleading.
+func TestRunLogsTx_FallbackBelowCapNoTruncationWarning(t *testing.T) {
+	resetCmdFlags(t)
+	logsTxCube = "Sales"
+
+	var requestCount int32
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&requestCount, 1)
+		w.Header().Set("Content-Type", "application/json")
+		if n == 1 {
+			w.WriteHeader(http.StatusBadRequest)
+			fmt.Fprint(w, `{"error":"$filter not supported"}`)
+			return
+		}
+		w.Write(transactionLogJSON(
+			model.TransactionLogEntry{ID: 1, TimeStamp: "2026-04-25T10:00:00Z", User: "u", Cube: "Sales", Tuple: []string{"x"}, OldValue: json.RawMessage(`0`), NewValue: json.RawMessage(`1`)},
+		))
+	})
+
+	out := captureAll(t, func() {
+		if err := runLogsTx(logsTxCmd, nil); err != nil {
+			t.Fatalf("unexpected: %v", err)
+		}
+	})
+
+	if strings.Contains(out.Stderr, "Hit fallback cap") {
+		t.Errorf("below-cap retry should not emit truncation warning, got: %q", out.Stderr)
+	}
+}
+
 // TestFallbackRetryTop covers the helper directly.
 func TestFallbackRetryTop(t *testing.T) {
 	tests := []struct {

--- a/cmd/logs_tx_test.go
+++ b/cmd/logs_tx_test.go
@@ -736,13 +736,13 @@ func TestRunLogsTx_RawSanitizesAllFields(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		w.Write(transactionLogJSON(
 			model.TransactionLogEntry{
-				ID:        1,
-				TimeStamp: "2026-04-25T10:00:00Z",
-				User:      "ali\nce",
-				Cube:      "Sa\rles",
-				Tuple:     []string{"Q1\t", "2025"},
-				OldValue:  json.RawMessage(`"old\nval"`),
-				NewValue:  json.RawMessage(`"new\rval"`),
+				ID:            1,
+				TimeStamp:     "2026-04-25T10:00:00Z",
+				User:          "ali\nce",
+				Cube:          "Sa\rles",
+				Tuple:         []string{"Q1\t", "2025"},
+				OldValue:      json.RawMessage(`"old\nval"`),
+				NewValue:      json.RawMessage(`"new\rval"`),
 				StatusMessage: "status\nlines",
 			},
 		))
@@ -1176,7 +1176,7 @@ func TestRunLogsTx_TupleRendering(t *testing.T) {
 		w.Write(transactionLogJSON(
 			model.TransactionLogEntry{
 				ID: 1, TimeStamp: "2026-04-25T10:00:00Z", User: "u", Cube: "C",
-				Tuple: []string{"Q1", "2025", "Sales"},
+				Tuple:    []string{"Q1", "2025", "Sales"},
 				OldValue: json.RawMessage(`null`), NewValue: json.RawMessage(`42`),
 			},
 		))

--- a/cmd/logs_tx_test.go
+++ b/cmd/logs_tx_test.go
@@ -1080,6 +1080,104 @@ func TestRunLogsTx_FilterFallbackCapsTop(t *testing.T) {
 	}
 }
 
+// TestRunLogsTx_FilterFallbackBuffersTailForCubeFilter verifies that when
+// --tail is set alongside a content filter and the server rejects $filter,
+// the retry over-fetches via fallbackTailMultiplier so client-side filtering
+// can find tail-many matches even when most fetched rows are non-matching.
+// Without the buffer, --tail 5 --cube Sales on a server without $filter
+// support would return at most 5 rows from the latest 5 globally — possibly
+// zero matches.
+func TestRunLogsTx_FilterFallbackBuffersTailForCubeFilter(t *testing.T) {
+	resetCmdFlags(t)
+	logsTxTail = 5
+	logsTxCube = "Sales"
+
+	const wantBuffered = 5 * fallbackTailMultiplier // 50
+
+	var capturedRetryQuery string
+	var requestCount int32
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&requestCount, 1)
+		w.Header().Set("Content-Type", "application/json")
+		if n == 1 {
+			w.WriteHeader(http.StatusBadRequest)
+			fmt.Fprint(w, `{"error":"$filter not supported"}`)
+			return
+		}
+		capturedRetryQuery = r.URL.RawQuery
+		// Simulate a window where Sales matches are sparse: 60 rows, only 7
+		// match cube=Sales. Without the buffer the retry would fetch 5 rows
+		// none of which were Sales; with the buffer (50) we get 7 matches and
+		// truncate to 5.
+		entries := make([]model.TransactionLogEntry, 0, 60)
+		for i := 0; i < 60; i++ {
+			cube := "Inventory"
+			// Place 7 Sales rows interleaved among the newest entries.
+			if i < 7 {
+				cube = "Sales"
+			}
+			entries = append(entries, model.TransactionLogEntry{
+				ID:        int64(i + 1),
+				TimeStamp: time.Date(2026, 4, 25, 10, 0, i, 0, time.UTC).Format(time.RFC3339),
+				User:      "u",
+				Cube:      cube,
+				Tuple:     []string{"x"},
+				OldValue:  json.RawMessage(`0`),
+				NewValue:  json.RawMessage(`1`),
+			})
+		}
+		w.Write(transactionLogJSON(entries...))
+	})
+
+	out := captureAll(t, func() {
+		if err := runLogsTx(logsTxCmd, nil); err != nil {
+			t.Fatalf("unexpected: %v", err)
+		}
+	})
+
+	decoded, _ := decodedQuery(capturedRetryQuery)
+	if !strings.Contains(decoded, fmt.Sprintf("$top=%d", wantBuffered)) {
+		t.Errorf("retry query %q should buffer $top to %d (=tail*multiplier)", decoded, wantBuffered)
+	}
+	if !strings.Contains(decoded, "$orderby=TimeStamp desc") {
+		t.Errorf("retry query %q should force desc order", decoded)
+	}
+	// Only Sales rows should remain after client filter, and at most --tail=5
+	// after truncation. Inventory must NOT appear.
+	if strings.Contains(out.Stdout, "Inventory") {
+		t.Errorf("stdout should not contain Inventory after client filter:\n%s", out.Stdout)
+	}
+	salesCount := strings.Count(out.Stdout, "Sales")
+	// Headers contain "Sales" only via row data; with 7 matches truncated to
+	// 5, we expect exactly 5 "Sales" cells.
+	if salesCount != 5 {
+		t.Errorf("expected exactly 5 Sales rows after truncation, got %d:\n%s", salesCount, out.Stdout)
+	}
+}
+
+// TestFallbackRetryTop covers the helper directly.
+func TestFallbackRetryTop(t *testing.T) {
+	tests := []struct {
+		name string
+		top  int
+		want int
+	}{
+		{"top=0 returns safety cap", 0, fallbackSafetyCap},
+		{"top=1 buffered to 10", 1, 10},
+		{"top=50 buffered to 500", 50, 500},
+		{"top at half-cap stays buffered", 99, 990},
+		{"top equal to cap clamps to cap", fallbackSafetyCap / fallbackTailMultiplier, fallbackSafetyCap},
+		{"top above cap clamps to cap", 5000, fallbackSafetyCap},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := fallbackRetryTop(tt.top); got != tt.want {
+				t.Errorf("fallbackRetryTop(%d) = %d, want %d", tt.top, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestRunLogsTx_NoFallbackOn401(t *testing.T) {
 	resetCmdFlags(t)
 	logsTxCube = "Sales"

--- a/cmd/logs_tx_test.go
+++ b/cmd/logs_tx_test.go
@@ -124,22 +124,47 @@ func TestFormatTxValue(t *testing.T) {
 // ============================================================
 
 func TestTxIDKey(t *testing.T) {
-	tests := []struct {
-		id   int64
-		want string
-	}{
-		{0, ""},
-		{1, "1"},
-		{12345, "12345"},
-		{9223372036854775807, "9223372036854775807"}, // max int64
-	}
-	for _, tt := range tests {
-		t.Run(fmt.Sprintf("id=%d", tt.id), func(t *testing.T) {
-			if got := txIDKey(tt.id); got != tt.want {
-				t.Errorf("txIDKey(%d) = %q, want %q", tt.id, got, tt.want)
-			}
-		})
-	}
+	t.Run("uses ID when present", func(t *testing.T) {
+		e := model.TransactionLogEntry{ID: 12345}
+		if got := txIDKey(e); got != "12345" {
+			t.Errorf("txIDKey(ID=12345) = %q, want %q", got, "12345")
+		}
+	})
+	t.Run("max int64", func(t *testing.T) {
+		e := model.TransactionLogEntry{ID: 9223372036854775807}
+		if got := txIDKey(e); got != "9223372036854775807" {
+			t.Errorf("txIDKey(maxInt64) = %q", got)
+		}
+	})
+	t.Run("synthesizes key when ID omitted", func(t *testing.T) {
+		e := model.TransactionLogEntry{
+			ID: 0, TimeStamp: "2026-04-25T10:00:00Z", User: "u", Cube: "C",
+			Tuple: []string{"x"}, OldValue: json.RawMessage(`0`), NewValue: json.RawMessage(`1`),
+		}
+		got := txIDKey(e)
+		if got == "" {
+			t.Errorf("txIDKey for ID=0 must synthesize a non-empty key")
+		}
+		if !strings.HasPrefix(got, "syn") {
+			t.Errorf("synthetic key should be prefixed to avoid colliding with numeric IDs, got %q", got)
+		}
+	})
+	t.Run("synthesized keys differ for distinct same-timestamp entries", func(t *testing.T) {
+		ts := "2026-04-25T10:00:00Z"
+		a := model.TransactionLogEntry{ID: 0, TimeStamp: ts, User: "u", Cube: "C", Tuple: []string{"x"}, OldValue: json.RawMessage(`0`), NewValue: json.RawMessage(`1`)}
+		b := model.TransactionLogEntry{ID: 0, TimeStamp: ts, User: "u", Cube: "C", Tuple: []string{"y"}, OldValue: json.RawMessage(`0`), NewValue: json.RawMessage(`2`)}
+		if txIDKey(a) == txIDKey(b) {
+			t.Errorf("distinct same-timestamp entries must produce distinct synth keys")
+		}
+	})
+	t.Run("synthesized keys match for identical entries", func(t *testing.T) {
+		ts := "2026-04-25T10:00:00Z"
+		a := model.TransactionLogEntry{ID: 0, TimeStamp: ts, User: "u", Cube: "C", Tuple: []string{"x"}, OldValue: json.RawMessage(`0`), NewValue: json.RawMessage(`1`)}
+		b := model.TransactionLogEntry{ID: 0, TimeStamp: ts, User: "u", Cube: "C", Tuple: []string{"x"}, OldValue: json.RawMessage(`0`), NewValue: json.RawMessage(`1`)}
+		if txIDKey(a) != txIDKey(b) {
+			t.Errorf("identical entries must produce identical synth keys")
+		}
+	})
 }
 
 // ============================================================
@@ -408,17 +433,23 @@ func TestBoundaryTxIDs(t *testing.T) {
 		}
 	})
 
-	t.Run("ID-less entries skipped from dedupe set", func(t *testing.T) {
+	t.Run("ID-less entries get synthetic dedupe key", func(t *testing.T) {
+		// Older TM1 omits ID. Synthetic content keys preserve dedupe coverage
+		// without skipping the entry — important for tx logs where same-
+		// timestamp batch writes are common.
 		entries := []model.TransactionLogEntry{
-			{ID: 0, TimeStamp: "2026-04-25T12:00:00Z"},
+			{ID: 0, TimeStamp: "2026-04-25T12:00:00Z", User: "u", Cube: "C", Tuple: []string{"x"}, OldValue: json.RawMessage(`0`), NewValue: json.RawMessage(`1`)},
 			{ID: 5, TimeStamp: "2026-04-25T12:00:00Z"},
 		}
 		ts, ids := boundaryTxIDs(entries)
 		if ts != "2026-04-25T12:00:00Z" {
 			t.Errorf("ts = %q", ts)
 		}
-		if len(ids) != 1 {
-			t.Errorf("ID-less entry should be skipped; got %v", ids)
+		if len(ids) != 2 {
+			t.Errorf("both boundary entries should be in dedupe set (one numeric, one synthetic); got %d: %v", len(ids), ids)
+		}
+		if _, ok := ids["5"]; !ok {
+			t.Errorf("numeric ID should appear as-is, got %v", ids)
 		}
 	})
 }
@@ -1156,29 +1187,28 @@ func TestRunLogsTx_FilterFallbackBuffersTailForCubeFilter(t *testing.T) {
 	}
 }
 
-// TestInitialFollowWatermark_AdvancesPastBoundaryWhenIDsOmitted is a
-// regression guard for older TM1 versions where TransactionLogEntries omits
-// the ID field. boundaryTxIDs then returns an empty dedupe set, and the
-// inclusive `TimeStamp ge` filter on the first follow poll would re-emit
-// the boundary entry. initialFollowWatermark must advance the watermark
-// past the boundary so the first poll's filter excludes it.
-func TestInitialFollowWatermark_AdvancesPastBoundaryWhenIDsOmitted(t *testing.T) {
+// TestInitialFollowWatermark_DedupesBoundaryWhenIDsOmitted is a regression
+// guard for older TM1 versions where TransactionLogEntries omits the ID
+// field. The watermark stays at the boundary timestamp (so same-timestamp
+// new arrivals on the next poll aren't skipped — common in tx logs where
+// batch writes share a timestamp), and the dedup set holds a synthetic
+// content key so the boundary entry isn't re-emitted.
+func TestInitialFollowWatermark_DedupesBoundaryWhenIDsOmitted(t *testing.T) {
 	boundaryTS := "2026-04-25T10:01:00Z"
 	entries := []model.TransactionLogEntry{
 		{ID: 0, TimeStamp: boundaryTS, User: "u", Cube: "C", Tuple: []string{"x"},
 			OldValue: json.RawMessage(`0`), NewValue: json.RawMessage(`1`)},
 	}
 	maxTS, ids := initialFollowWatermark(entries, "", time.Now())
-	if len(ids) != 0 {
-		t.Errorf("expected empty dedupe set when ID omitted, got %v", ids)
+	if maxTS != boundaryTS {
+		t.Errorf("watermark should stay at boundary %s (synthetic key handles dedupe), got %s", boundaryTS, maxTS)
 	}
-	boundary, _ := parseTimeStamp(boundaryTS)
-	advanced, err := parseTimeStamp(maxTS)
-	if err != nil {
-		t.Fatalf("watermark unparseable: %v", err)
+	if len(ids) != 1 {
+		t.Errorf("expected synthetic dedupe key for ID-less boundary entry, got %v", ids)
 	}
-	if !advanced.After(boundary) {
-		t.Errorf("watermark %s should be after boundary %s — first poll would re-emit it", maxTS, boundaryTS)
+	wantKey := txIDKey(entries[0])
+	if _, ok := ids[wantKey]; !ok {
+		t.Errorf("dedup set should contain synthetic key %q, got %v", wantKey, ids)
 	}
 }
 
@@ -1642,5 +1672,126 @@ func TestFollowTxLogs_DropsDuplicateIDsAtBoundary(t *testing.T) {
 	countB := strings.Count(out.Stdout, "2026-04-25T10:02:00Z")
 	if countB != 1 {
 		t.Errorf("entry B should appear exactly once, got %d times in:\n%s", countB, out.Stdout)
+	}
+}
+
+// TestFollowTxLogs_MergesBoundaryIDsAcrossSameTimestampPolls is a regression
+// guard for the prior bug where each poll *replaced* the dedup set with the
+// IDs of post-dedup boundary entries. When new entries arrived at the same
+// timestamp as the prior watermark, the old boundary IDs were dropped and
+// the server's next response re-emitted them.
+//
+// Sequence:
+//   poll1: server returns [A@T]. dedup set becomes {A}.
+//   poll2: server returns [A@T, B@T] (B is new at the same timestamp).
+//          Dedup drops A, leaves [B]. Without the merge, dedup set becomes {B}.
+//   poll3: server returns [A@T, B@T] again (A is at the inclusive lower bound).
+//          Dedup against {B} only drops B — A is re-emitted. With the merge,
+//          dedup set is {A,B} and both are dropped.
+func TestFollowTxLogs_MergesBoundaryIDsAcrossSameTimestampPolls(t *testing.T) {
+	resetCmdFlags(t)
+
+	const ts = "2026-04-25T10:00:00Z"
+	entryA := model.TransactionLogEntry{ID: 1, TimeStamp: ts, User: "u", Cube: "C", Tuple: []string{"x"}, OldValue: json.RawMessage(`0`), NewValue: json.RawMessage(`1`)}
+	entryB := model.TransactionLogEntry{ID: 2, TimeStamp: ts, User: "u", Cube: "C", Tuple: []string{"y"}, OldValue: json.RawMessage(`0`), NewValue: json.RawMessage(`2`)}
+
+	var pollCount int32
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		n := int(atomic.AddInt32(&pollCount, 1))
+		w.Header().Set("Content-Type", "application/json")
+		switch n {
+		case 1:
+			// Initial follow has already emitted [A]; pretend B just arrived.
+			w.Write(transactionLogJSON(entryA, entryB))
+		default:
+			// Subsequent polls keep returning the boundary entries — server's
+			// inclusive `TimeStamp ge ts` always includes them.
+			w.Write(transactionLogJSON(entryA, entryB))
+		}
+	})
+
+	cfg, _ := loadConfig()
+	cl, _ := createClient(cfg)
+	ctx, cancel := context.WithCancel(context.Background())
+
+	out := captureAll(t, func() {
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			// Start with watermarkIDs={1} (A already seen) and watermarkTS=ts.
+			// Raw mode keeps each entry on a single line with deterministic
+			// "old -> new" formatting we can count on.
+			followTxLogs(ctx, cl, ts, map[string]struct{}{"1": {}}, "", "", 5*time.Millisecond, false, true)
+		}()
+		for i := 0; i < 200; i++ {
+			if atomic.LoadInt32(&pollCount) >= 3 {
+				break
+			}
+			time.Sleep(5 * time.Millisecond)
+		}
+		cancel()
+		<-done
+	})
+
+	// B should appear exactly once (emitted on poll1).
+	if got := strings.Count(out.Stdout, "0 -> 2"); got != 1 {
+		t.Errorf("entry B should appear exactly once, got %d:\n%s", got, out.Stdout)
+	}
+	// A should NEVER appear (it was already in the prior dedup set, and the
+	// merge keeps it across same-timestamp polls).
+	if got := strings.Count(out.Stdout, "0 -> 1"); got != 0 {
+		t.Errorf("entry A should not be re-emitted across polls, got %d times:\n%s", got, out.Stdout)
+	}
+}
+
+// TestFetchTxEntries_WarnsOnPaginatedResponse is a regression guard ensuring
+// the @odata.nextLink continuation marker isn't silently dropped. Without
+// the warning, large --since/--until windows could return only the first
+// server page with no signal that the result set is incomplete.
+func TestFetchTxEntries_WarnsOnPaginatedResponse(t *testing.T) {
+	resetCmdFlags(t)
+
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"value":[],"@odata.nextLink":"TransactionLogEntries?$skiptoken=42"}`)
+	})
+
+	cfg, _ := loadConfig()
+	cl, _ := createClient(cfg)
+
+	out := captureAll(t, func() {
+		_, _, err := fetchTxEntries(cl, "", 0, false)
+		if err != nil {
+			t.Fatalf("unexpected: %v", err)
+		}
+	})
+
+	if !strings.Contains(out.Stderr, "paginated") {
+		t.Errorf("stderr should warn about paginated response, got: %q", out.Stderr)
+	}
+}
+
+// TestFetchTxEntries_NoWarningWhenNotPaginated is a sanity check that the
+// pagination warning only fires when @odata.nextLink is present.
+func TestFetchTxEntries_NoWarningWhenNotPaginated(t *testing.T) {
+	resetCmdFlags(t)
+
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"value":[]}`)
+	})
+
+	cfg, _ := loadConfig()
+	cl, _ := createClient(cfg)
+
+	out := captureAll(t, func() {
+		_, _, err := fetchTxEntries(cl, "", 0, false)
+		if err != nil {
+			t.Fatalf("unexpected: %v", err)
+		}
+	})
+
+	if strings.Contains(out.Stderr, "paginated") {
+		t.Errorf("stderr should not warn about pagination on full response, got: %q", out.Stderr)
 	}
 }

--- a/cmd/logs_tx_test.go
+++ b/cmd/logs_tx_test.go
@@ -1771,6 +1771,128 @@ func TestFetchTxEntries_WarnsOnPaginatedResponse(t *testing.T) {
 	}
 }
 
+// TestFollowTxLogs_FallbackDoesNotRegressWatermark is a regression guard
+// for a P0 bug where filter-fallback in --follow mode regressed the
+// watermark backwards on quiet polls. Sequence:
+//   - Initial state: watermarkTS=T2, watermarkIDs={2}.
+//   - Poll1: server rejects $filter, retry returns DESC unfiltered list
+//     [B@T2, A@T1]. Dedup against {2} drops B, leaving [A@T1].
+//     boundaryTxIDs([A]) yields seenMaxTS=T1 — STRICTLY EARLIER than the
+//     prior watermark T2.
+//   - With the bug: watermarkTS regresses to T1, watermarkIDs forgets {2}.
+//     Poll2 then re-emits B because B is no longer in the dedup set.
+//   - With the fix: watermark stays at T2 (older boundary ignored), B is
+//     never re-emitted across polls.
+func TestFollowTxLogs_FallbackDoesNotRegressWatermark(t *testing.T) {
+	resetCmdFlags(t)
+
+	const t1 = "2026-04-25T10:00:00Z"
+	const t2 = "2026-04-25T11:00:00Z"
+	entryA := model.TransactionLogEntry{ID: 1, TimeStamp: t1, User: "u", Cube: "C", Tuple: []string{"x"}, OldValue: json.RawMessage(`0`), NewValue: json.RawMessage(`1`)}
+	entryB := model.TransactionLogEntry{ID: 2, TimeStamp: t2, User: "u", Cube: "C", Tuple: []string{"y"}, OldValue: json.RawMessage(`0`), NewValue: json.RawMessage(`2`)}
+
+	var pollCount int32
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&pollCount, 1)
+		w.Header().Set("Content-Type", "application/json")
+		// Every poll: first request hits filter rejection, second is the
+		// unfiltered DESC retry returning both boundary entries.
+		if r.URL.Query().Get("$filter") != "" {
+			w.WriteHeader(http.StatusBadRequest)
+			fmt.Fprint(w, `{"error":"$filter not supported"}`)
+			return
+		}
+		_ = n
+		w.Write(transactionLogJSON(entryB, entryA))
+	})
+
+	cfg, _ := loadConfig()
+	cl, _ := createClient(cfg)
+	ctx, cancel := context.WithCancel(context.Background())
+
+	out := captureAll(t, func() {
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			// Watermark at T2 with B already in dedup set.
+			followTxLogs(ctx, cl, t2, map[string]struct{}{"2": {}}, "", "", 5*time.Millisecond, false, true)
+		}()
+		for i := 0; i < 200; i++ {
+			if atomic.LoadInt32(&pollCount) >= 6 {
+				break
+			}
+			time.Sleep(5 * time.Millisecond)
+		}
+		cancel()
+		<-done
+	})
+
+	// B (already seen, T2) must NEVER be re-emitted regardless of poll count.
+	if got := strings.Count(out.Stdout, "0 -> 2"); got != 0 {
+		t.Errorf("entry B should never be re-emitted, got %d times:\n%s", got, out.Stdout)
+	}
+	// A is at T1 < watermarkTS T2 — server returns it under fallback because
+	// $filter is gone, but client-side since-filter (set to watermarkTS) should
+	// drop it. So A should also not appear.
+	if got := strings.Count(out.Stdout, "0 -> 1"); got != 0 {
+		t.Errorf("entry A is older than watermark and should be dropped client-side, got %d times:\n%s", got, out.Stdout)
+	}
+}
+
+// TestRunLogsTx_FallbackTailKeepsLatestUnderAscRetry is a regression guard
+// for a P0 bug where --until --tail N under filter-fallback returned the
+// OLDEST N entries instead of the LATEST N. Because --until-only forensic
+// queries trigger ASC retry, the unfiltered cap was oldest-first, and the
+// naive `entries[:tail]` truncation kept oldest rather than latest.
+func TestRunLogsTx_FallbackTailKeepsLatestUnderAscRetry(t *testing.T) {
+	resetCmdFlags(t)
+	logsTxUntil = "2030-01-01T00:00:00Z"
+	logsTxTail = 3
+
+	var requestCount int32
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&requestCount, 1)
+		w.Header().Set("Content-Type", "application/json")
+		if n == 1 {
+			w.WriteHeader(http.StatusBadRequest)
+			fmt.Fprint(w, `{"error":"$filter not supported"}`)
+			return
+		}
+		// ASC retry: server returns oldest-first.
+		entries := make([]model.TransactionLogEntry, 0, 10)
+		for i := 0; i < 10; i++ {
+			entries = append(entries, model.TransactionLogEntry{
+				ID:        int64(i + 1),
+				TimeStamp: time.Date(2026, 4, 25, 10, i, 0, 0, time.UTC).Format(time.RFC3339),
+				User:      fmt.Sprintf("u%d", i),
+				Cube:      "C",
+				Tuple:     []string{"x"},
+				OldValue:  json.RawMessage(`0`),
+				NewValue:  json.RawMessage(`1`),
+			})
+		}
+		w.Write(transactionLogJSON(entries...))
+	})
+
+	out := captureAll(t, func() {
+		if err := runLogsTx(logsTxCmd, nil); err != nil {
+			t.Fatalf("unexpected: %v", err)
+		}
+	})
+
+	// --tail 3 must keep the LATEST 3 (u7, u8, u9), NOT the oldest 3 (u0..u2).
+	for _, oldest := range []string{"u0", "u1", "u2"} {
+		if strings.Contains(out.Stdout, oldest) {
+			t.Errorf("--tail under ASC fallback should keep latest, but found oldest user %q in output:\n%s", oldest, out.Stdout)
+		}
+	}
+	for _, latest := range []string{"u7", "u8", "u9"} {
+		if !strings.Contains(out.Stdout, latest) {
+			t.Errorf("--tail under ASC fallback should keep latest user %q, missing from output:\n%s", latest, out.Stdout)
+		}
+	}
+}
+
 // TestRunLogsTx_FallbackUsesAscOrderForUntilOnlyForensicQuery is a
 // regression guard for the silent-empty-result bug: with --until alone
 // (forensic / audit query), DESC retry would return the latest 1000 rows

--- a/cmd/logs_tx_test.go
+++ b/cmd/logs_tx_test.go
@@ -1760,7 +1760,7 @@ func TestFetchTxEntries_WarnsOnPaginatedResponse(t *testing.T) {
 	cl, _ := createClient(cfg)
 
 	out := captureAll(t, func() {
-		_, _, err := fetchTxEntries(cl, "", 0, false)
+		_, _, err := fetchTxEntries(cl, "", 0, false, false, false)
 		if err != nil {
 			t.Fatalf("unexpected: %v", err)
 		}
@@ -1768,6 +1768,113 @@ func TestFetchTxEntries_WarnsOnPaginatedResponse(t *testing.T) {
 
 	if !strings.Contains(out.Stderr, "paginated") {
 		t.Errorf("stderr should warn about paginated response, got: %q", out.Stderr)
+	}
+}
+
+// TestRunLogsTx_FallbackUsesAscOrderForUntilOnlyForensicQuery is a
+// regression guard for the silent-empty-result bug: with --until alone
+// (forensic / audit query), DESC retry would return the latest 1000 rows
+// — all newer than untilTS — and applyTxClientFilters would drop them all.
+// Output: empty, no error, missed historical entries. The fallback must
+// retry ASC so the cap captures the OLDEST rows (most likely before
+// untilTS), and emit a warning explaining --until cannot be enforced
+// server-side under fallback.
+func TestRunLogsTx_FallbackUsesAscOrderForUntilOnlyForensicQuery(t *testing.T) {
+	resetCmdFlags(t)
+	logsTxUntil = "2030-01-01T00:00:00Z"
+
+	var capturedRetryQuery string
+	var requestCount int32
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&requestCount, 1)
+		w.Header().Set("Content-Type", "application/json")
+		if n == 1 {
+			w.WriteHeader(http.StatusBadRequest)
+			fmt.Fprint(w, `{"error":"$filter not supported"}`)
+			return
+		}
+		capturedRetryQuery = r.URL.RawQuery
+		w.Write(transactionLogJSON())
+	})
+
+	out := captureAll(t, func() {
+		if err := runLogsTx(logsTxCmd, nil); err != nil {
+			t.Fatalf("unexpected: %v", err)
+		}
+	})
+
+	decoded, _ := decodedQuery(capturedRetryQuery)
+	if strings.Contains(decoded, "$orderby=TimeStamp desc") {
+		t.Errorf("retry for --until-only forensic query should NOT use DESC ordering (DESC returns the latest rows, all newer than untilTS); got %q", decoded)
+	}
+	if !strings.Contains(out.Stderr, "--until cannot be enforced server-side") {
+		t.Errorf("stderr should warn that --until is unenforceable under fallback, got: %q", out.Stderr)
+	}
+}
+
+// TestRunLogsTx_FallbackUsesDescOrderForSinceQuery verifies the retry stays
+// DESC when --since is set (with or without --until) — the user wants the
+// latest entries within the window, not the oldest entries since epoch.
+func TestRunLogsTx_FallbackUsesDescOrderForSinceQuery(t *testing.T) {
+	resetCmdFlags(t)
+	logsTxSince = "2026-04-25T10:00:00Z"
+	logsTxUntil = "2030-01-01T00:00:00Z"
+
+	var capturedRetryQuery string
+	var requestCount int32
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&requestCount, 1)
+		w.Header().Set("Content-Type", "application/json")
+		if n == 1 {
+			w.WriteHeader(http.StatusBadRequest)
+			fmt.Fprint(w, `{"error":"$filter not supported"}`)
+			return
+		}
+		capturedRetryQuery = r.URL.RawQuery
+		w.Write(transactionLogJSON())
+	})
+
+	out := captureAll(t, func() {
+		if err := runLogsTx(logsTxCmd, nil); err != nil {
+			t.Fatalf("unexpected: %v", err)
+		}
+	})
+
+	decoded, _ := decodedQuery(capturedRetryQuery)
+	if !strings.Contains(decoded, "$orderby=TimeStamp desc") {
+		t.Errorf("retry with --since should keep DESC ordering, got %q", decoded)
+	}
+	// --until is set, so the warning must still fire.
+	if !strings.Contains(out.Stderr, "--until cannot be enforced server-side") {
+		t.Errorf("stderr should still warn about --until limitation, got: %q", out.Stderr)
+	}
+}
+
+// TestRunLogsTx_FallbackNoUntilWarningWhenUntilUnset is a sanity check.
+func TestRunLogsTx_FallbackNoUntilWarningWhenUntilUnset(t *testing.T) {
+	resetCmdFlags(t)
+	logsTxSince = "2026-04-25T10:00:00Z"
+
+	var requestCount int32
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&requestCount, 1)
+		w.Header().Set("Content-Type", "application/json")
+		if n == 1 {
+			w.WriteHeader(http.StatusBadRequest)
+			fmt.Fprint(w, `{"error":"$filter not supported"}`)
+			return
+		}
+		w.Write(transactionLogJSON())
+	})
+
+	out := captureAll(t, func() {
+		if err := runLogsTx(logsTxCmd, nil); err != nil {
+			t.Fatalf("unexpected: %v", err)
+		}
+	})
+
+	if strings.Contains(out.Stderr, "--until cannot be enforced") {
+		t.Errorf("--until warning should not fire when --until is unset, got: %q", out.Stderr)
 	}
 }
 
@@ -1785,7 +1892,7 @@ func TestFetchTxEntries_NoWarningWhenNotPaginated(t *testing.T) {
 	cl, _ := createClient(cfg)
 
 	out := captureAll(t, func() {
-		_, _, err := fetchTxEntries(cl, "", 0, false)
+		_, _, err := fetchTxEntries(cl, "", 0, false, false, false)
 		if err != nil {
 			t.Fatalf("unexpected: %v", err)
 		}

--- a/cmd/logs_tx_test.go
+++ b/cmd/logs_tx_test.go
@@ -380,6 +380,54 @@ func TestSortTxByTimeStamp(t *testing.T) {
 	})
 }
 
+func TestSortTxByTimeStampDesc(t *testing.T) {
+	t.Run("descending order", func(t *testing.T) {
+		entries := []model.TransactionLogEntry{
+			{ID: 1, TimeStamp: "2026-04-25T10:00:00Z"},
+			{ID: 3, TimeStamp: "2026-04-25T12:00:00Z"},
+			{ID: 2, TimeStamp: "2026-04-25T11:00:00Z"},
+		}
+		sortTxByTimeStampDesc(entries)
+		for i, want := range []int64{3, 2, 1} {
+			if entries[i].ID != want {
+				t.Errorf("entries[%d].ID = %d, want %d", i, entries[i].ID, want)
+			}
+		}
+	})
+
+	t.Run("tie-break by ID descending", func(t *testing.T) {
+		entries := []model.TransactionLogEntry{
+			{ID: 1, TimeStamp: "2026-04-25T10:00:00Z"},
+			{ID: 5, TimeStamp: "2026-04-25T10:00:00Z"},
+			{ID: 3, TimeStamp: "2026-04-25T10:00:00Z"},
+		}
+		sortTxByTimeStampDesc(entries)
+		for i, want := range []int64{5, 3, 1} {
+			if entries[i].ID != want {
+				t.Errorf("entries[%d].ID = %d, want %d", i, entries[i].ID, want)
+			}
+		}
+	})
+
+	// Mixed-precision RFC3339 timestamps: a raw string compare gets this
+	// wrong because "2026-04-25T10:00:00Z" < "2026-04-25T10:00:00.5Z"
+	// lexicographically, but the latter is chronologically later.
+	// sortTxByTimeStampDesc must put 10:00:00.5Z first.
+	t.Run("mixed-precision ordering matches chronology", func(t *testing.T) {
+		entries := []model.TransactionLogEntry{
+			{ID: 1, TimeStamp: "2026-04-25T10:00:00Z"},
+			{ID: 2, TimeStamp: "2026-04-25T10:00:00.5Z"},
+			{ID: 3, TimeStamp: "2026-04-25T10:00:00.250Z"},
+		}
+		sortTxByTimeStampDesc(entries)
+		for i, want := range []int64{2, 3, 1} {
+			if entries[i].ID != want {
+				t.Errorf("entries[%d].ID = %d, want %d (chronological order); got %v", i, entries[i].ID, want, entries)
+			}
+		}
+	})
+}
+
 // ============================================================
 // Unit tests — reverseTxEntries
 // ============================================================
@@ -1897,6 +1945,58 @@ func TestRunLogsTx_FallbackTailKeepsLatestUnderAscRetry(t *testing.T) {
 	for _, latest := range []string{"u7", "u8", "u9"} {
 		if !strings.Contains(out.Stdout, latest) {
 			t.Errorf("--tail under ASC fallback should keep latest user %q, missing from output:\n%s", latest, out.Stdout)
+		}
+	}
+}
+
+// TestRunLogsTx_FallbackTailRespectsChronologyUnderMixedPrecision is a
+// regression guard for a P1 bug where the fallback truncation used a raw
+// string compare on the TimeStamp field. With TM1 mixing precision (e.g.
+// "10:00:00.9Z" vs "10:00:00Z"), lexicographic order disagrees with
+// chronological order: "10:00:00Z" sorts AFTER "10:00:00.9Z" as strings
+// even though it's earlier chronologically. Under fallback truncation
+// to --tail N, the wrong entries would be kept.
+func TestRunLogsTx_FallbackTailRespectsChronologyUnderMixedPrecision(t *testing.T) {
+	resetCmdFlags(t)
+	logsTxUntil = "2030-01-01T00:00:00Z"
+	logsTxTail = 2
+
+	var requestCount int32
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&requestCount, 1)
+		w.Header().Set("Content-Type", "application/json")
+		if n == 1 {
+			w.WriteHeader(http.StatusBadRequest)
+			fmt.Fprint(w, `{"error":"$filter not supported"}`)
+			return
+		}
+		// ASC retry returns oldest-first, mixing precisions. Chronological
+		// order is u_old < u_mid < u_late_a < u_late_b. Lexicographic order
+		// of TimeStamp would disagree on the fractional vs no-fractional
+		// pair, putting u_late_a (no fraction) before u_late_b's parent.
+		w.Write(transactionLogJSON(
+			model.TransactionLogEntry{ID: 1, TimeStamp: "2026-04-25T09:00:00Z", User: "u_old", Cube: "C", Tuple: []string{"x"}, OldValue: json.RawMessage(`0`), NewValue: json.RawMessage(`1`)},
+			model.TransactionLogEntry{ID: 2, TimeStamp: "2026-04-25T10:00:00Z", User: "u_mid", Cube: "C", Tuple: []string{"x"}, OldValue: json.RawMessage(`0`), NewValue: json.RawMessage(`1`)},
+			model.TransactionLogEntry{ID: 3, TimeStamp: "2026-04-25T11:00:00.250Z", User: "u_late_a", Cube: "C", Tuple: []string{"x"}, OldValue: json.RawMessage(`0`), NewValue: json.RawMessage(`1`)},
+			model.TransactionLogEntry{ID: 4, TimeStamp: "2026-04-25T11:00:00.9Z", User: "u_late_b", Cube: "C", Tuple: []string{"x"}, OldValue: json.RawMessage(`0`), NewValue: json.RawMessage(`1`)},
+		))
+	})
+
+	out := captureAll(t, func() {
+		if err := runLogsTx(logsTxCmd, nil); err != nil {
+			t.Fatalf("unexpected: %v", err)
+		}
+	})
+
+	// --tail 2 must keep the chronologically-latest two: u_late_b then u_late_a.
+	for _, want := range []string{"u_late_a", "u_late_b"} {
+		if !strings.Contains(out.Stdout, want) {
+			t.Errorf("--tail 2 should keep chronologically latest %q, missing:\n%s", want, out.Stdout)
+		}
+	}
+	for _, unwanted := range []string{"u_old", "u_mid"} {
+		if strings.Contains(out.Stdout, unwanted) {
+			t.Errorf("--tail 2 should not keep older %q, found in:\n%s", unwanted, out.Stdout)
 		}
 	}
 }

--- a/cmd/logs_tx_test.go
+++ b/cmd/logs_tx_test.go
@@ -233,14 +233,14 @@ func TestBuildTxFilter(t *testing.T) {
 
 func TestBuildTxQuery(t *testing.T) {
 	t.Run("no params returns bare endpoint", func(t *testing.T) {
-		got := buildTxQuery("", 0, false)
+		got := buildTxQuery("", 0, "")
 		if got != "TransactionLogEntries" {
 			t.Errorf("got %q, want TransactionLogEntries", got)
 		}
 	})
 
 	t.Run("filter + top + orderby desc", func(t *testing.T) {
-		got := buildTxQuery("Cube eq 'Sales'", 50, true)
+		got := buildTxQuery("Cube eq 'Sales'", 50, orderTimeStampDesc)
 		decoded, err := decodedQuery(strings.TrimPrefix(got, "TransactionLogEntries?"))
 		if err != nil {
 			t.Fatalf("cannot decode: %v", err)
@@ -252,15 +252,23 @@ func TestBuildTxQuery(t *testing.T) {
 		}
 	})
 
+	t.Run("orderby asc explicit", func(t *testing.T) {
+		got := buildTxQuery("", 100, orderTimeStampAsc)
+		decoded, _ := decodedQuery(strings.TrimPrefix(got, "TransactionLogEntries?"))
+		if !strings.Contains(decoded, "$orderby=TimeStamp asc") {
+			t.Errorf("query %q should request asc, got %q", got, decoded)
+		}
+	})
+
 	t.Run("top=0 omits $top", func(t *testing.T) {
-		got := buildTxQuery("Cube eq 'X'", 0, true)
+		got := buildTxQuery("Cube eq 'X'", 0, orderTimeStampDesc)
 		if strings.Contains(got, "$top=") {
 			t.Errorf("query %q should not contain $top", got)
 		}
 	})
 
-	t.Run("orderDesc=false omits $orderby", func(t *testing.T) {
-		got := buildTxQuery("Cube eq 'X'", 10, false)
+	t.Run("empty orderBy omits $orderby (server default)", func(t *testing.T) {
+		got := buildTxQuery("Cube eq 'X'", 10, "")
 		if strings.Contains(got, "$orderby") {
 			t.Errorf("query %q should not contain $orderby", got)
 		}
@@ -1926,8 +1934,14 @@ func TestRunLogsTx_FallbackUsesAscOrderForUntilOnlyForensicQuery(t *testing.T) {
 	})
 
 	decoded, _ := decodedQuery(capturedRetryQuery)
+	// Assert the query EXPLICITLY requests ASC — relying on server default
+	// is undefined for TransactionLogEntries (TM1 commonly defaults to DESC,
+	// which would defeat the rescue).
+	if !strings.Contains(decoded, "$orderby=TimeStamp asc") {
+		t.Errorf("retry for --until-only forensic query must explicitly request ASC; got %q", decoded)
+	}
 	if strings.Contains(decoded, "$orderby=TimeStamp desc") {
-		t.Errorf("retry for --until-only forensic query should NOT use DESC ordering (DESC returns the latest rows, all newer than untilTS); got %q", decoded)
+		t.Errorf("retry for --until-only forensic query should not use DESC; got %q", decoded)
 	}
 	if !strings.Contains(out.Stderr, "--until cannot be enforced server-side") {
 		t.Errorf("stderr should warn that --until is unenforceable under fallback, got: %q", out.Stderr)

--- a/cmd/logs_tx_test.go
+++ b/cmd/logs_tx_test.go
@@ -551,6 +551,43 @@ func TestTransactionLogEntry_UnmarshalPrimitiveTypes(t *testing.T) {
 	}
 }
 
+// TestTransactionLogEntry_UnmarshalChangeSetIDPolymorphism is a regression
+// guard. TM1 emits ChangeSetID in three observed forms across versions and
+// row sources: numeric Edm.Int64 (TI processes / bulk ops), string UUIDs,
+// and null. Modelling it as `string` would fail unmarshal on the numeric
+// form — the entire response would bail with a generic parse error and
+// the user would lose access to forensic data from any TI-emitted rows.
+func TestTransactionLogEntry_UnmarshalChangeSetIDPolymorphism(t *testing.T) {
+	body := []byte(`{
+		"value": [
+			{"ID":1,"TimeStamp":"2026-04-25T10:00:00Z","User":"u","Cube":"C","Tuple":["x"],"OldValue":0,"NewValue":1,"ChangeSetID":12345},
+			{"ID":2,"TimeStamp":"2026-04-25T10:01:00Z","User":"u","Cube":"C","Tuple":["x"],"OldValue":0,"NewValue":1,"ChangeSetID":"7e8f2a"},
+			{"ID":3,"TimeStamp":"2026-04-25T10:02:00Z","User":"u","Cube":"C","Tuple":["x"],"OldValue":0,"NewValue":1,"ChangeSetID":null},
+			{"ID":4,"TimeStamp":"2026-04-25T10:03:00Z","User":"u","Cube":"C","Tuple":["x"],"OldValue":0,"NewValue":1}
+		]
+	}`)
+
+	var resp model.TransactionLogResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		t.Fatalf("unmarshal failed for polymorphic ChangeSetID: %v", err)
+	}
+	if len(resp.Value) != 4 {
+		t.Fatalf("got %d entries, want 4", len(resp.Value))
+	}
+	if got := string(resp.Value[0].ChangeSetID); got != "12345" {
+		t.Errorf("numeric ChangeSetID = %q, want \"12345\"", got)
+	}
+	if got := string(resp.Value[1].ChangeSetID); got != `"7e8f2a"` {
+		t.Errorf("string ChangeSetID = %q, want \"7e8f2a\" (raw JSON)", got)
+	}
+	if got := string(resp.Value[2].ChangeSetID); got != "null" {
+		t.Errorf("null ChangeSetID = %q, want \"null\"", got)
+	}
+	if len(resp.Value[3].ChangeSetID) != 0 {
+		t.Errorf("missing ChangeSetID should unmarshal to zero-length RawMessage, got %q", string(resp.Value[3].ChangeSetID))
+	}
+}
+
 // ============================================================
 // Integration tests — flag validation
 // ============================================================

--- a/cmd/logs_tx_test.go
+++ b/cmd/logs_tx_test.go
@@ -1181,6 +1181,37 @@ func TestFallbackRetryTop(t *testing.T) {
 	}
 }
 
+// TestRunLogsTx_UntilOnlyDoesNotCap is a regression guard. Previously,
+// `tm1cli logs tx --until X` (no --since, no --tail) silently capped
+// results to the latest 100 entries before X, because the boundedness
+// check only considered --since. An analyst auditing "all changes before
+// incident X" would miss older entries with no warning.
+func TestRunLogsTx_UntilOnlyDoesNotCap(t *testing.T) {
+	resetCmdFlags(t)
+	logsTxUntil = "2030-01-01T00:00:00Z"
+
+	var capturedQuery string
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		capturedQuery = r.URL.RawQuery
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(transactionLogJSON())
+	})
+
+	captureAll(t, func() {
+		if err := runLogsTx(logsTxCmd, nil); err != nil {
+			t.Fatalf("unexpected: %v", err)
+		}
+	})
+
+	decoded, _ := decodedQuery(capturedQuery)
+	if strings.Contains(decoded, "$top=") {
+		t.Errorf("--until alone should NOT impose a $top cap; query was %q", decoded)
+	}
+	if !strings.Contains(decoded, "TimeStamp le 2030-01-01T00:00:00Z") {
+		t.Errorf("query %q should still bound by TimeStamp le", decoded)
+	}
+}
+
 func TestRunLogsTx_NoFallbackOn401(t *testing.T) {
 	resetCmdFlags(t)
 	logsTxCube = "Sales"

--- a/cmd/logs_tx_test.go
+++ b/cmd/logs_tx_test.go
@@ -1217,61 +1217,34 @@ func TestRunLogsTx_OldNewValuesPresent(t *testing.T) {
 // Integration tests — follow mode
 // ============================================================
 
-func TestRunLogsTx_FollowJSONInitialBatchIsNDJSON(t *testing.T) {
-	resetCmdFlags(t)
-	logsTxFollow = true
-	logsTxInterval = 5 * time.Millisecond
-	flagOutput = "json"
+// TestPrintTxEntries_NDJSONInFollowChunk verifies the follow+json render path
+// emits one JSON object per line (NDJSON) instead of a JSON array, so that
+// downstream stream parsers can ingest a uniform format across the initial
+// batch and subsequent poll chunks.
+func TestPrintTxEntries_NDJSONInFollowChunk(t *testing.T) {
+	entries := []model.TransactionLogEntry{
+		{ID: 1, TimeStamp: "2026-04-25T10:00:00Z", User: "u", Cube: "C",
+			Tuple: []string{"x"}, OldValue: json.RawMessage(`0`), NewValue: json.RawMessage(`1`)},
+		{ID: 2, TimeStamp: "2026-04-25T10:00:01Z", User: "u", Cube: "C",
+			Tuple: []string{"x"}, OldValue: json.RawMessage(`1`), NewValue: json.RawMessage(`2`)},
+	}
 
-	var pollCount int32
-	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
-		atomic.AddInt32(&pollCount, 1)
-		w.Header().Set("Content-Type", "application/json")
-		// Initial fetch returns one entry; subsequent polls return nothing.
-		if atomic.LoadInt32(&pollCount) == 1 {
-			w.Write(transactionLogJSON(
-				model.TransactionLogEntry{
-					ID: 1, TimeStamp: "2026-04-25T10:00:00Z", User: "u", Cube: "C",
-					Tuple: []string{"x"}, OldValue: json.RawMessage(`0`), NewValue: json.RawMessage(`1`),
-				},
-			))
-		} else {
-			w.Write(transactionLogJSON())
-		}
+	out := captureStdout(t, func() {
+		printTxEntries(entries, true, false, true)
 	})
 
-	ctx, cancel := context.WithCancel(context.Background())
-
-	out := captureAll(t, func() {
-		done := make(chan struct{})
-		go func() {
-			defer close(done)
-			cfg, _ := loadConfig()
-			cl, _ := createClient(cfg)
-			// Run only the initial-batch portion: emulate follow=true initial print.
-			entries, _, _ := fetchTxEntries(cl, "", 100, true)
-			if logsTxTail == 0 && logsTxSince == "" {
-				// no-op: tail defaulting handled in runLogsTx; for this test we
-				// just want to confirm the print code path emits NDJSON in
-				// follow+json. Use printTxEntries directly with isFollowChunk=true.
-			}
-			printTxEntries(entries, true /*json*/, false, true /*follow*/)
-			cancel()
-		}()
-		<-done
-	})
-	_ = ctx
-
-	stdout := strings.TrimSpace(out.Stdout)
+	stdout := strings.TrimSpace(out)
 	if stdout == "" {
 		t.Fatalf("expected NDJSON, got empty stdout")
 	}
-	// Must NOT be a JSON array
 	if strings.HasPrefix(stdout, "[") {
 		t.Errorf("follow+json should be NDJSON not array, got: %q", stdout)
 	}
-	// Each line must parse as a single object
-	for i, line := range strings.Split(stdout, "\n") {
+	lines := strings.Split(stdout, "\n")
+	if len(lines) != len(entries) {
+		t.Fatalf("expected %d NDJSON lines, got %d", len(entries), len(lines))
+	}
+	for i, line := range lines {
 		var e model.TransactionLogEntry
 		if err := json.Unmarshal([]byte(line), &e); err != nil {
 			t.Errorf("line %d not a JSON object: %v: %q", i, err, line)

--- a/cmd/logs_tx_test.go
+++ b/cmd/logs_tx_test.go
@@ -1,0 +1,1384 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+	"tm1cli/internal/model"
+)
+
+// ============================================================
+// Unit tests — odataEscape
+// ============================================================
+
+func TestOdataEscape(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"Sales", "Sales"},
+		{"O'Brien", "O''Brien"},
+		{"a''b", "a''''b"},
+		{"", ""},
+	}
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("input=%q", tt.input), func(t *testing.T) {
+			if got := odataEscape(tt.input); got != tt.want {
+				t.Errorf("odataEscape(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+// ============================================================
+// Unit tests — parseTimeFlag
+// ============================================================
+
+func TestParseTimeFlag(t *testing.T) {
+	now := time.Date(2026, 4, 25, 12, 0, 0, 0, time.UTC)
+
+	t.Run("valid input passes through", func(t *testing.T) {
+		got, err := parseTimeFlag("--until", "2026-04-24T10:00:00Z", now)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != "2026-04-24T10:00:00Z" {
+			t.Errorf("got %q, want 2026-04-24T10:00:00Z", got)
+		}
+	})
+
+	t.Run("--since error names --since", func(t *testing.T) {
+		_, err := parseTimeFlag("--since", "garbage", now)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "--since") {
+			t.Errorf("error %q should mention --since", err.Error())
+		}
+		if strings.Contains(err.Error(), "--until") {
+			t.Errorf("error %q should NOT mention --until", err.Error())
+		}
+	})
+
+	t.Run("--until error names --until", func(t *testing.T) {
+		_, err := parseTimeFlag("--until", "garbage", now)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "--until") {
+			t.Errorf("error %q should mention --until", err.Error())
+		}
+		if strings.Contains(err.Error(), "--since") {
+			t.Errorf("error %q should NOT mention --since", err.Error())
+		}
+	})
+
+	t.Run("empty input returns empty", func(t *testing.T) {
+		got, err := parseTimeFlag("--until", "", now)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != "" {
+			t.Errorf("got %q, want empty", got)
+		}
+	})
+}
+
+// ============================================================
+// Unit tests — formatTxValue
+// ============================================================
+
+func TestFormatTxValue(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  json.RawMessage
+		want string
+	}{
+		{"null", json.RawMessage(`null`), ""},
+		{"empty", json.RawMessage(``), ""},
+		{"whitespace", json.RawMessage(`   `), ""},
+		{"string", json.RawMessage(`"hello"`), "hello"},
+		{"string with spaces", json.RawMessage(`"hello world"`), "hello world"},
+		{"number int", json.RawMessage(`42`), "42"},
+		{"number float", json.RawMessage(`3.14`), "3.14"},
+		{"bool true", json.RawMessage(`true`), "true"},
+		{"bool false", json.RawMessage(`false`), "false"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := formatTxValue(tt.raw); got != tt.want {
+				t.Errorf("formatTxValue(%s) = %q, want %q", string(tt.raw), got, tt.want)
+			}
+		})
+	}
+}
+
+// ============================================================
+// Unit tests — txIDKey
+// ============================================================
+
+func TestTxIDKey(t *testing.T) {
+	tests := []struct {
+		id   int64
+		want string
+	}{
+		{0, ""},
+		{1, "1"},
+		{12345, "12345"},
+		{9223372036854775807, "9223372036854775807"}, // max int64
+	}
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("id=%d", tt.id), func(t *testing.T) {
+			if got := txIDKey(tt.id); got != tt.want {
+				t.Errorf("txIDKey(%d) = %q, want %q", tt.id, got, tt.want)
+			}
+		})
+	}
+}
+
+// ============================================================
+// Unit tests — tupleString
+// ============================================================
+
+func TestTupleString(t *testing.T) {
+	tests := []struct {
+		name  string
+		input []string
+		want  string
+	}{
+		{"empty", []string{}, ""},
+		{"nil", nil, ""},
+		{"single", []string{"a"}, "a"},
+		{"three", []string{"Q1", "2025", "Sales"}, "Q1:2025:Sales"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tupleString(tt.input); got != tt.want {
+				t.Errorf("tupleString(%v) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+// ============================================================
+// Unit tests — buildTxFilter
+// ============================================================
+
+func TestBuildTxFilter(t *testing.T) {
+	tests := []struct {
+		name    string
+		sinceTS string
+		untilTS string
+		cube    string
+		user    string
+		want    string
+	}{
+		{"empty", "", "", "", "", ""},
+		{"since only", "2026-04-25T10:00:00Z", "", "", "", "TimeStamp ge 2026-04-25T10:00:00Z"},
+		{"until only", "", "2026-04-25T18:00:00Z", "", "", "TimeStamp le 2026-04-25T18:00:00Z"},
+		{"both times", "2026-04-25T10:00:00Z", "2026-04-25T18:00:00Z", "", "",
+			"TimeStamp ge 2026-04-25T10:00:00Z and TimeStamp le 2026-04-25T18:00:00Z"},
+		{"cube only", "", "", "Sales", "", "Cube eq 'Sales'"},
+		{"user only", "", "", "", "admin", "User eq 'admin'"},
+		{"cube and user", "", "", "Sales", "admin", "Cube eq 'Sales' and User eq 'admin'"},
+		{"all four", "2026-04-25T10:00:00Z", "2026-04-25T18:00:00Z", "Sales", "admin",
+			"TimeStamp ge 2026-04-25T10:00:00Z and TimeStamp le 2026-04-25T18:00:00Z and Cube eq 'Sales' and User eq 'admin'"},
+		{"cube with embedded quote escaped", "", "", "O'Brien", "", "Cube eq 'O''Brien'"},
+		{"user with embedded quote escaped", "", "", "", "o'reilly", "User eq 'o''reilly'"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildTxFilter(tt.sinceTS, tt.untilTS, tt.cube, tt.user)
+			if got != tt.want {
+				t.Errorf("buildTxFilter() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// ============================================================
+// Unit tests — buildTxQuery
+// ============================================================
+
+func TestBuildTxQuery(t *testing.T) {
+	t.Run("no params returns bare endpoint", func(t *testing.T) {
+		got := buildTxQuery("", 0, false)
+		if got != "TransactionLogEntries" {
+			t.Errorf("got %q, want TransactionLogEntries", got)
+		}
+	})
+
+	t.Run("filter + top + orderby desc", func(t *testing.T) {
+		got := buildTxQuery("Cube eq 'Sales'", 50, true)
+		decoded, err := decodedQuery(strings.TrimPrefix(got, "TransactionLogEntries?"))
+		if err != nil {
+			t.Fatalf("cannot decode: %v", err)
+		}
+		for _, want := range []string{"$filter=Cube eq 'Sales'", "$top=50", "$orderby=TimeStamp desc"} {
+			if !strings.Contains(decoded, want) {
+				t.Errorf("query %q missing %q", decoded, want)
+			}
+		}
+	})
+
+	t.Run("top=0 omits $top", func(t *testing.T) {
+		got := buildTxQuery("Cube eq 'X'", 0, true)
+		if strings.Contains(got, "$top=") {
+			t.Errorf("query %q should not contain $top", got)
+		}
+	})
+
+	t.Run("orderDesc=false omits $orderby", func(t *testing.T) {
+		got := buildTxQuery("Cube eq 'X'", 10, false)
+		if strings.Contains(got, "$orderby") {
+			t.Errorf("query %q should not contain $orderby", got)
+		}
+	})
+}
+
+// ============================================================
+// Unit tests — applyTxClientFilters
+// ============================================================
+
+func TestApplyTxClientFilters(t *testing.T) {
+	entries := []model.TransactionLogEntry{
+		{ID: 1, TimeStamp: "2026-04-25T10:00:00Z", User: "alice", Cube: "Sales"},
+		{ID: 2, TimeStamp: "2026-04-25T11:00:00Z", User: "bob", Cube: "Inventory"},
+		{ID: 3, TimeStamp: "2026-04-25T12:00:00Z", User: "alice", Cube: "Sales"},
+	}
+
+	t.Run("since drops older", func(t *testing.T) {
+		got := applyTxClientFilters(entries, "2026-04-25T10:30:00Z", "", "", "")
+		if len(got) != 2 {
+			t.Fatalf("got %d, want 2", len(got))
+		}
+		if got[0].ID != 2 || got[1].ID != 3 {
+			t.Errorf("got IDs %d,%d; want 2,3", got[0].ID, got[1].ID)
+		}
+	})
+
+	t.Run("until drops newer", func(t *testing.T) {
+		got := applyTxClientFilters(entries, "", "2026-04-25T11:30:00Z", "", "")
+		if len(got) != 2 {
+			t.Fatalf("got %d, want 2", len(got))
+		}
+		if got[0].ID != 1 || got[1].ID != 2 {
+			t.Errorf("got IDs %d,%d; want 1,2", got[0].ID, got[1].ID)
+		}
+	})
+
+	t.Run("cube exact-match case-sensitive", func(t *testing.T) {
+		got := applyTxClientFilters(entries, "", "", "Sales", "")
+		if len(got) != 2 {
+			t.Errorf("Sales should match 2, got %d", len(got))
+		}
+
+		gotMixed := applyTxClientFilters(entries, "", "", "sales", "") // lowercase
+		if len(gotMixed) != 0 {
+			t.Errorf("lowercase 'sales' should NOT match 'Sales' (case-sensitive), got %d", len(gotMixed))
+		}
+	})
+
+	t.Run("user exact-match case-sensitive", func(t *testing.T) {
+		got := applyTxClientFilters(entries, "", "", "", "alice")
+		if len(got) != 2 {
+			t.Errorf("alice should match 2, got %d", len(got))
+		}
+
+		gotMixed := applyTxClientFilters(entries, "", "", "", "Alice")
+		if len(gotMixed) != 0 {
+			t.Errorf("'Alice' should NOT match 'alice' (case-sensitive), got %d", len(gotMixed))
+		}
+	})
+
+	t.Run("combined", func(t *testing.T) {
+		got := applyTxClientFilters(entries, "2026-04-25T10:30:00Z", "2026-04-25T11:30:00Z", "Inventory", "bob")
+		if len(got) != 1 || got[0].ID != 2 {
+			t.Errorf("expected only ID=2, got %+v", got)
+		}
+	})
+
+	t.Run("unparseable timestamp dropped on time filter", func(t *testing.T) {
+		bad := []model.TransactionLogEntry{{ID: 99, TimeStamp: "not-a-time"}}
+		got := applyTxClientFilters(bad, "2026-04-25T10:00:00Z", "", "", "")
+		if len(got) != 0 {
+			t.Errorf("unparseable should be dropped when since is set, got %+v", got)
+		}
+	})
+}
+
+// ============================================================
+// Unit tests — sortTxByTimeStamp
+// ============================================================
+
+func TestSortTxByTimeStamp(t *testing.T) {
+	t.Run("ascending order", func(t *testing.T) {
+		entries := []model.TransactionLogEntry{
+			{ID: 3, TimeStamp: "2026-04-25T12:00:00Z"},
+			{ID: 1, TimeStamp: "2026-04-25T10:00:00Z"},
+			{ID: 2, TimeStamp: "2026-04-25T11:00:00Z"},
+		}
+		sortTxByTimeStamp(entries)
+		for i, want := range []int64{1, 2, 3} {
+			if entries[i].ID != want {
+				t.Errorf("entries[%d].ID = %d, want %d", i, entries[i].ID, want)
+			}
+		}
+	})
+
+	t.Run("tie-break by ID", func(t *testing.T) {
+		entries := []model.TransactionLogEntry{
+			{ID: 5, TimeStamp: "2026-04-25T10:00:00Z"},
+			{ID: 1, TimeStamp: "2026-04-25T10:00:00Z"},
+			{ID: 3, TimeStamp: "2026-04-25T10:00:00Z"},
+		}
+		sortTxByTimeStamp(entries)
+		for i, want := range []int64{1, 3, 5} {
+			if entries[i].ID != want {
+				t.Errorf("entries[%d].ID = %d, want %d", i, entries[i].ID, want)
+			}
+		}
+	})
+}
+
+// ============================================================
+// Unit tests — reverseTxEntries
+// ============================================================
+
+func TestReverseTxEntries(t *testing.T) {
+	entries := []model.TransactionLogEntry{
+		{ID: 1}, {ID: 2}, {ID: 3},
+	}
+	reverseTxEntries(entries)
+	for i, want := range []int64{3, 2, 1} {
+		if entries[i].ID != want {
+			t.Errorf("entries[%d].ID = %d, want %d", i, entries[i].ID, want)
+		}
+	}
+}
+
+// ============================================================
+// Unit tests — boundaryTxIDs
+// ============================================================
+
+func TestBoundaryTxIDs(t *testing.T) {
+	t.Run("empty input", func(t *testing.T) {
+		ts, ids := boundaryTxIDs(nil)
+		if ts != "" || ids != nil {
+			t.Errorf("got (%q, %v), want (\"\", nil)", ts, ids)
+		}
+	})
+
+	t.Run("single entry", func(t *testing.T) {
+		entries := []model.TransactionLogEntry{
+			{ID: 7, TimeStamp: "2026-04-25T12:00:00Z"},
+		}
+		ts, ids := boundaryTxIDs(entries)
+		if ts != "2026-04-25T12:00:00Z" {
+			t.Errorf("ts = %q", ts)
+		}
+		if _, ok := ids["7"]; !ok {
+			t.Errorf("ids should contain '7', got %v", ids)
+		}
+	})
+
+	t.Run("two boundary entries with same TS", func(t *testing.T) {
+		entries := []model.TransactionLogEntry{
+			{ID: 1, TimeStamp: "2026-04-25T10:00:00Z"},
+			{ID: 2, TimeStamp: "2026-04-25T12:00:00Z"},
+			{ID: 3, TimeStamp: "2026-04-25T12:00:00Z"},
+		}
+		ts, ids := boundaryTxIDs(entries)
+		if ts != "2026-04-25T12:00:00Z" {
+			t.Errorf("ts = %q", ts)
+		}
+		if len(ids) != 2 {
+			t.Errorf("expected 2 boundary IDs, got %d (%v)", len(ids), ids)
+		}
+		for _, want := range []string{"2", "3"} {
+			if _, ok := ids[want]; !ok {
+				t.Errorf("ids missing %q: %v", want, ids)
+			}
+		}
+	})
+
+	t.Run("ID-less entries skipped from dedupe set", func(t *testing.T) {
+		entries := []model.TransactionLogEntry{
+			{ID: 0, TimeStamp: "2026-04-25T12:00:00Z"},
+			{ID: 5, TimeStamp: "2026-04-25T12:00:00Z"},
+		}
+		ts, ids := boundaryTxIDs(entries)
+		if ts != "2026-04-25T12:00:00Z" {
+			t.Errorf("ts = %q", ts)
+		}
+		if len(ids) != 1 {
+			t.Errorf("ID-less entry should be skipped; got %v", ids)
+		}
+	})
+}
+
+// ============================================================
+// Unit tests — TransactionLogEntry JSON unmarshal (PrimitiveType fidelity)
+// ============================================================
+
+func TestTransactionLogEntry_UnmarshalPrimitiveTypes(t *testing.T) {
+	body := []byte(`{
+		"value": [
+			{"ID": 1, "TimeStamp":"2026-04-25T10:00:00Z","User":"alice","Cube":"Sales","Tuple":["Q1","2025"],"OldValue":null,"NewValue":42},
+			{"ID": 2, "TimeStamp":"2026-04-25T10:01:00Z","User":"bob","Cube":"Sales","Tuple":["Q1","2025"],"OldValue":42,"NewValue":"forty-two"},
+			{"ID": 3, "TimeStamp":"2026-04-25T10:02:00Z","User":"carol","Cube":"Sales","Tuple":["Q1","2025"],"OldValue":true,"NewValue":false}
+		]
+	}`)
+
+	var resp model.TransactionLogResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+	if len(resp.Value) != 3 {
+		t.Fatalf("got %d entries, want 3", len(resp.Value))
+	}
+	checks := []struct {
+		idx      int
+		old, new string
+	}{
+		{0, "", "42"},
+		{1, "42", "forty-two"},
+		{2, "true", "false"},
+	}
+	for _, c := range checks {
+		if got := formatTxValue(resp.Value[c.idx].OldValue); got != c.old {
+			t.Errorf("entry[%d].OldValue formatted = %q, want %q", c.idx, got, c.old)
+		}
+		if got := formatTxValue(resp.Value[c.idx].NewValue); got != c.new {
+			t.Errorf("entry[%d].NewValue formatted = %q, want %q", c.idx, got, c.new)
+		}
+	}
+	if resp.Value[0].ID != 1 || resp.Value[2].ID != 3 {
+		t.Errorf("numeric ID round-trip failed: got %d, %d", resp.Value[0].ID, resp.Value[2].ID)
+	}
+}
+
+// ============================================================
+// Integration tests — flag validation
+// ============================================================
+
+func TestRunLogsTx_NegativeTailRejected(t *testing.T) {
+	resetCmdFlags(t)
+	logsTxTail = -1
+
+	var requestCount int32
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&requestCount, 1)
+		w.Write(transactionLogJSON())
+	})
+
+	out := captureAll(t, func() {
+		err := runLogsTx(logsTxCmd, nil)
+		if err != errSilent {
+			t.Fatalf("expected errSilent, got: %v", err)
+		}
+	})
+	if !strings.Contains(out.Stderr, "--tail must be non-negative") {
+		t.Errorf("stderr should reject negative --tail, got: %q", out.Stderr)
+	}
+	if got := atomic.LoadInt32(&requestCount); got != 0 {
+		t.Errorf("expected 0 HTTP requests, got %d", got)
+	}
+}
+
+func TestRunLogsTx_ZeroIntervalWithFollowRejected(t *testing.T) {
+	resetCmdFlags(t)
+	logsTxFollow = true
+	logsTxInterval = 0
+
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Write(transactionLogJSON())
+	})
+	out := captureAll(t, func() {
+		err := runLogsTx(logsTxCmd, nil)
+		if err != errSilent {
+			t.Fatalf("expected errSilent, got: %v", err)
+		}
+	})
+	if !strings.Contains(out.Stderr, "--interval must be greater than zero") {
+		t.Errorf("stderr should reject zero --interval, got: %q", out.Stderr)
+	}
+}
+
+func TestRunLogsTx_NegativeIntervalWithFollowRejected(t *testing.T) {
+	resetCmdFlags(t)
+	logsTxFollow = true
+	logsTxInterval = -5 * time.Second
+
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Write(transactionLogJSON())
+	})
+	out := captureAll(t, func() {
+		err := runLogsTx(logsTxCmd, nil)
+		if err != errSilent {
+			t.Fatalf("expected errSilent, got: %v", err)
+		}
+	})
+	if !strings.Contains(out.Stderr, "--interval must be greater than zero") {
+		t.Errorf("stderr should reject negative --interval, got: %q", out.Stderr)
+	}
+}
+
+func TestRunLogsTx_UntilWithFollowRejected(t *testing.T) {
+	resetCmdFlags(t)
+	logsTxFollow = true
+	logsTxUntil = "1h"
+
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("should not make HTTP request")
+	})
+	out := captureAll(t, func() {
+		err := runLogsTx(logsTxCmd, nil)
+		if err != errSilent {
+			t.Fatalf("expected errSilent, got: %v", err)
+		}
+	})
+	if !strings.Contains(out.Stderr, "--until cannot be combined with --follow") {
+		t.Errorf("stderr should reject --until + --follow, got: %q", out.Stderr)
+	}
+}
+
+func TestRunLogsTx_SinceAfterUntilRejected(t *testing.T) {
+	resetCmdFlags(t)
+	logsTxSince = "2026-04-25T18:00:00Z"
+	logsTxUntil = "2026-04-25T10:00:00Z"
+
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("should not make HTTP request")
+	})
+	out := captureAll(t, func() {
+		err := runLogsTx(logsTxCmd, nil)
+		if err != errSilent {
+			t.Fatalf("expected errSilent, got: %v", err)
+		}
+	})
+	if !strings.Contains(out.Stderr, "--since must be earlier than --until") {
+		t.Errorf("stderr should reject since>until, got: %q", out.Stderr)
+	}
+}
+
+func TestRunLogsTx_InvalidSince(t *testing.T) {
+	resetCmdFlags(t)
+	logsTxSince = "not-a-time"
+
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("should not make HTTP request")
+	})
+	out := captureAll(t, func() {
+		err := runLogsTx(logsTxCmd, nil)
+		if err != errSilent {
+			t.Fatalf("expected errSilent, got: %v", err)
+		}
+	})
+	if !strings.Contains(out.Stderr, "--since") {
+		t.Errorf("stderr should mention --since, got: %q", out.Stderr)
+	}
+}
+
+func TestRunLogsTx_InvalidUntil(t *testing.T) {
+	resetCmdFlags(t)
+	logsTxUntil = "garbage"
+
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("should not make HTTP request")
+	})
+	out := captureAll(t, func() {
+		err := runLogsTx(logsTxCmd, nil)
+		if err != errSilent {
+			t.Fatalf("expected errSilent, got: %v", err)
+		}
+	})
+	if !strings.Contains(out.Stderr, "--until") {
+		t.Errorf("stderr should mention --until, got: %q", out.Stderr)
+	}
+	if strings.Contains(out.Stderr, "--since") {
+		t.Errorf("stderr should NOT mention --since for --until error, got: %q", out.Stderr)
+	}
+}
+
+// ============================================================
+// Integration tests — output formats
+// ============================================================
+
+func TestRunLogsTx_TableOutput(t *testing.T) {
+	resetCmdFlags(t)
+
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(transactionLogJSON(
+			model.TransactionLogEntry{
+				ID: 1, TimeStamp: "2026-04-25T10:00:00Z", User: "alice", Cube: "Sales",
+				Tuple:    []string{"Q1", "2025", "Revenue"},
+				OldValue: json.RawMessage(`100`), NewValue: json.RawMessage(`200`),
+				StatusMessage: "ok",
+			},
+		))
+	})
+
+	out := captureAll(t, func() {
+		if err := runLogsTx(logsTxCmd, nil); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	for _, header := range []string{"TIME", "USER", "CUBE", "TUPLE", "OLD", "NEW", "STATUS"} {
+		if !strings.Contains(out.Stdout, header) {
+			t.Errorf("stdout missing header %q", header)
+		}
+	}
+	for _, want := range []string{"alice", "Sales", "Q1:2025:Revenue", "100", "200", "ok"} {
+		if !strings.Contains(out.Stdout, want) {
+			t.Errorf("stdout missing %q\noutput:\n%s", want, out.Stdout)
+		}
+	}
+}
+
+func TestRunLogsTx_JSONOutput(t *testing.T) {
+	resetCmdFlags(t)
+	flagOutput = "json"
+
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(transactionLogJSON(
+			model.TransactionLogEntry{
+				ID: 1, TimeStamp: "2026-04-25T10:00:00Z", User: "alice", Cube: "Sales",
+				Tuple:    []string{"Q1"},
+				OldValue: json.RawMessage(`100`), NewValue: json.RawMessage(`200`),
+			},
+		))
+	})
+
+	out := captureAll(t, func() {
+		if err := runLogsTx(logsTxCmd, nil); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	var got []model.TransactionLogEntry
+	if err := json.Unmarshal([]byte(out.Stdout), &got); err != nil {
+		t.Fatalf("stdout is not valid JSON array: %v\noutput: %s", err, out.Stdout)
+	}
+	if len(got) != 1 {
+		t.Fatalf("got %d entries, want 1", len(got))
+	}
+	if got[0].User != "alice" || got[0].Cube != "Sales" {
+		t.Errorf("got %+v, want alice/Sales", got[0])
+	}
+}
+
+func TestRunLogsTx_RawOutput(t *testing.T) {
+	resetCmdFlags(t)
+	logsTxRaw = true
+
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(transactionLogJSON(
+			model.TransactionLogEntry{
+				ID: 1, TimeStamp: "2026-04-25T10:00:00Z", User: "alice", Cube: "Sales",
+				Tuple:    []string{"Q1", "2025"},
+				OldValue: json.RawMessage(`100`), NewValue: json.RawMessage(`200`),
+				StatusMessage: "ok",
+			},
+		))
+	})
+
+	out := captureAll(t, func() {
+		if err := runLogsTx(logsTxCmd, nil); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	lines := strings.Split(strings.TrimRight(out.Stdout, "\n"), "\n")
+	if len(lines) != 1 {
+		t.Fatalf("expected 1 raw line, got %d:\n%s", len(lines), out.Stdout)
+	}
+	for _, want := range []string{"alice", "Sales:Q1:2025", "100 -> 200", "ok"} {
+		if !strings.Contains(lines[0], want) {
+			t.Errorf("raw line missing %q: %q", want, lines[0])
+		}
+	}
+}
+
+func TestRunLogsTx_RawWithJSONRejected(t *testing.T) {
+	resetCmdFlags(t)
+	logsTxRaw = true
+	flagOutput = "json"
+
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("should not make any HTTP request")
+	})
+	out := captureAll(t, func() {
+		err := runLogsTx(logsTxCmd, nil)
+		if err != errSilent {
+			t.Fatalf("expected errSilent, got: %v", err)
+		}
+	})
+	if !strings.Contains(out.Stderr, "--raw cannot be combined with --output json") {
+		t.Errorf("stderr should contain conflict, got: %q", out.Stderr)
+	}
+}
+
+func TestRunLogsTx_RawSanitizesAllFields(t *testing.T) {
+	resetCmdFlags(t)
+	logsTxRaw = true
+
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(transactionLogJSON(
+			model.TransactionLogEntry{
+				ID:        1,
+				TimeStamp: "2026-04-25T10:00:00Z",
+				User:      "ali\nce",
+				Cube:      "Sa\rles",
+				Tuple:     []string{"Q1\t", "2025"},
+				OldValue:  json.RawMessage(`"old\nval"`),
+				NewValue:  json.RawMessage(`"new\rval"`),
+				StatusMessage: "status\nlines",
+			},
+		))
+	})
+
+	out := captureAll(t, func() {
+		if err := runLogsTx(logsTxCmd, nil); err != nil {
+			t.Fatalf("unexpected: %v", err)
+		}
+	})
+	lines := strings.Split(strings.TrimRight(out.Stdout, "\n"), "\n")
+	if len(lines) != 1 {
+		t.Errorf("expected 1 line after sanitization, got %d:\n%s", len(lines), out.Stdout)
+	}
+}
+
+// ============================================================
+// Integration tests — defaults / ordering
+// ============================================================
+
+func TestRunLogsTx_DefaultsToTail100(t *testing.T) {
+	resetCmdFlags(t)
+
+	var capturedQuery string
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		capturedQuery = r.URL.RawQuery
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(transactionLogJSON())
+	})
+
+	captureAll(t, func() {
+		if err := runLogsTx(logsTxCmd, nil); err != nil {
+			t.Fatalf("unexpected: %v", err)
+		}
+	})
+
+	decoded, err := decodedQuery(capturedQuery)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !strings.Contains(decoded, "$top=100") {
+		t.Errorf("query %q should contain $top=100", decoded)
+	}
+	if !strings.Contains(decoded, "$orderby=TimeStamp desc") {
+		t.Errorf("query %q should contain $orderby=TimeStamp desc", decoded)
+	}
+}
+
+func TestRunLogsTx_TailOrdering(t *testing.T) {
+	resetCmdFlags(t)
+	logsTxTail = 2
+
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		// Server returns DESC order — newest first
+		w.Write(transactionLogJSON(
+			model.TransactionLogEntry{ID: 2, TimeStamp: "2026-04-25T11:00:00Z", User: "bob", Cube: "C", Tuple: []string{"x"}, OldValue: json.RawMessage(`1`), NewValue: json.RawMessage(`2`)},
+			model.TransactionLogEntry{ID: 1, TimeStamp: "2026-04-25T10:00:00Z", User: "alice", Cube: "C", Tuple: []string{"x"}, OldValue: json.RawMessage(`0`), NewValue: json.RawMessage(`1`)},
+		))
+	})
+
+	out := captureAll(t, func() {
+		if err := runLogsTx(logsTxCmd, nil); err != nil {
+			t.Fatalf("unexpected: %v", err)
+		}
+	})
+
+	idxAlice := strings.Index(out.Stdout, "alice")
+	idxBob := strings.Index(out.Stdout, "bob")
+	if idxAlice < 0 || idxBob < 0 {
+		t.Fatalf("missing rows, output:\n%s", out.Stdout)
+	}
+	if idxAlice > idxBob {
+		t.Errorf("expected ASC after reverse: alice (older) before bob (newer); got bob first")
+	}
+}
+
+// ============================================================
+// Integration tests — server-side filters
+// ============================================================
+
+func TestRunLogsTx_CubeFilter_ServerSide(t *testing.T) {
+	resetCmdFlags(t)
+	logsTxCube = "Sales"
+
+	var capturedQuery string
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		capturedQuery = r.URL.RawQuery
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(transactionLogJSON())
+	})
+
+	captureAll(t, func() {
+		if err := runLogsTx(logsTxCmd, nil); err != nil {
+			t.Fatalf("unexpected: %v", err)
+		}
+	})
+	decoded, _ := decodedQuery(capturedQuery)
+	if !strings.Contains(decoded, "Cube eq 'Sales'") {
+		t.Errorf("query %q should contain Cube eq 'Sales'", decoded)
+	}
+}
+
+func TestRunLogsTx_UserFilter_ServerSide(t *testing.T) {
+	resetCmdFlags(t)
+	logsTxUser = "admin"
+
+	var capturedQuery string
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		capturedQuery = r.URL.RawQuery
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(transactionLogJSON())
+	})
+
+	captureAll(t, func() {
+		if err := runLogsTx(logsTxCmd, nil); err != nil {
+			t.Fatalf("unexpected: %v", err)
+		}
+	})
+	decoded, _ := decodedQuery(capturedQuery)
+	if !strings.Contains(decoded, "User eq 'admin'") {
+		t.Errorf("query %q should contain User eq 'admin'", decoded)
+	}
+}
+
+func TestRunLogsTx_SinceDuration(t *testing.T) {
+	resetCmdFlags(t)
+	logsTxSince = "10m"
+
+	var capturedQuery string
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		capturedQuery = r.URL.RawQuery
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(transactionLogJSON())
+	})
+
+	captureAll(t, func() {
+		if err := runLogsTx(logsTxCmd, nil); err != nil {
+			t.Fatalf("unexpected: %v", err)
+		}
+	})
+	decoded, _ := decodedQuery(capturedQuery)
+	if !strings.Contains(decoded, "TimeStamp ge ") {
+		t.Errorf("query %q should contain TimeStamp ge", decoded)
+	}
+}
+
+func TestRunLogsTx_SinceAbsolute(t *testing.T) {
+	resetCmdFlags(t)
+	logsTxSince = "2026-04-24T10:00:00Z"
+
+	var capturedQuery string
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		capturedQuery = r.URL.RawQuery
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(transactionLogJSON())
+	})
+
+	captureAll(t, func() {
+		if err := runLogsTx(logsTxCmd, nil); err != nil {
+			t.Fatalf("unexpected: %v", err)
+		}
+	})
+	decoded, _ := decodedQuery(capturedQuery)
+	if !strings.Contains(decoded, "TimeStamp ge 2026-04-24T10:00:00Z") {
+		t.Errorf("query %q should contain TimeStamp ge 2026-04-24T10:00:00Z", decoded)
+	}
+}
+
+func TestRunLogsTx_UntilApplied(t *testing.T) {
+	resetCmdFlags(t)
+	logsTxSince = "2026-04-25T10:00:00Z"
+	logsTxUntil = "2026-04-25T11:30:00Z"
+
+	var capturedQuery string
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		capturedQuery = r.URL.RawQuery
+		w.Header().Set("Content-Type", "application/json")
+		// Server returns three entries — last one is past --until and must be
+		// dropped client-side as defense in depth.
+		w.Write(transactionLogJSON(
+			model.TransactionLogEntry{ID: 1, TimeStamp: "2026-04-25T10:30:00Z", User: "u", Cube: "c", Tuple: []string{"x"}, OldValue: json.RawMessage(`0`), NewValue: json.RawMessage(`1`)},
+			model.TransactionLogEntry{ID: 2, TimeStamp: "2026-04-25T11:00:00Z", User: "u", Cube: "c", Tuple: []string{"x"}, OldValue: json.RawMessage(`1`), NewValue: json.RawMessage(`2`)},
+			model.TransactionLogEntry{ID: 3, TimeStamp: "2026-04-25T12:00:00Z", User: "u", Cube: "c", Tuple: []string{"x"}, OldValue: json.RawMessage(`2`), NewValue: json.RawMessage(`3`)},
+		))
+	})
+
+	out := captureAll(t, func() {
+		if err := runLogsTx(logsTxCmd, nil); err != nil {
+			t.Fatalf("unexpected: %v", err)
+		}
+	})
+
+	decoded, _ := decodedQuery(capturedQuery)
+	if !strings.Contains(decoded, "TimeStamp le 2026-04-25T11:30:00Z") {
+		t.Errorf("query %q should include 'TimeStamp le 2026-04-25T11:30:00Z'", decoded)
+	}
+	// Client-side: third entry (12:00) past until → must be dropped.
+	if strings.Contains(out.Stdout, "2026-04-25T12:00:00Z") {
+		t.Errorf("stdout should NOT contain entry past --until, got:\n%s", out.Stdout)
+	}
+}
+
+func TestRunLogsTx_CombinedFilters(t *testing.T) {
+	resetCmdFlags(t)
+	logsTxSince = "2026-04-25T10:00:00Z"
+	logsTxUntil = "2026-04-25T18:00:00Z"
+	logsTxCube = "Sales"
+	logsTxUser = "admin"
+
+	var capturedQuery string
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		capturedQuery = r.URL.RawQuery
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(transactionLogJSON())
+	})
+
+	captureAll(t, func() {
+		if err := runLogsTx(logsTxCmd, nil); err != nil {
+			t.Fatalf("unexpected: %v", err)
+		}
+	})
+
+	decoded, _ := decodedQuery(capturedQuery)
+	for _, want := range []string{
+		"TimeStamp ge 2026-04-25T10:00:00Z",
+		"TimeStamp le 2026-04-25T18:00:00Z",
+		"Cube eq 'Sales'",
+		"User eq 'admin'",
+		" and ",
+	} {
+		if !strings.Contains(decoded, want) {
+			t.Errorf("query %q missing %q", decoded, want)
+		}
+	}
+}
+
+func TestRunLogsTx_CubeWithQuoteEscaped(t *testing.T) {
+	resetCmdFlags(t)
+	logsTxCube = "O'Brien"
+
+	var capturedQuery string
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		capturedQuery = r.URL.RawQuery
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(transactionLogJSON())
+	})
+
+	captureAll(t, func() {
+		if err := runLogsTx(logsTxCmd, nil); err != nil {
+			t.Fatalf("unexpected: %v", err)
+		}
+	})
+
+	decoded, _ := decodedQuery(capturedQuery)
+	if !strings.Contains(decoded, "Cube eq 'O''Brien'") {
+		t.Errorf("query %q should escape ' as '': want Cube eq 'O''Brien'", decoded)
+	}
+}
+
+// ============================================================
+// Integration tests — fallback behavior
+// ============================================================
+
+func TestRunLogsTx_FilterFallback(t *testing.T) {
+	resetCmdFlags(t)
+	logsTxCube = "Sales"
+
+	var requestCount int32
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&requestCount, 1)
+		w.Header().Set("Content-Type", "application/json")
+		if n == 1 {
+			w.WriteHeader(http.StatusBadRequest)
+			fmt.Fprint(w, `{"error":"$filter not supported"}`)
+			return
+		}
+		// Second call: no $filter — return mixed cubes; client should drop non-Sales.
+		w.Write(transactionLogJSON(
+			model.TransactionLogEntry{ID: 1, TimeStamp: "2026-04-25T10:00:00Z", User: "u", Cube: "Sales", Tuple: []string{"x"}, OldValue: json.RawMessage(`0`), NewValue: json.RawMessage(`1`)},
+			model.TransactionLogEntry{ID: 2, TimeStamp: "2026-04-25T10:01:00Z", User: "u", Cube: "Inventory", Tuple: []string{"x"}, OldValue: json.RawMessage(`0`), NewValue: json.RawMessage(`1`)},
+		))
+	})
+
+	out := captureAll(t, func() {
+		if err := runLogsTx(logsTxCmd, nil); err != nil {
+			t.Fatalf("unexpected: %v", err)
+		}
+	})
+
+	if !strings.Contains(out.Stderr, "[warn] Server-side filter not supported") {
+		t.Errorf("stderr should print fallback warning, got: %q", out.Stderr)
+	}
+	if !strings.Contains(out.Stdout, "Sales") {
+		t.Errorf("stdout should contain Sales row, got:\n%s", out.Stdout)
+	}
+	if strings.Contains(out.Stdout, "Inventory") {
+		t.Errorf("stdout should NOT contain Inventory after client-filter, got:\n%s", out.Stdout)
+	}
+}
+
+func TestRunLogsTx_FilterFallbackCapsTop(t *testing.T) {
+	resetCmdFlags(t)
+	// --since defeats defaultTailIfUnbounded so top=0 reaches the fetch;
+	// only then does fallback exercise its safety cap.
+	logsTxSince = "2026-04-25T10:00:00Z"
+	logsTxCube = "Sales"
+
+	var capturedRetryQuery string
+	var requestCount int32
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&requestCount, 1)
+		w.Header().Set("Content-Type", "application/json")
+		if n == 1 {
+			w.WriteHeader(http.StatusBadRequest)
+			fmt.Fprint(w, `{"error":"$filter not supported"}`)
+			return
+		}
+		capturedRetryQuery = r.URL.RawQuery
+		w.Write(transactionLogJSON())
+	})
+
+	captureAll(t, func() {
+		if err := runLogsTx(logsTxCmd, nil); err != nil {
+			t.Fatalf("unexpected: %v", err)
+		}
+	})
+
+	decoded, _ := decodedQuery(capturedRetryQuery)
+	if !strings.Contains(decoded, fmt.Sprintf("$top=%d", fallbackSafetyCap)) {
+		t.Errorf("retry query %q should cap $top at %d", decoded, fallbackSafetyCap)
+	}
+	if !strings.Contains(decoded, "$orderby=TimeStamp desc") {
+		t.Errorf("retry query %q should force desc order", decoded)
+	}
+}
+
+func TestRunLogsTx_NoFallbackOn401(t *testing.T) {
+	resetCmdFlags(t)
+	logsTxCube = "Sales"
+
+	var requestCount int32
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&requestCount, 1)
+		w.WriteHeader(http.StatusUnauthorized)
+		fmt.Fprint(w, `{"error":"unauthorized"}`)
+	})
+
+	out := captureAll(t, func() {
+		err := runLogsTx(logsTxCmd, nil)
+		if err != errSilent {
+			t.Fatalf("expected errSilent, got: %v", err)
+		}
+	})
+	if got := atomic.LoadInt32(&requestCount); got != 1 {
+		t.Errorf("expected 1 request (no retry), got %d", got)
+	}
+	if !strings.Contains(out.Stderr, "Authentication failed") {
+		t.Errorf("stderr should mention auth failure, got: %q", out.Stderr)
+	}
+}
+
+func TestRunLogsTx_NoFallbackOn404(t *testing.T) {
+	resetCmdFlags(t)
+	logsTxCube = "Sales"
+
+	var requestCount int32
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&requestCount, 1)
+		w.WriteHeader(http.StatusNotFound)
+	})
+
+	captureAll(t, func() {
+		err := runLogsTx(logsTxCmd, nil)
+		if err != errSilent {
+			t.Fatalf("expected errSilent, got: %v", err)
+		}
+	})
+	if got := atomic.LoadInt32(&requestCount); got != 1 {
+		t.Errorf("expected 1 request (no retry), got %d", got)
+	}
+}
+
+// ============================================================
+// Integration tests — edge cases
+// ============================================================
+
+func TestRunLogsTx_EmptyResponse(t *testing.T) {
+	resetCmdFlags(t)
+
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(transactionLogJSON())
+	})
+
+	out := captureAll(t, func() {
+		if err := runLogsTx(logsTxCmd, nil); err != nil {
+			t.Fatalf("unexpected: %v", err)
+		}
+	})
+	// Empty response should print headers (still a table) but no rows.
+	if !strings.Contains(out.Stdout, "TIME") {
+		t.Errorf("table headers should still print on empty response, got:\n%s", out.Stdout)
+	}
+}
+
+func TestRunLogsTx_StatusMessageOmitted(t *testing.T) {
+	resetCmdFlags(t)
+
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		// Note: no StatusMessage field
+		fmt.Fprint(w, `{"value":[{"ID":1,"TimeStamp":"2026-04-25T10:00:00Z","User":"alice","Cube":"Sales","Tuple":["x"],"OldValue":null,"NewValue":42}]}`)
+	})
+
+	out := captureAll(t, func() {
+		if err := runLogsTx(logsTxCmd, nil); err != nil {
+			t.Fatalf("unexpected: %v", err)
+		}
+	})
+	if !strings.Contains(out.Stdout, "alice") {
+		t.Errorf("entry should still render without StatusMessage, got:\n%s", out.Stdout)
+	}
+}
+
+func TestRunLogsTx_TupleRendering(t *testing.T) {
+	resetCmdFlags(t)
+
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(transactionLogJSON(
+			model.TransactionLogEntry{
+				ID: 1, TimeStamp: "2026-04-25T10:00:00Z", User: "u", Cube: "C",
+				Tuple: []string{"Q1", "2025", "Sales"},
+				OldValue: json.RawMessage(`null`), NewValue: json.RawMessage(`42`),
+			},
+		))
+	})
+
+	out := captureAll(t, func() {
+		if err := runLogsTx(logsTxCmd, nil); err != nil {
+			t.Fatalf("unexpected: %v", err)
+		}
+	})
+	if !strings.Contains(out.Stdout, "Q1:2025:Sales") {
+		t.Errorf("tuple should render colon-joined, got:\n%s", out.Stdout)
+	}
+}
+
+func TestRunLogsTx_OldNewValuesPresent(t *testing.T) {
+	resetCmdFlags(t)
+
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"value":[{"ID":1,"TimeStamp":"2026-04-25T10:00:00Z","User":"u","Cube":"C","Tuple":["x"],"OldValue":99,"NewValue":"hello"}]}`)
+	})
+
+	out := captureAll(t, func() {
+		if err := runLogsTx(logsTxCmd, nil); err != nil {
+			t.Fatalf("unexpected: %v", err)
+		}
+	})
+	if !strings.Contains(out.Stdout, "99") {
+		t.Errorf("stdout should contain numeric old value 99, got:\n%s", out.Stdout)
+	}
+	if !strings.Contains(out.Stdout, "hello") {
+		t.Errorf("stdout should contain string new value 'hello', got:\n%s", out.Stdout)
+	}
+}
+
+// ============================================================
+// Integration tests — follow mode
+// ============================================================
+
+func TestRunLogsTx_FollowJSONInitialBatchIsNDJSON(t *testing.T) {
+	resetCmdFlags(t)
+	logsTxFollow = true
+	logsTxInterval = 5 * time.Millisecond
+	flagOutput = "json"
+
+	var pollCount int32
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&pollCount, 1)
+		w.Header().Set("Content-Type", "application/json")
+		// Initial fetch returns one entry; subsequent polls return nothing.
+		if atomic.LoadInt32(&pollCount) == 1 {
+			w.Write(transactionLogJSON(
+				model.TransactionLogEntry{
+					ID: 1, TimeStamp: "2026-04-25T10:00:00Z", User: "u", Cube: "C",
+					Tuple: []string{"x"}, OldValue: json.RawMessage(`0`), NewValue: json.RawMessage(`1`),
+				},
+			))
+		} else {
+			w.Write(transactionLogJSON())
+		}
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	out := captureAll(t, func() {
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			cfg, _ := loadConfig()
+			cl, _ := createClient(cfg)
+			// Run only the initial-batch portion: emulate follow=true initial print.
+			entries, _, _ := fetchTxEntries(cl, "", 100, true)
+			if logsTxTail == 0 && logsTxSince == "" {
+				// no-op: tail defaulting handled in runLogsTx; for this test we
+				// just want to confirm the print code path emits NDJSON in
+				// follow+json. Use printTxEntries directly with isFollowChunk=true.
+			}
+			printTxEntries(entries, true /*json*/, false, true /*follow*/)
+			cancel()
+		}()
+		<-done
+	})
+	_ = ctx
+
+	stdout := strings.TrimSpace(out.Stdout)
+	if stdout == "" {
+		t.Fatalf("expected NDJSON, got empty stdout")
+	}
+	// Must NOT be a JSON array
+	if strings.HasPrefix(stdout, "[") {
+		t.Errorf("follow+json should be NDJSON not array, got: %q", stdout)
+	}
+	// Each line must parse as a single object
+	for i, line := range strings.Split(stdout, "\n") {
+		var e model.TransactionLogEntry
+		if err := json.Unmarshal([]byte(line), &e); err != nil {
+			t.Errorf("line %d not a JSON object: %v: %q", i, err, line)
+		}
+	}
+}
+
+func TestFollowTxLogs_PollsAndAdvancesWatermark(t *testing.T) {
+	resetCmdFlags(t)
+
+	var pollCount int32
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		n := int(atomic.AddInt32(&pollCount, 1))
+		w.Header().Set("Content-Type", "application/json")
+		switch n {
+		case 1:
+			w.Write(transactionLogJSON(
+				model.TransactionLogEntry{ID: 1, TimeStamp: "2026-04-25T10:01:00Z", User: "u", Cube: "C", Tuple: []string{"x"}, OldValue: json.RawMessage(`0`), NewValue: json.RawMessage(`1`)},
+			))
+		case 2:
+			w.Write(transactionLogJSON(
+				model.TransactionLogEntry{ID: 2, TimeStamp: "2026-04-25T10:02:00Z", User: "u", Cube: "C", Tuple: []string{"x"}, OldValue: json.RawMessage(`1`), NewValue: json.RawMessage(`2`)},
+			))
+		default:
+			w.Write(transactionLogJSON())
+		}
+	})
+
+	cfg, _ := loadConfig()
+	cl, _ := createClient(cfg)
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	out := captureAll(t, func() {
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			followTxLogs(ctx, cl, "2026-04-25T10:00:00Z", nil, "", "", 5*time.Millisecond, false, false)
+		}()
+
+		for i := 0; i < 100; i++ {
+			if atomic.LoadInt32(&pollCount) >= 3 {
+				break
+			}
+			time.Sleep(5 * time.Millisecond)
+		}
+		cancel()
+		<-done
+	})
+
+	if !strings.Contains(out.Stdout, "2026-04-25T10:01:00Z") {
+		t.Errorf("stdout should contain T1 entry, got:\n%s", out.Stdout)
+	}
+	if !strings.Contains(out.Stdout, "2026-04-25T10:02:00Z") {
+		t.Errorf("stdout should contain T2 entry, got:\n%s", out.Stdout)
+	}
+}
+
+func TestFollowTxLogs_DropsDuplicateIDsAtBoundary(t *testing.T) {
+	resetCmdFlags(t)
+
+	var pollCount int32
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		n := int(atomic.AddInt32(&pollCount, 1))
+		w.Header().Set("Content-Type", "application/json")
+		entryA := model.TransactionLogEntry{ID: 1, TimeStamp: "2026-04-25T10:01:00Z", User: "u", Cube: "C", Tuple: []string{"x"}, OldValue: json.RawMessage(`0`), NewValue: json.RawMessage(`1`)}
+		entryB := model.TransactionLogEntry{ID: 2, TimeStamp: "2026-04-25T10:02:00Z", User: "u", Cube: "C", Tuple: []string{"x"}, OldValue: json.RawMessage(`1`), NewValue: json.RawMessage(`2`)}
+		switch n {
+		case 1:
+			w.Write(transactionLogJSON(entryA))
+		case 2:
+			// Boundary entry A reappears at the boundary; B is new
+			w.Write(transactionLogJSON(entryA, entryB))
+		default:
+			w.Write(transactionLogJSON())
+		}
+	})
+
+	cfg, _ := loadConfig()
+	cl, _ := createClient(cfg)
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	out := captureAll(t, func() {
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			followTxLogs(ctx, cl, "2026-04-25T10:00:00Z", nil, "", "", 5*time.Millisecond, false, false)
+		}()
+
+		for i := 0; i < 100; i++ {
+			if atomic.LoadInt32(&pollCount) >= 3 {
+				break
+			}
+			time.Sleep(5 * time.Millisecond)
+		}
+		cancel()
+		<-done
+	})
+
+	// Entry A's timestamp should appear exactly once
+	countA := strings.Count(out.Stdout, "2026-04-25T10:01:00Z")
+	if countA != 1 {
+		t.Errorf("entry A should appear exactly once, got %d times in:\n%s", countA, out.Stdout)
+	}
+	countB := strings.Count(out.Stdout, "2026-04-25T10:02:00Z")
+	if countB != 1 {
+		t.Errorf("entry B should appear exactly once, got %d times in:\n%s", countB, out.Stdout)
+	}
+}

--- a/cmd/testhelpers_test.go
+++ b/cmd/testhelpers_test.go
@@ -228,6 +228,14 @@ func zeroAllFlags() {
 	logsMsgInterval = 5 * time.Second
 	logsMsgTail = 0
 	logsMsgRaw = false
+	logsTxSince = ""
+	logsTxUntil = ""
+	logsTxCube = ""
+	logsTxUser = ""
+	logsTxFollow = false
+	logsTxInterval = 5 * time.Second
+	logsTxTail = 0
+	logsTxRaw = false
 }
 
 // cubesJSON returns JSON for a TM1 Cubes response.
@@ -410,6 +418,18 @@ func messageLogJSON(entries ...model.MessageLogEntry) []byte {
 	}{Value: entries}
 	if resp.Value == nil {
 		resp.Value = []model.MessageLogEntry{}
+	}
+	data, _ := json.Marshal(resp)
+	return data
+}
+
+// transactionLogJSON returns JSON for a TM1 TransactionLogEntries response.
+func transactionLogJSON(entries ...model.TransactionLogEntry) []byte {
+	resp := struct {
+		Value []model.TransactionLogEntry `json:"value"`
+	}{Value: entries}
+	if resp.Value == nil {
+		resp.Value = []model.TransactionLogEntry{}
 	}
 	data, _ := json.Marshal(resp)
 	return data

--- a/internal/model/transactionlog.go
+++ b/internal/model/transactionlog.go
@@ -9,11 +9,16 @@ import "encoding/json"
 // formatted at render time. Modelling them as string would fail unmarshal
 // for non-string responses.
 //
+// ChangeSetID rides as json.RawMessage too: some TM1 versions emit it as
+// Edm.Int64 (numeric, set by TI processes / bulk ops), others as a string
+// UUID, others as null. Modelling it as string would fail to unmarshal
+// numeric forms and the whole response would bail with a parse error.
+//
 // ID is Edm.Int64; older TM1 versions may omit it (zero == absent).
 type TransactionLogEntry struct {
 	ID            int64           `json:"ID,omitempty"`
 	TimeStamp     string          `json:"TimeStamp"`
-	ChangeSetID   string          `json:"ChangeSetID,omitempty"`
+	ChangeSetID   json.RawMessage `json:"ChangeSetID,omitempty"`
 	User          string          `json:"User"`
 	Cube          string          `json:"Cube"`
 	Tuple         []string        `json:"Tuple"`

--- a/internal/model/transactionlog.go
+++ b/internal/model/transactionlog.go
@@ -1,0 +1,28 @@
+package model
+
+import "encoding/json"
+
+// TransactionLogEntry represents a single entry from GET /TransactionLogEntries.
+//
+// OldValue and NewValue are TM1 Edm.PrimitiveType — they may arrive as JSON
+// null, number, string, or bool — so they ride as json.RawMessage and are
+// formatted at render time. Modelling them as string would fail unmarshal
+// for non-string responses.
+//
+// ID is Edm.Int64; older TM1 versions may omit it (zero == absent).
+type TransactionLogEntry struct {
+	ID            int64           `json:"ID,omitempty"`
+	TimeStamp     string          `json:"TimeStamp"`
+	ChangeSetID   string          `json:"ChangeSetID,omitempty"`
+	User          string          `json:"User"`
+	Cube          string          `json:"Cube"`
+	Tuple         []string        `json:"Tuple"`
+	OldValue      json.RawMessage `json:"OldValue"`
+	NewValue      json.RawMessage `json:"NewValue"`
+	StatusMessage string          `json:"StatusMessage,omitempty"`
+}
+
+// TransactionLogResponse is the OData collection wrapper.
+type TransactionLogResponse struct {
+	Value []TransactionLogEntry `json:"value"`
+}

--- a/internal/model/transactionlog.go
+++ b/internal/model/transactionlog.go
@@ -23,6 +23,11 @@ type TransactionLogEntry struct {
 }
 
 // TransactionLogResponse is the OData collection wrapper.
+//
+// NextLink is set by TM1 when the response is paginated and more entries
+// are available beyond Value. Callers must surface this to the user (or
+// follow it) — silently dropping it leaves results incomplete.
 type TransactionLogResponse struct {
-	Value []TransactionLogEntry `json:"value"`
+	Value    []TransactionLogEntry `json:"value"`
+	NextLink string                `json:"@odata.nextLink,omitempty"`
 }


### PR DESCRIPTION
## Summary

Add `tm1cli logs tx` — a sibling subcommand to `logs messages` (#78) that fetches and streams entries from `GET /TransactionLogEntries`.

- **Flags:** `--cube`, `--user`, `--since`, `--until`, `--tail`, `--follow` / `-f`, `--interval`, `--raw`, `--output json`.
- **Columns:** `TimeStamp`, `User`, `Cube`, `Tuple`, `OldValue`, `NewValue`, `StatusMessage`.
- **Server-side OData `\$filter`** for time bounds and exact-match cube/user (`eq`, case-sensitive). Client-side fallback with `[warn]` when the server rejects `\$filter`, applying all four filters locally.
- **`--follow`** polls on `--interval`, dedupes the boundary across ticks, and emits NDJSON when paired with `--output json` so the stream is uniform across initial-batch + poll chunks.
- **Pre-fetch validation**: `--raw + --output json`, `--since > --until`, `--until + --follow`, negative `--tail`/`--interval` all error before any HTTP call.

### Notable correctness work along the way

- **`OldValue`/`NewValue` are TM1 `Edm.PrimitiveType`** (string/number/bool/null) — modelled as \`json.RawMessage\` and rendered via \`formatTxValue\` so JSON unmarshal doesn't fail on numeric/bool/null entries.
- **Filter-fallback retry buffers `--tail`** by 10× (capped at \`fallbackSafetyCap=1000\`, overflow-safe) and truncates post-filter back to the user-requested tail. Prevents silent under-reporting when \`--tail\` is combined with content filters on a server without \`\$filter\` support. Applied symmetrically to \`cmd/logs.go\` for \`logs messages\` parity.
- **\`--until\` is now treated as a query bound** in \`defaultTailIfUnbounded\`. Previously \`logs tx --until X\` (no \`--since\`, no \`--tail\`) silently capped to the latest 100 entries before X — bad for audit/forensics use cases. Fixed by generalizing the helper signature to \`(bounded bool, tail int)\`.

## Test plan

- [x] Unit tests cover: OData escape, time-flag parsing (with correct flag-name in errors), value rendering, ID key, tuple rendering, filter builder (incl. quote-escape), URL builder, client filter (case-sensitive cube/user, since/until edges), sort tie-break, reverse, boundary IDs (incl. ID==0 skip), Edm.PrimitiveType unmarshal fidelity, fallback-retry buffer + overflow guard.
- [x] Integration tests cover: table/JSON/raw output, raw+JSON conflict, `--tail` ordering, all four flag-validation rejections, server-side filters (single, combined, escaped quote), `--since` duration + absolute, `--until` enforcement, fallback path (warn + client filter + buffered top + truncation), no-fallback-on-401/404, empty response, tuple rendering, missing `StatusMessage`, raw sanitization across all string fields, follow polling + boundary dedupe, NDJSON in follow chunks.
- [x] Regression test: `--until` alone produces a query without `\$top`.
- [x] `go test ./...` passes (5 packages, all green).
- [x] `go vet ./...` clean.

## Reviews

- Internal review (manual + multi-perspective): APPROVED
- External `/review` round 1: APPROVED with P2 nits → all addressed in round-1 + round-2 fixup commits
- External feedback flagging the `--tail + filter` fallback windowing as P1: addressed via buffered retry + post-filter truncation
- External feedback flagging `--until`-only silent cap as P1: addressed via `defaultTailIfUnbounded` signature generalization

Closes #79