### PR TITLE
feat(#80): logs audit — query the TM1 audit log

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ tm1cli logs messages --follow --output json   # NDJSON stream (one object per li
 ```
 
 ```bash
-# Audit log (requires AuditLog=T in tm1s.cfg; see below)
+# Audit log (requires AuditLogOn=T in tm1s.cfg; see below)
 tm1cli logs audit                                            # show last 100 audit log entries
 tm1cli logs audit --tail 50                                  # show last 50 entries
 tm1cli logs audit --since 24h --object-type Cube             # cube events in the past 24 hours
@@ -223,7 +223,7 @@ tm1cli logs audit --output json                              # JSON array output
 tm1cli logs audit --follow --output json                     # NDJSON stream (one object per line)
 ```
 
-**Prerequisite:** The TM1 server must have audit logging enabled (`AuditLog=T` in `tm1s.cfg`).
+**Prerequisite:** The TM1 server must have audit logging enabled (`AuditLogOn=T` in `tm1s.cfg`).
 When audit logging is disabled, the command exits with a clear error explaining how to enable it.
 
 **Note:** An empty result set may also indicate insufficient permission to read the audit log on

--- a/README.md
+++ b/README.md
@@ -211,6 +211,24 @@ tm1cli logs messages --output json            # JSON array output
 tm1cli logs messages --follow --output json   # NDJSON stream (one object per line)
 ```
 
+```bash
+# Audit log (requires AuditLog=T in tm1s.cfg; see below)
+tm1cli logs audit                                            # show last 100 audit log entries
+tm1cli logs audit --tail 50                                  # show last 50 entries
+tm1cli logs audit --since 24h --object-type Cube             # cube events in the past 24 hours
+tm1cli logs audit --object-type Process --object-name ImportSales  # specific process events
+tm1cli logs audit --user admin --follow                      # stream new entries for a user
+tm1cli logs audit --since 2026-04-24T10:00 --until 2026-04-24T18:00 --raw  # time range, raw output
+tm1cli logs audit --output json                              # JSON array output
+tm1cli logs audit --follow --output json                     # NDJSON stream (one object per line)
+```
+
+**Prerequisite:** The TM1 server must have audit logging enabled (`AuditLog=T` in `tm1s.cfg`).
+When audit logging is disabled, the command exits with a clear error explaining how to enable it.
+
+**Note:** An empty result set may also indicate insufficient permission to read the audit log on
+this server.
+
 Levels use canonical TM1 names: `Info`, `Warning`, `Error`, `Fatal`, `Debug`, `Unknown`, `Off`.
 Aliases `warn` and `err` are also accepted.
 

--- a/cmd/logs_audit.go
+++ b/cmd/logs_audit.go
@@ -430,11 +430,17 @@ func followAuditLogs(ctx context.Context, cl *client.Client, watermarkTS string,
 		}
 
 		if seenMaxTS != "" {
-			// The watermark must be MONOTONIC — never regress.
+			// The watermark must be MONOTONIC — never regress. Under fallback,
+			// the server returns the unfiltered log; dedupe can strip the
+			// latest rows leaving older entries whose seenMaxTS is BEFORE
+			// watermarkTS. Accepting that would forget the prior boundary IDs
+			// and re-emit the original entries on the next poll, indefinitely.
 			seenT, seenErr := parseTimeStamp(seenMaxTS)
 			curT, curErr := parseTimeStamp(watermarkTS)
 			if seenMaxTS == watermarkTS {
 				// Same boundary: MERGE new IDs into the existing dedup set.
+				// Replacing would drop prior boundary IDs and re-emit them
+				// next poll if the server keeps returning them at this TS.
 				for k, v := range seenIDs {
 					watermarkIDs[k] = v
 				}

--- a/cmd/logs_audit.go
+++ b/cmd/logs_audit.go
@@ -85,6 +85,13 @@ func isAuditLogDisabled(err error) bool {
 		return false
 	}
 	lower := strings.ToLower(msg)
+	// Filter / orderby rejection bodies often phrase the issue with the
+	// feature name spelled out ("$filter is not supported for the audit
+	// log"). Those must fall through to isFilterRejection so the client
+	// retries unfiltered — never short-circuit them as disabled.
+	if strings.Contains(lower, "filter") || strings.Contains(lower, "orderby") {
+		return false
+	}
 	// Require the feature phrase to avoid matching "AuditLogEntries"
 	// (entity-set name) which lowercases to "auditlogentries" — neither
 	// "audit log" (note the space) nor "auditing" appears in it.

--- a/cmd/logs_audit.go
+++ b/cmd/logs_audit.go
@@ -115,7 +115,7 @@ func buildAuditFilter(sinceTS, untilTS, objectType, objectName, user string) str
 		parts = append(parts, fmt.Sprintf("ObjectName eq '%s'", odataEscape(objectName)))
 	}
 	if user != "" {
-		parts = append(parts, fmt.Sprintf("User eq '%s'", odataEscape(user)))
+		parts = append(parts, fmt.Sprintf("UserName eq '%s'", odataEscape(user)))
 	}
 	return strings.Join(parts, " and ")
 }
@@ -229,7 +229,7 @@ func applyAuditClientFilters(entries []model.AuditLogEntry, sinceTS, untilTS, ob
 		if objectName != "" && e.ObjectName != objectName {
 			continue
 		}
-		if user != "" && e.User != user {
+		if user != "" && e.UserName != user {
 			continue
 		}
 		out = append(out, e)
@@ -301,11 +301,10 @@ func auditIDKey(e model.AuditLogEntry) string {
 	return strings.Join([]string{
 		"syn",
 		e.TimeStamp,
-		e.User,
+		e.UserName,
 		e.ObjectType,
 		e.ObjectName,
 		e.Description,
-		e.AuditDetails,
 	}, sep)
 }
 
@@ -366,7 +365,7 @@ func printAuditEntries(entries []model.AuditLogEntry, jsonMode, rawMode, isFollo
 		for _, e := range entries {
 			fmt.Printf("%s %s %s %s %s\n",
 				e.TimeStamp,
-				sanitizeRawMessage(e.User),
+				sanitizeRawMessage(e.UserName),
 				sanitizeRawMessage(e.ObjectType),
 				sanitizeRawMessage(e.ObjectName),
 				sanitizeRawMessage(e.Description),
@@ -379,7 +378,7 @@ func printAuditEntries(entries []model.AuditLogEntry, jsonMode, rawMode, isFollo
 	for i, e := range entries {
 		rows[i] = []string{
 			e.TimeStamp,
-			sanitizeRawMessage(e.User),
+			sanitizeRawMessage(e.UserName),
 			sanitizeRawMessage(e.ObjectType),
 			sanitizeRawMessage(e.ObjectName),
 			sanitizeRawMessage(e.Description),

--- a/cmd/logs_audit.go
+++ b/cmd/logs_audit.go
@@ -1,0 +1,565 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/url"
+	"os"
+	"os/signal"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+	"tm1cli/internal/client"
+	"tm1cli/internal/model"
+	"tm1cli/internal/output"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	logsAuditSince      string
+	logsAuditUntil      string
+	logsAuditObjectType string
+	logsAuditObjectName string
+	logsAuditUser       string
+	logsAuditFollow     bool
+	logsAuditInterval   time.Duration
+	logsAuditTail       int
+	logsAuditRaw        bool
+)
+
+var logsAuditCmd = &cobra.Command{
+	Use:   "audit",
+	Short: "Show and stream the TM1 audit log",
+	Long: `Show and stream the TM1 audit log (object create/delete/update/rename events).
+
+REST API: GET /AuditLogEntries
+
+Prerequisite: the server must have audit logging enabled (AuditLog=T in
+tm1s.cfg). When disabled, this command exits with a clear error.
+
+Filter by time range, object type, object name, or user. Use --follow to
+stream new entries kubectl-style; --tail to show the last N entries.
+
+--object-type, --object-name, and --user are matched case-sensitively
+(server-side OData eq); when the server cannot apply $filter, the client
+falls back to the same case-sensitive equality.
+
+When --follow is combined with --output json, entries are emitted as
+NDJSON (one JSON object per line) instead of a JSON array.
+
+Note: an empty result set may also indicate insufficient permission to read
+the audit log on this server.`,
+	Example: `  tm1cli logs audit --tail 50
+  tm1cli logs audit --since 24h --object-type Cube
+  tm1cli logs audit --user admin --follow
+  tm1cli logs audit --since 2026-04-24T10:00 --until 2026-04-24T18:00 --raw
+  tm1cli logs audit --object-type Process --object-name ImportSales`,
+	RunE: runLogsAudit,
+}
+
+var errAuditLogDisabled = errors.New("Audit log is disabled on this TM1 server. Set AuditLog=T in tm1s.cfg and restart the server.")
+
+// isAuditLogDisabled returns true when the server error indicates audit
+// logging is not enabled. The signal varies by TM1 version, so accept
+// any of "disabled" / "not enabled" / "not supported" / "not available"
+// in combination with "audit". Auth and not-found errors are excluded:
+// they imply nothing about audit-log config.
+func isAuditLogDisabled(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	if strings.HasPrefix(msg, "HTTP 401") || strings.HasPrefix(msg, "HTTP 403") || strings.HasPrefix(msg, "HTTP 404") {
+		return false
+	}
+	if strings.Contains(msg, "Authentication failed") {
+		return false
+	}
+	lower := strings.ToLower(msg)
+	if !strings.Contains(lower, "audit") {
+		return false
+	}
+	return strings.Contains(lower, "disabled") ||
+		strings.Contains(lower, "not enabled") ||
+		strings.Contains(lower, "not supported") ||
+		strings.Contains(lower, "not available")
+}
+
+// buildAuditFilter assembles the OData $filter from time bounds and exact-match
+// objectType/objectName/user. Empty inputs are skipped. All string values use
+// OData eq with odata-escaped string literals.
+func buildAuditFilter(sinceTS, untilTS, objectType, objectName, user string) string {
+	var parts []string
+	if sinceTS != "" {
+		parts = append(parts, fmt.Sprintf("TimeStamp ge %s", sinceTS))
+	}
+	if untilTS != "" {
+		parts = append(parts, fmt.Sprintf("TimeStamp le %s", untilTS))
+	}
+	if objectType != "" {
+		parts = append(parts, fmt.Sprintf("ObjectType eq '%s'", odataEscape(objectType)))
+	}
+	if objectName != "" {
+		parts = append(parts, fmt.Sprintf("ObjectName eq '%s'", odataEscape(objectName)))
+	}
+	if user != "" {
+		parts = append(parts, fmt.Sprintf("User eq '%s'", odataEscape(user)))
+	}
+	return strings.Join(parts, " and ")
+}
+
+// buildAuditQuery builds the endpoint URL with $filter, $top, $orderby using
+// url.Values for safe encoding. orderBy must be "", orderTimeStampAsc, or
+// orderTimeStampDesc — empty means no $orderby clause (use server default).
+func buildAuditQuery(filter string, top int, orderBy string) string {
+	v := url.Values{}
+	if filter != "" {
+		v.Set("$filter", filter)
+	}
+	if top > 0 {
+		v.Set("$top", strconv.Itoa(top))
+	}
+	if orderBy != "" {
+		v.Set("$orderby", orderBy)
+	}
+	if len(v) == 0 {
+		return "AuditLogEntries"
+	}
+	return "AuditLogEntries?" + v.Encode()
+}
+
+// fetchAuditEntries performs GET. On HTTP 400/501 with a filter-rejection body,
+// it retries without $filter (over-fetching via fallbackRetryTop when --tail is
+// set so client-side filtering has room to find matches) and returns fallback=true.
+// On disabled-audit errors the friendly errAuditLogDisabled is returned.
+// On auth/not-found/network errors the error propagates unchanged.
+//
+// sinceSet/untilSet steer the retry order so the cap captures the right slice
+// of the log:
+//   - --until alone → retry ASC so the cap captures the oldest entries (most
+//     likely before untilTS), avoiding silent empty output.
+//   - --since (with or without --until) → retry DESC for the latest entries.
+//   - neither → retry DESC (latest rows by default).
+func fetchAuditEntries(cl *client.Client, filter string, top int, orderDesc, sinceSet, untilSet bool) ([]model.AuditLogEntry, bool, error) {
+	successOrderBy := ""
+	if orderDesc {
+		successOrderBy = orderTimeStampDesc
+	}
+	endpoint := buildAuditQuery(filter, top, successOrderBy)
+	data, err := cl.Get(endpoint)
+	if err != nil {
+		if isAuditLogDisabled(err) {
+			return nil, false, errAuditLogDisabled
+		}
+		if filter != "" && isFilterRejection(err) {
+			retryTop := fallbackRetryTop(top)
+			retryOrderBy := orderTimeStampDesc
+			if untilSet && !sinceSet {
+				retryOrderBy = orderTimeStampAsc
+			}
+			retryData, retryErr := cl.Get(buildAuditQuery("", retryTop, retryOrderBy))
+			if retryErr != nil {
+				if isAuditLogDisabled(retryErr) {
+					return nil, false, errAuditLogDisabled
+				}
+				return nil, false, retryErr
+			}
+			var resp model.AuditLogResponse
+			if jerr := json.Unmarshal(retryData, &resp); jerr != nil {
+				return nil, false, fmt.Errorf("cannot parse server response: %w", jerr)
+			}
+			emitFallbackWarning(retryTop, len(resp.Value))
+			if untilSet {
+				output.PrintWarning("--until cannot be enforced server-side under fallback; historical entries past the retry window will be missed. Narrow --tail, set --since, or accept the limitation.")
+			}
+			warnIfPaginated(resp.NextLink)
+			return resp.Value, true, nil
+		}
+		return nil, false, err
+	}
+	var resp model.AuditLogResponse
+	if err := json.Unmarshal(data, &resp); err != nil {
+		return nil, false, fmt.Errorf("cannot parse server response: %w", err)
+	}
+	warnIfPaginated(resp.NextLink)
+	return resp.Value, false, nil
+}
+
+// applyAuditClientFilters drops entries outside the [sinceTS, untilTS] window
+// and any whose ObjectType/ObjectName/User don't match exactly (case-sensitive —
+// matches server eq semantics).
+func applyAuditClientFilters(entries []model.AuditLogEntry, sinceTS, untilTS, objectType, objectName, user string) []model.AuditLogEntry {
+	var sinceT, untilT time.Time
+	if sinceTS != "" {
+		sinceT, _ = parseTimeStamp(sinceTS)
+	}
+	if untilTS != "" {
+		untilT, _ = parseTimeStamp(untilTS)
+	}
+
+	out := make([]model.AuditLogEntry, 0, len(entries))
+	for _, e := range entries {
+		if !sinceT.IsZero() || !untilT.IsZero() {
+			t, err := parseTimeStamp(e.TimeStamp)
+			if err != nil {
+				continue
+			}
+			if !sinceT.IsZero() && t.Before(sinceT) {
+				continue
+			}
+			if !untilT.IsZero() && t.After(untilT) {
+				continue
+			}
+		}
+		if objectType != "" && e.ObjectType != objectType {
+			continue
+		}
+		if objectName != "" && e.ObjectName != objectName {
+			continue
+		}
+		if user != "" && e.User != user {
+			continue
+		}
+		out = append(out, e)
+	}
+	return out
+}
+
+// sortAuditByTimeStamp sorts ascending; ties are broken by ID (string compare).
+// Unparseable timestamps go to the end stably.
+func sortAuditByTimeStamp(entries []model.AuditLogEntry) {
+	sort.SliceStable(entries, func(i, j int) bool {
+		ti, errI := parseTimeStamp(entries[i].TimeStamp)
+		tj, errJ := parseTimeStamp(entries[j].TimeStamp)
+		switch {
+		case errI != nil && errJ != nil:
+			return false
+		case errI != nil:
+			return false
+		case errJ != nil:
+			return true
+		case ti.Equal(tj):
+			return entries[i].ID < entries[j].ID
+		default:
+			return ti.Before(tj)
+		}
+	})
+}
+
+// sortAuditByTimeStampDesc sorts descending; ties are broken by ID (descending).
+// Unparseable timestamps go to the end stably.
+func sortAuditByTimeStampDesc(entries []model.AuditLogEntry) {
+	sort.SliceStable(entries, func(i, j int) bool {
+		ti, errI := parseTimeStamp(entries[i].TimeStamp)
+		tj, errJ := parseTimeStamp(entries[j].TimeStamp)
+		switch {
+		case errI != nil && errJ != nil:
+			return false
+		case errI != nil:
+			return false
+		case errJ != nil:
+			return true
+		case ti.Equal(tj):
+			return entries[i].ID > entries[j].ID
+		default:
+			return ti.After(tj)
+		}
+	})
+}
+
+// reverseAuditEntries reverses entries in place.
+func reverseAuditEntries(entries []model.AuditLogEntry) {
+	for i, j := 0, len(entries)-1; i < j; i, j = i+1, j-1 {
+		entries[i], entries[j] = entries[j], entries[i]
+	}
+}
+
+// auditIDKey returns the dedupe key for an audit-log entry. When TM1 supplies
+// ID we use it directly. When ID is omitted (older versions) we synthesize a
+// key from the observable fields so same-timestamp entries can be distinguished.
+// Two functionally identical events (same content, same timestamp) hash to the
+// same key, which is the right behavior — they are indistinguishable.
+func auditIDKey(e model.AuditLogEntry) string {
+	if e.ID != "" {
+		return e.ID
+	}
+	// 0x1f (unit separator) is illegal in TM1 names and OData strings, so
+	// it cannot appear inside any field — safe as a delimiter.
+	const sep = "\x1f"
+	return strings.Join([]string{
+		"syn",
+		e.TimeStamp,
+		e.User,
+		e.ObjectType,
+		e.ObjectName,
+		e.Description,
+		e.AuditDetails,
+	}, sep)
+}
+
+// boundaryAuditIDs returns the maximum TimeStamp string in entries and the set
+// of dedupe keys whose timestamp equals it. Used by --follow to drop boundary
+// duplicates across polls.
+func boundaryAuditIDs(entries []model.AuditLogEntry) (string, map[string]struct{}) {
+	if len(entries) == 0 {
+		return "", nil
+	}
+	maxT, errFirst := parseTimeStamp(entries[0].TimeStamp)
+	hasMaxT := errFirst == nil
+	maxTS := entries[0].TimeStamp
+	for _, e := range entries[1:] {
+		t, err := parseTimeStamp(e.TimeStamp)
+		if err != nil {
+			continue
+		}
+		if !hasMaxT || t.After(maxT) {
+			maxT, maxTS, hasMaxT = t, e.TimeStamp, true
+		}
+	}
+	ids := map[string]struct{}{}
+	for _, e := range entries {
+		if e.TimeStamp != maxTS {
+			continue
+		}
+		ids[auditIDKey(e)] = struct{}{}
+	}
+	return maxTS, ids
+}
+
+// initialFollowAuditWatermark composes boundaryAuditIDs + advanceWatermark +
+// resolveFollowWatermark to produce the starting (watermarkTS, watermarkIDs)
+// pair for follow polls.
+func initialFollowAuditWatermark(entries []model.AuditLogEntry, sinceTS string, now time.Time) (string, map[string]struct{}) {
+	maxTS, ids := boundaryAuditIDs(entries)
+	maxTS, ids = advanceWatermark(maxTS, ids)
+	return resolveFollowWatermark(maxTS, sinceTS, now), ids
+}
+
+// printAuditEntries renders entries in the chosen format. In follow+jsonMode it
+// emits NDJSON (one object per line). In raw mode every string field is passed
+// through sanitizeRawMessage so each entry stays on a single line.
+func printAuditEntries(entries []model.AuditLogEntry, jsonMode, rawMode, isFollowChunk bool) {
+	if jsonMode {
+		if isFollowChunk {
+			for _, e := range entries {
+				data, _ := json.Marshal(e)
+				fmt.Println(string(data))
+			}
+			return
+		}
+		output.PrintJSON(entries)
+		return
+	}
+	if rawMode {
+		for _, e := range entries {
+			fmt.Printf("%s %s %s %s %s\n",
+				e.TimeStamp,
+				sanitizeRawMessage(e.User),
+				sanitizeRawMessage(e.ObjectType),
+				sanitizeRawMessage(e.ObjectName),
+				sanitizeRawMessage(e.Description),
+			)
+		}
+		return
+	}
+	headers := []string{"TIME", "USER", "OBJECT_TYPE", "OBJECT_NAME", "DESCRIPTION"}
+	rows := make([][]string, len(entries))
+	for i, e := range entries {
+		rows[i] = []string{
+			e.TimeStamp,
+			sanitizeRawMessage(e.User),
+			sanitizeRawMessage(e.ObjectType),
+			sanitizeRawMessage(e.ObjectName),
+			sanitizeRawMessage(e.Description),
+		}
+	}
+	output.PrintTable(headers, rows)
+}
+
+// followAuditLogs is the polling loop driven by ctx for testability.
+func followAuditLogs(ctx context.Context, cl *client.Client, watermarkTS string, watermarkIDs map[string]struct{}, objectType, objectName, user string, interval time.Duration, jsonMode, rawMode bool) error {
+	if watermarkIDs == nil {
+		watermarkIDs = map[string]struct{}{}
+	}
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-time.After(interval):
+		}
+
+		filter := buildAuditFilter(watermarkTS, "", objectType, objectName, user)
+		// --until is mutually exclusive with --follow, so untilSet is false.
+		// sinceSet is true because the watermark itself is a since-anchor.
+		entries, fallback, err := fetchAuditEntries(cl, filter, 0, false, true, false)
+		if err != nil {
+			output.PrintWarning(fmt.Sprintf("poll failed: %s", err))
+			continue
+		}
+
+		// Drop boundary duplicates first (clock-skew dedupe).
+		filtered := entries[:0]
+		for _, e := range entries {
+			if _, seen := watermarkIDs[auditIDKey(e)]; seen {
+				continue
+			}
+			filtered = append(filtered, e)
+		}
+		entries = filtered
+
+		// Compute next watermark from POST-DEDUP entries (what the server
+		// actually surfaced this poll), not from POST-client-filter — otherwise
+		// objectType/objectName/user filtering everything out leaves the watermark frozen.
+		seenMaxTS, seenIDs := boundaryAuditIDs(entries)
+
+		applySince, applyObjectType, applyObjectName, applyUser := "", "", "", ""
+		if fallback {
+			applySince, applyObjectType, applyObjectName, applyUser = watermarkTS, objectType, objectName, user
+		}
+		if applySince != "" || applyObjectType != "" || applyObjectName != "" || applyUser != "" {
+			entries = applyAuditClientFilters(entries, applySince, "", applyObjectType, applyObjectName, applyUser)
+		}
+
+		if len(entries) > 0 {
+			sortAuditByTimeStamp(entries)
+			printAuditEntries(entries, jsonMode, rawMode, true)
+		}
+
+		if seenMaxTS != "" {
+			// The watermark must be MONOTONIC — never regress.
+			seenT, seenErr := parseTimeStamp(seenMaxTS)
+			curT, curErr := parseTimeStamp(watermarkTS)
+			if seenMaxTS == watermarkTS {
+				// Same boundary: MERGE new IDs into the existing dedup set.
+				for k, v := range seenIDs {
+					watermarkIDs[k] = v
+				}
+			} else if seenErr == nil && (curErr != nil || seenT.After(curT)) {
+				// Strictly later boundary: advance.
+				watermarkTS, watermarkIDs = advanceWatermark(seenMaxTS, seenIDs)
+			}
+			// else: seenMaxTS is older than watermarkTS — ignore (do not regress).
+		}
+	}
+}
+
+func runLogsAudit(cmd *cobra.Command, args []string) error {
+	cfg, err := loadConfig()
+	if err != nil {
+		output.PrintError(err.Error(), isJSONOutput(nil))
+		return errSilent
+	}
+	jsonMode := isJSONOutput(cfg)
+
+	if logsAuditRaw && jsonMode {
+		output.PrintError("--raw cannot be combined with --output json.", jsonMode)
+		return errSilent
+	}
+	if logsAuditTail < 0 {
+		output.PrintError("--tail must be non-negative.", jsonMode)
+		return errSilent
+	}
+	if logsAuditFollow && logsAuditInterval <= 0 {
+		output.PrintError("--interval must be greater than zero (e.g. 5s).", jsonMode)
+		return errSilent
+	}
+	if logsAuditFollow && logsAuditUntil != "" {
+		output.PrintError("--until cannot be combined with --follow.", jsonMode)
+		return errSilent
+	}
+
+	now := time.Now()
+	sinceTS, err := parseTimeFlag("--since", logsAuditSince, now)
+	if err != nil {
+		output.PrintError(err.Error(), jsonMode)
+		return errSilent
+	}
+	untilTS, err := parseTimeFlag("--until", logsAuditUntil, now)
+	if err != nil {
+		output.PrintError(err.Error(), jsonMode)
+		return errSilent
+	}
+	if sinceTS != "" && untilTS != "" {
+		sinceT, _ := parseTimeStamp(sinceTS)
+		untilT, _ := parseTimeStamp(untilTS)
+		if untilT.Before(sinceT) {
+			output.PrintError("--since must be earlier than --until.", jsonMode)
+			return errSilent
+		}
+	}
+
+	tail := defaultTailIfUnbounded(logsAuditSince != "" || logsAuditUntil != "", logsAuditTail)
+
+	cl, err := createClient(cfg)
+	if err != nil {
+		output.PrintError(err.Error(), jsonMode)
+		return errSilent
+	}
+
+	filter := buildAuditFilter(sinceTS, untilTS, logsAuditObjectType, logsAuditObjectName, logsAuditUser)
+	entries, fallback, err := fetchAuditEntries(cl, filter, tail, tail > 0, sinceTS != "", untilTS != "")
+	if err != nil {
+		output.PrintError(err.Error(), jsonMode)
+		return errSilent
+	}
+
+	// On fallback, apply all five filters client-side. On the success path,
+	// still apply --until client-side as defense in depth — TM1 may round
+	// timestamps server-side and surface entries slightly outside the window.
+	applySince, applyUntil, applyObjectType, applyObjectName, applyUser := "", "", "", "", ""
+	if fallback {
+		applySince, applyUntil, applyObjectType, applyObjectName, applyUser = sinceTS, untilTS, logsAuditObjectType, logsAuditObjectName, logsAuditUser
+	} else if untilTS != "" {
+		applyUntil = untilTS
+	}
+	if applySince != "" || applyUntil != "" || applyObjectType != "" || applyObjectName != "" || applyUser != "" {
+		entries = applyAuditClientFilters(entries, applySince, applyUntil, applyObjectType, applyObjectName, applyUser)
+	}
+
+	// Fallback over-fetches via fallbackTailMultiplier so client-side filtering
+	// has room to find matches; trim back to the user-requested --tail before
+	// display. Sort DESC first so [:tail] always keeps the LATEST N.
+	if fallback && tail > 0 && len(entries) > tail {
+		sortAuditByTimeStampDesc(entries)
+		entries = entries[:tail]
+	}
+
+	if tail > 0 {
+		reverseAuditEntries(entries)
+	} else {
+		sortAuditByTimeStamp(entries)
+	}
+
+	// In --follow + --output json, the initial batch is also NDJSON so the
+	// stream is uniform.
+	printAuditEntries(entries, jsonMode, logsAuditRaw, logsAuditFollow)
+
+	if !logsAuditFollow {
+		return nil
+	}
+
+	maxTS, ids := initialFollowAuditWatermark(entries, sinceTS, time.Now())
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
+	defer stop()
+
+	return followAuditLogs(ctx, cl, maxTS, ids, logsAuditObjectType, logsAuditObjectName, logsAuditUser, logsAuditInterval, jsonMode, logsAuditRaw)
+}
+
+func init() {
+	logsCmd.AddCommand(logsAuditCmd)
+
+	logsAuditCmd.Flags().StringVar(&logsAuditSince, "since", "", "Show entries newer than duration (e.g. 10m, 2h) or timestamp (e.g. 2026-04-24T10:00 — interpreted as local time when no timezone is given)")
+	logsAuditCmd.Flags().StringVar(&logsAuditUntil, "until", "", "Show entries older than duration or timestamp (same syntax as --since)")
+	logsAuditCmd.Flags().StringVar(&logsAuditObjectType, "object-type", "", "Filter by object type (server-side; case-sensitive, e.g. Cube, Process, Dimension)")
+	logsAuditCmd.Flags().StringVar(&logsAuditObjectName, "object-name", "", "Filter by object name (server-side; case-sensitive)")
+	logsAuditCmd.Flags().StringVar(&logsAuditUser, "user", "", "Filter by user name (server-side; case-sensitive)")
+	logsAuditCmd.Flags().BoolVarP(&logsAuditFollow, "follow", "f", false, "Stream new entries kubectl-style (--output json emits NDJSON)")
+	logsAuditCmd.Flags().DurationVar(&logsAuditInterval, "interval", 5*time.Second, "Polling interval when --follow is set")
+	logsAuditCmd.Flags().IntVar(&logsAuditTail, "tail", 0, "Show last N entries (defaults to 100 when no --since/--follow)")
+	logsAuditCmd.Flags().BoolVar(&logsAuditRaw, "raw", false, "Raw output: one line per entry (control characters in fields are collapsed to spaces)")
+}

--- a/cmd/logs_audit.go
+++ b/cmd/logs_audit.go
@@ -66,8 +66,13 @@ var errAuditLogDisabled = errors.New("Audit log is disabled on this TM1 server. 
 // isAuditLogDisabled returns true when the server error indicates audit
 // logging is not enabled. The signal varies by TM1 version, so accept
 // any of "disabled" / "not enabled" / "not supported" / "not available"
-// in combination with "audit". Auth and not-found errors are excluded:
-// they imply nothing about audit-log config.
+// in combination with the feature phrase ("audit log" or "auditing").
+// The bare token "audit" is rejected because it appears inside the
+// entity-set name AuditLogEntries — server bodies that echo the entity
+// name in a $filter-rejection (e.g. "$filter is not supported for
+// AuditLogEntries") would otherwise be misclassified as disabled and
+// suppress the required client-side fallback. Auth and not-found errors
+// are also excluded: they imply nothing about audit-log config.
 func isAuditLogDisabled(err error) bool {
 	if err == nil {
 		return false
@@ -80,7 +85,10 @@ func isAuditLogDisabled(err error) bool {
 		return false
 	}
 	lower := strings.ToLower(msg)
-	if !strings.Contains(lower, "audit") {
+	// Require the feature phrase to avoid matching "AuditLogEntries"
+	// (entity-set name) which lowercases to "auditlogentries" — neither
+	// "audit log" (note the space) nor "auditing" appears in it.
+	if !strings.Contains(lower, "audit log") && !strings.Contains(lower, "auditing") {
 		return false
 	}
 	return strings.Contains(lower, "disabled") ||

--- a/cmd/logs_audit.go
+++ b/cmd/logs_audit.go
@@ -38,7 +38,7 @@ var logsAuditCmd = &cobra.Command{
 
 REST API: GET /AuditLogEntries
 
-Prerequisite: the server must have audit logging enabled (AuditLog=T in
+Prerequisite: the server must have audit logging enabled (AuditLogOn=T in
 tm1s.cfg). When disabled, this command exits with a clear error.
 
 Filter by time range, object type, object name, or user. Use --follow to
@@ -61,7 +61,7 @@ the audit log on this server.`,
 	RunE: runLogsAudit,
 }
 
-var errAuditLogDisabled = errors.New("Audit log is disabled on this TM1 server. Set AuditLog=T in tm1s.cfg and restart the server.")
+var errAuditLogDisabled = errors.New("Audit log is disabled on this TM1 server. Set AuditLogOn=T in tm1s.cfg and restart the server.")
 
 // isAuditLogDisabled returns true when the server error indicates audit
 // logging is not enabled. The signal varies by TM1 version, so accept
@@ -404,6 +404,11 @@ func followAuditLogs(ctx context.Context, cl *client.Client, watermarkTS string,
 		// sinceSet is true because the watermark itself is a since-anchor.
 		entries, fallback, err := fetchAuditEntries(cl, filter, 0, false, true, false)
 		if err != nil {
+			// Audit logging toggled off mid-stream: bail out instead of
+			// spamming "poll failed" warnings forever.
+			if errors.Is(err, errAuditLogDisabled) {
+				return err
+			}
 			output.PrintWarning(fmt.Sprintf("poll failed: %s", err))
 			continue
 		}

--- a/cmd/logs_audit_test.go
+++ b/cmd/logs_audit_test.go
@@ -401,6 +401,14 @@ func TestIsAuditLogDisabled(t *testing.T) {
 		{"HTTP 404 not found", fmt.Errorf("HTTP 404: Not found"), false},
 		{"HTTP 400 filter not supported (no audit keyword)", fmt.Errorf("HTTP 400: filter not supported"), false},
 		{"connection timeout (no audit keyword)", fmt.Errorf("Connection error: timeout"), false},
+		// Regression: the entity-set name "AuditLogEntries" lowercases to
+		// "auditlogentries" and contains the substring "audit". A naive
+		// keyword check that accepted the bare token "audit" would
+		// misclassify these benign filter-rejection bodies as disabled
+		// and suppress the required client-side fallback. Both must
+		// return false.
+		{"filter rejection body mentions entity-set name", fmt.Errorf("HTTP 400: $filter is not supported for AuditLogEntries"), false},
+		{"orderby rejection body mentions entity-set name", fmt.Errorf("HTTP 501: AuditLogEntries: $orderby not supported"), false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -869,6 +877,48 @@ func TestRunLogsAudit_FilterFallbackOnHTTP400(t *testing.T) {
 	}
 	if strings.Contains(out.Stdout, "Process") {
 		t.Errorf("stdout should NOT contain Process after client-filter, got:\n%s", out.Stdout)
+	}
+}
+
+// Regression for #80 review feedback: a filter-rejection body that echoes
+// the entity-set name "AuditLogEntries" must NOT be misclassified as a
+// disabled-audit error. The client must fall back to client-side filtering
+// (request count == 2, fallback warning emitted, no AuditLog=T error).
+func TestRunLogsAudit_FilterRejectionMentioningEntityNameStillFallsBack(t *testing.T) {
+	resetCmdFlags(t)
+	logsAuditObjectType = "Cube"
+
+	var requestCount int32
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&requestCount, 1)
+		w.Header().Set("Content-Type", "application/json")
+		if n == 1 {
+			w.WriteHeader(http.StatusBadRequest)
+			fmt.Fprint(w, `{"error":"$filter is not supported for AuditLogEntries"}`)
+			return
+		}
+		w.Write(auditLogJSON(
+			model.AuditLogEntry{ID: "1", TimeStamp: "2026-04-25T10:00:00Z", User: "alice", ObjectType: "Cube", ObjectName: "Sales", Description: "Created"},
+		))
+	})
+
+	out := captureAll(t, func() {
+		if err := runLogsAudit(logsAuditCmd, nil); err != nil {
+			t.Fatalf("unexpected: %v", err)
+		}
+	})
+
+	if got := atomic.LoadInt32(&requestCount); got != 2 {
+		t.Errorf("expected exactly 2 requests (initial + fallback), got %d", got)
+	}
+	if !strings.Contains(out.Stderr, "[warn] Server-side filter not supported") {
+		t.Errorf("stderr should print fallback warning, got: %q", out.Stderr)
+	}
+	if strings.Contains(out.Stderr, "AuditLog=T") {
+		t.Errorf("filter-rejection body must NOT trigger the disabled-audit error, got: %q", out.Stderr)
+	}
+	if !strings.Contains(out.Stdout, "Cube") {
+		t.Errorf("stdout should contain the Cube row, got:\n%s", out.Stdout)
 	}
 }
 

--- a/cmd/logs_audit_test.go
+++ b/cmd/logs_audit_test.go
@@ -1,0 +1,1225 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+	"tm1cli/internal/model"
+)
+
+// ============================================================
+// Unit tests — buildAuditFilter
+// ============================================================
+
+func TestBuildAuditFilter(t *testing.T) {
+	tests := []struct {
+		name       string
+		sinceTS    string
+		untilTS    string
+		objectType string
+		objectName string
+		user       string
+		want       string
+	}{
+		{"empty", "", "", "", "", "", ""},
+		{"since only", "2026-04-25T10:00:00Z", "", "", "", "", "TimeStamp ge 2026-04-25T10:00:00Z"},
+		{"until only", "", "2026-04-25T18:00:00Z", "", "", "", "TimeStamp le 2026-04-25T18:00:00Z"},
+		{"both times", "2026-04-25T10:00:00Z", "2026-04-25T18:00:00Z", "", "", "",
+			"TimeStamp ge 2026-04-25T10:00:00Z and TimeStamp le 2026-04-25T18:00:00Z"},
+		{"object-type only", "", "", "Cube", "", "", "ObjectType eq 'Cube'"},
+		{"object-name only", "", "", "", "Sales", "", "ObjectName eq 'Sales'"},
+		{"user only", "", "", "", "", "admin", "User eq 'admin'"},
+		{"object-type and object-name", "", "", "Cube", "Sales", "", "ObjectType eq 'Cube' and ObjectName eq 'Sales'"},
+		{"object-name and user", "", "", "", "ImportSales", "admin", "ObjectName eq 'ImportSales' and User eq 'admin'"},
+		{"all five", "2026-04-25T10:00:00Z", "2026-04-25T18:00:00Z", "Process", "ImportSales", "admin",
+			"TimeStamp ge 2026-04-25T10:00:00Z and TimeStamp le 2026-04-25T18:00:00Z and ObjectType eq 'Process' and ObjectName eq 'ImportSales' and User eq 'admin'"},
+		{"object-type with embedded quote", "", "", "O'Brien", "", "", "ObjectType eq 'O''Brien'"},
+		{"object-name with embedded quote", "", "", "", "O'Brien", "", "ObjectName eq 'O''Brien'"},
+		{"user with embedded quote", "", "", "", "", "O'Brien", "User eq 'O''Brien'"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildAuditFilter(tt.sinceTS, tt.untilTS, tt.objectType, tt.objectName, tt.user)
+			if got != tt.want {
+				t.Errorf("buildAuditFilter() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// ============================================================
+// Unit tests — buildAuditQuery
+// ============================================================
+
+func TestBuildAuditQuery_NoParamsBare(t *testing.T) {
+	got := buildAuditQuery("", 0, "")
+	if got != "AuditLogEntries" {
+		t.Errorf("got %q, want AuditLogEntries", got)
+	}
+}
+
+func TestBuildAuditQuery_FilterTopOrderDesc(t *testing.T) {
+	got := buildAuditQuery("ObjectType eq 'Cube'", 50, orderTimeStampDesc)
+	decoded, err := decodedQuery(strings.TrimPrefix(got, "AuditLogEntries?"))
+	if err != nil {
+		t.Fatalf("cannot decode: %v", err)
+	}
+	for _, want := range []string{"$filter=ObjectType eq 'Cube'", "$top=50", "$orderby=TimeStamp desc"} {
+		if !strings.Contains(decoded, want) {
+			t.Errorf("query %q missing %q", decoded, want)
+		}
+	}
+}
+
+func TestBuildAuditQuery_AscFromBuilder(t *testing.T) {
+	got := buildAuditQuery("", 100, orderTimeStampAsc)
+	decoded, _ := decodedQuery(strings.TrimPrefix(got, "AuditLogEntries?"))
+	if !strings.Contains(decoded, "$orderby=TimeStamp asc") {
+		t.Errorf("query %q should request asc, got %q", got, decoded)
+	}
+}
+
+func TestBuildAuditQuery_TopZeroOmitsTop(t *testing.T) {
+	got := buildAuditQuery("ObjectType eq 'Cube'", 0, orderTimeStampDesc)
+	if strings.Contains(got, "$top=") {
+		t.Errorf("query %q should not contain $top", got)
+	}
+}
+
+func TestBuildAuditQuery_EmptyOrderByOmitsOrderby(t *testing.T) {
+	got := buildAuditQuery("ObjectType eq 'Cube'", 10, "")
+	if strings.Contains(got, "$orderby") {
+		t.Errorf("query %q should not contain $orderby", got)
+	}
+}
+
+// ============================================================
+// Unit tests — applyAuditClientFilters
+// ============================================================
+
+func TestApplyAuditClientFilters(t *testing.T) {
+	entries := []model.AuditLogEntry{
+		{ID: "1", TimeStamp: "2026-04-25T10:00:00Z", User: "alice", ObjectType: "Cube", ObjectName: "Sales"},
+		{ID: "2", TimeStamp: "2026-04-25T11:00:00Z", User: "bob", ObjectType: "Process", ObjectName: "ImportSales"},
+		{ID: "3", TimeStamp: "2026-04-25T12:00:00Z", User: "alice", ObjectType: "Cube", ObjectName: "Sales"},
+	}
+
+	t.Run("since drops older", func(t *testing.T) {
+		got := applyAuditClientFilters(entries, "2026-04-25T10:30:00Z", "", "", "", "")
+		if len(got) != 2 {
+			t.Fatalf("got %d, want 2", len(got))
+		}
+		if got[0].ID != "2" || got[1].ID != "3" {
+			t.Errorf("got IDs %s,%s; want 2,3", got[0].ID, got[1].ID)
+		}
+	})
+
+	t.Run("until drops newer", func(t *testing.T) {
+		got := applyAuditClientFilters(entries, "", "2026-04-25T11:30:00Z", "", "", "")
+		if len(got) != 2 {
+			t.Fatalf("got %d, want 2", len(got))
+		}
+		if got[0].ID != "1" || got[1].ID != "2" {
+			t.Errorf("got IDs %s,%s; want 1,2", got[0].ID, got[1].ID)
+		}
+	})
+
+	t.Run("object-type exact-match case-sensitive", func(t *testing.T) {
+		got := applyAuditClientFilters(entries, "", "", "Cube", "", "")
+		if len(got) != 2 {
+			t.Errorf("Cube should match 2, got %d", len(got))
+		}
+		gotMixed := applyAuditClientFilters(entries, "", "", "cube", "", "")
+		if len(gotMixed) != 0 {
+			t.Errorf("lowercase 'cube' should NOT match 'Cube' (case-sensitive), got %d", len(gotMixed))
+		}
+	})
+
+	t.Run("object-name exact-match case-sensitive", func(t *testing.T) {
+		got := applyAuditClientFilters(entries, "", "", "", "Sales", "")
+		if len(got) != 2 {
+			t.Errorf("Sales should match 2, got %d", len(got))
+		}
+		gotMixed := applyAuditClientFilters(entries, "", "", "", "sales", "")
+		if len(gotMixed) != 0 {
+			t.Errorf("lowercase 'sales' should NOT match 'Sales', got %d", len(gotMixed))
+		}
+	})
+
+	t.Run("user exact-match case-sensitive", func(t *testing.T) {
+		got := applyAuditClientFilters(entries, "", "", "", "", "alice")
+		if len(got) != 2 {
+			t.Errorf("alice should match 2, got %d", len(got))
+		}
+		gotMixed := applyAuditClientFilters(entries, "", "", "", "", "Alice")
+		if len(gotMixed) != 0 {
+			t.Errorf("'Alice' should NOT match 'alice', got %d", len(gotMixed))
+		}
+	})
+
+	t.Run("combined", func(t *testing.T) {
+		got := applyAuditClientFilters(entries, "2026-04-25T10:30:00Z", "2026-04-25T11:30:00Z", "Process", "ImportSales", "bob")
+		if len(got) != 1 || got[0].ID != "2" {
+			t.Errorf("expected only ID=2, got %+v", got)
+		}
+	})
+
+	t.Run("unparseable timestamp dropped on time filter", func(t *testing.T) {
+		bad := []model.AuditLogEntry{{ID: "99", TimeStamp: "not-a-time"}}
+		got := applyAuditClientFilters(bad, "2026-04-25T10:00:00Z", "", "", "", "")
+		if len(got) != 0 {
+			t.Errorf("unparseable should be dropped when since is set, got %+v", got)
+		}
+	})
+}
+
+// ============================================================
+// Unit tests — sortAuditByTimeStamp
+// ============================================================
+
+func TestSortAuditByTimeStamp(t *testing.T) {
+	t.Run("ascending order", func(t *testing.T) {
+		entries := []model.AuditLogEntry{
+			{ID: "3", TimeStamp: "2026-04-25T12:00:00Z"},
+			{ID: "1", TimeStamp: "2026-04-25T10:00:00Z"},
+			{ID: "2", TimeStamp: "2026-04-25T11:00:00Z"},
+		}
+		sortAuditByTimeStamp(entries)
+		for i, want := range []string{"1", "2", "3"} {
+			if entries[i].ID != want {
+				t.Errorf("entries[%d].ID = %s, want %s", i, entries[i].ID, want)
+			}
+		}
+	})
+
+	t.Run("tie-break by ID", func(t *testing.T) {
+		entries := []model.AuditLogEntry{
+			{ID: "c", TimeStamp: "2026-04-25T10:00:00Z"},
+			{ID: "a", TimeStamp: "2026-04-25T10:00:00Z"},
+			{ID: "b", TimeStamp: "2026-04-25T10:00:00Z"},
+		}
+		sortAuditByTimeStamp(entries)
+		for i, want := range []string{"a", "b", "c"} {
+			if entries[i].ID != want {
+				t.Errorf("entries[%d].ID = %s, want %s", i, entries[i].ID, want)
+			}
+		}
+	})
+}
+
+// ============================================================
+// Unit tests — sortAuditByTimeStampDesc
+// ============================================================
+
+func TestSortAuditByTimeStampDesc(t *testing.T) {
+	t.Run("descending order", func(t *testing.T) {
+		entries := []model.AuditLogEntry{
+			{ID: "1", TimeStamp: "2026-04-25T10:00:00Z"},
+			{ID: "3", TimeStamp: "2026-04-25T12:00:00Z"},
+			{ID: "2", TimeStamp: "2026-04-25T11:00:00Z"},
+		}
+		sortAuditByTimeStampDesc(entries)
+		for i, want := range []string{"3", "2", "1"} {
+			if entries[i].ID != want {
+				t.Errorf("entries[%d].ID = %s, want %s", i, entries[i].ID, want)
+			}
+		}
+	})
+
+	t.Run("tie-break by ID descending", func(t *testing.T) {
+		entries := []model.AuditLogEntry{
+			{ID: "a", TimeStamp: "2026-04-25T10:00:00Z"},
+			{ID: "c", TimeStamp: "2026-04-25T10:00:00Z"},
+			{ID: "b", TimeStamp: "2026-04-25T10:00:00Z"},
+		}
+		sortAuditByTimeStampDesc(entries)
+		for i, want := range []string{"c", "b", "a"} {
+			if entries[i].ID != want {
+				t.Errorf("entries[%d].ID = %s, want %s", i, entries[i].ID, want)
+			}
+		}
+	})
+
+	t.Run("mixed-precision ordering matches chronology", func(t *testing.T) {
+		entries := []model.AuditLogEntry{
+			{ID: "1", TimeStamp: "2026-04-25T10:00:00Z"},
+			{ID: "2", TimeStamp: "2026-04-25T10:00:00.5Z"},
+			{ID: "3", TimeStamp: "2026-04-25T10:00:00.250Z"},
+		}
+		sortAuditByTimeStampDesc(entries)
+		for i, want := range []string{"2", "3", "1"} {
+			if entries[i].ID != want {
+				t.Errorf("entries[%d].ID = %s, want %s (chronological order)", i, entries[i].ID, want)
+			}
+		}
+	})
+}
+
+// ============================================================
+// Unit tests — reverseAuditEntries
+// ============================================================
+
+func TestReverseAuditEntries(t *testing.T) {
+	entries := []model.AuditLogEntry{
+		{ID: "1"}, {ID: "2"}, {ID: "3"},
+	}
+	reverseAuditEntries(entries)
+	for i, want := range []string{"3", "2", "1"} {
+		if entries[i].ID != want {
+			t.Errorf("entries[%d].ID = %s, want %s", i, entries[i].ID, want)
+		}
+	}
+}
+
+// ============================================================
+// Unit tests — boundaryAuditIDs
+// ============================================================
+
+func TestBoundaryAuditIDs(t *testing.T) {
+	t.Run("empty input", func(t *testing.T) {
+		ts, ids := boundaryAuditIDs(nil)
+		if ts != "" || ids != nil {
+			t.Errorf("got (%q, %v), want (\"\", nil)", ts, ids)
+		}
+	})
+
+	t.Run("single entry", func(t *testing.T) {
+		entries := []model.AuditLogEntry{
+			{ID: "abc", TimeStamp: "2026-04-25T12:00:00Z"},
+		}
+		ts, ids := boundaryAuditIDs(entries)
+		if ts != "2026-04-25T12:00:00Z" {
+			t.Errorf("ts = %q", ts)
+		}
+		if _, ok := ids["abc"]; !ok {
+			t.Errorf("ids should contain 'abc', got %v", ids)
+		}
+	})
+
+	t.Run("two boundary entries with same TS", func(t *testing.T) {
+		entries := []model.AuditLogEntry{
+			{ID: "x", TimeStamp: "2026-04-25T10:00:00Z"},
+			{ID: "y", TimeStamp: "2026-04-25T12:00:00Z"},
+			{ID: "z", TimeStamp: "2026-04-25T12:00:00Z"},
+		}
+		ts, ids := boundaryAuditIDs(entries)
+		if ts != "2026-04-25T12:00:00Z" {
+			t.Errorf("ts = %q", ts)
+		}
+		if len(ids) != 2 {
+			t.Errorf("expected 2 boundary IDs, got %d (%v)", len(ids), ids)
+		}
+		for _, want := range []string{"y", "z"} {
+			if _, ok := ids[want]; !ok {
+				t.Errorf("ids missing %q: %v", want, ids)
+			}
+		}
+	})
+
+	t.Run("ID-less entries get synthetic dedupe key", func(t *testing.T) {
+		entries := []model.AuditLogEntry{
+			{ID: "", TimeStamp: "2026-04-25T12:00:00Z", User: "u", ObjectType: "Cube", ObjectName: "Sales", Description: "Created"},
+			{ID: "abc", TimeStamp: "2026-04-25T12:00:00Z"},
+		}
+		ts, ids := boundaryAuditIDs(entries)
+		if ts != "2026-04-25T12:00:00Z" {
+			t.Errorf("ts = %q", ts)
+		}
+		if len(ids) != 2 {
+			t.Errorf("both boundary entries should be in dedupe set; got %d: %v", len(ids), ids)
+		}
+		if _, ok := ids["abc"]; !ok {
+			t.Errorf("explicit ID should appear as-is, got %v", ids)
+		}
+	})
+}
+
+// ============================================================
+// Unit tests — auditIDKey
+// ============================================================
+
+func TestAuditIDKey(t *testing.T) {
+	t.Run("uses ID when non-empty", func(t *testing.T) {
+		e := model.AuditLogEntry{ID: "some-uuid"}
+		if got := auditIDKey(e); got != "some-uuid" {
+			t.Errorf("auditIDKey(ID=some-uuid) = %q, want some-uuid", got)
+		}
+	})
+
+	t.Run("synthesizes key when ID empty", func(t *testing.T) {
+		e := model.AuditLogEntry{ID: "", TimeStamp: "2026-04-25T10:00:00Z", User: "u", ObjectType: "Cube", ObjectName: "Sales"}
+		got := auditIDKey(e)
+		if got == "" {
+			t.Errorf("auditIDKey for ID='' must synthesize a non-empty key")
+		}
+		if !strings.HasPrefix(got, "syn") {
+			t.Errorf("synthetic key should be prefixed to avoid colliding with real IDs, got %q", got)
+		}
+	})
+
+	t.Run("distinct same-TS entries get distinct synth keys", func(t *testing.T) {
+		ts := "2026-04-25T10:00:00Z"
+		a := model.AuditLogEntry{ID: "", TimeStamp: ts, User: "u", ObjectType: "Cube", ObjectName: "SalesA"}
+		b := model.AuditLogEntry{ID: "", TimeStamp: ts, User: "u", ObjectType: "Cube", ObjectName: "SalesB"}
+		if auditIDKey(a) == auditIDKey(b) {
+			t.Errorf("distinct same-timestamp entries must produce distinct synth keys")
+		}
+	})
+
+	t.Run("identical entries get identical synth keys", func(t *testing.T) {
+		ts := "2026-04-25T10:00:00Z"
+		a := model.AuditLogEntry{ID: "", TimeStamp: ts, User: "u", ObjectType: "Cube", ObjectName: "Sales"}
+		b := model.AuditLogEntry{ID: "", TimeStamp: ts, User: "u", ObjectType: "Cube", ObjectName: "Sales"}
+		if auditIDKey(a) != auditIDKey(b) {
+			t.Errorf("identical entries must produce identical synth keys")
+		}
+	})
+}
+
+// ============================================================
+// Unit tests — isAuditLogDisabled
+// ============================================================
+
+func TestIsAuditLogDisabled(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil error", nil, false},
+		{"HTTP 400 disabled", fmt.Errorf("HTTP 400: Audit log is disabled."), true},
+		{"HTTP 400 not enabled", fmt.Errorf("HTTP 400: Audit log feature is not enabled"), true},
+		{"HTTP 501 not supported", fmt.Errorf("HTTP 501: auditing not supported"), true},
+		{"HTTP 501 not available", fmt.Errorf("HTTP 501: audit log not available on this server"), true},
+		{"HTTP 401 auth failed", fmt.Errorf("HTTP 401: Authentication failed."), false},
+		{"HTTP 403 forbidden", fmt.Errorf("HTTP 403: Forbidden"), false},
+		{"HTTP 404 not found", fmt.Errorf("HTTP 404: Not found"), false},
+		{"HTTP 400 filter not supported (no audit keyword)", fmt.Errorf("HTTP 400: filter not supported"), false},
+		{"connection timeout (no audit keyword)", fmt.Errorf("Connection error: timeout"), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isAuditLogDisabled(tt.err); got != tt.want {
+				t.Errorf("isAuditLogDisabled(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+// ============================================================
+// Unit tests — AuditLogEntry JSON round-trip
+// ============================================================
+
+func TestRunLogsAudit_AuditLogEntryRoundTrip(t *testing.T) {
+	body := []byte(`{
+		"value": [
+			{"ID":"uuid-abc","TimeStamp":"2026-04-25T10:00:00Z","User":"alice","ObjectType":"Cube","ObjectName":"Sales","Description":"Created","AuditDetails":"some detail"},
+			{"TimeStamp":"2026-04-25T10:01:00Z","User":"bob","ObjectType":"Process","ObjectName":"ImportSales","Description":"Updated"}
+		]
+	}`)
+
+	var resp model.AuditLogResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+	if len(resp.Value) != 2 {
+		t.Fatalf("got %d entries, want 2", len(resp.Value))
+	}
+
+	e0 := resp.Value[0]
+	if e0.ID != "uuid-abc" {
+		t.Errorf("ID = %q, want uuid-abc", e0.ID)
+	}
+	if e0.AuditDetails != "some detail" {
+		t.Errorf("AuditDetails = %q, want 'some detail'", e0.AuditDetails)
+	}
+
+	e1 := resp.Value[1]
+	if e1.ID != "" {
+		t.Errorf("missing ID should unmarshal to empty string, got %q", e1.ID)
+	}
+	if e1.User != "bob" || e1.ObjectType != "Process" {
+		t.Errorf("unexpected fields: User=%q ObjectType=%q", e1.User, e1.ObjectType)
+	}
+}
+
+// ============================================================
+// Integration tests — flag validation
+// ============================================================
+
+func TestRunLogsAudit_NegativeTailRejected(t *testing.T) {
+	resetCmdFlags(t)
+	logsAuditTail = -1
+
+	var requestCount int32
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&requestCount, 1)
+		w.Write(auditLogJSON())
+	})
+
+	out := captureAll(t, func() {
+		err := runLogsAudit(logsAuditCmd, nil)
+		if err != errSilent {
+			t.Fatalf("expected errSilent, got: %v", err)
+		}
+	})
+	if !strings.Contains(out.Stderr, "--tail must be non-negative") {
+		t.Errorf("stderr should reject negative --tail, got: %q", out.Stderr)
+	}
+	if got := atomic.LoadInt32(&requestCount); got != 0 {
+		t.Errorf("expected 0 HTTP requests, got %d", got)
+	}
+}
+
+func TestRunLogsAudit_ZeroIntervalWithFollowRejected(t *testing.T) {
+	resetCmdFlags(t)
+	logsAuditFollow = true
+	logsAuditInterval = 0
+
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Write(auditLogJSON())
+	})
+	out := captureAll(t, func() {
+		err := runLogsAudit(logsAuditCmd, nil)
+		if err != errSilent {
+			t.Fatalf("expected errSilent, got: %v", err)
+		}
+	})
+	if !strings.Contains(out.Stderr, "--interval must be greater than zero") {
+		t.Errorf("stderr should reject zero --interval, got: %q", out.Stderr)
+	}
+}
+
+func TestRunLogsAudit_NegativeIntervalWithFollowRejected(t *testing.T) {
+	resetCmdFlags(t)
+	logsAuditFollow = true
+	logsAuditInterval = -5 * time.Second
+
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Write(auditLogJSON())
+	})
+	out := captureAll(t, func() {
+		err := runLogsAudit(logsAuditCmd, nil)
+		if err != errSilent {
+			t.Fatalf("expected errSilent, got: %v", err)
+		}
+	})
+	if !strings.Contains(out.Stderr, "--interval must be greater than zero") {
+		t.Errorf("stderr should reject negative --interval, got: %q", out.Stderr)
+	}
+}
+
+func TestRunLogsAudit_UntilWithFollowRejected(t *testing.T) {
+	resetCmdFlags(t)
+	logsAuditFollow = true
+	logsAuditUntil = "1h"
+
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("should not make HTTP request")
+	})
+	out := captureAll(t, func() {
+		err := runLogsAudit(logsAuditCmd, nil)
+		if err != errSilent {
+			t.Fatalf("expected errSilent, got: %v", err)
+		}
+	})
+	if !strings.Contains(out.Stderr, "--until cannot be combined with --follow") {
+		t.Errorf("stderr should reject --until + --follow, got: %q", out.Stderr)
+	}
+}
+
+func TestRunLogsAudit_SinceAfterUntilRejected(t *testing.T) {
+	resetCmdFlags(t)
+	logsAuditSince = "2026-04-25T18:00:00Z"
+	logsAuditUntil = "2026-04-25T10:00:00Z"
+
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("should not make HTTP request")
+	})
+	out := captureAll(t, func() {
+		err := runLogsAudit(logsAuditCmd, nil)
+		if err != errSilent {
+			t.Fatalf("expected errSilent, got: %v", err)
+		}
+	})
+	if !strings.Contains(out.Stderr, "--since must be earlier than --until") {
+		t.Errorf("stderr should reject since>until, got: %q", out.Stderr)
+	}
+}
+
+func TestRunLogsAudit_InvalidSince(t *testing.T) {
+	resetCmdFlags(t)
+	logsAuditSince = "not-a-time"
+
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("should not make HTTP request")
+	})
+	out := captureAll(t, func() {
+		err := runLogsAudit(logsAuditCmd, nil)
+		if err != errSilent {
+			t.Fatalf("expected errSilent, got: %v", err)
+		}
+	})
+	if !strings.Contains(out.Stderr, "--since") {
+		t.Errorf("stderr should mention --since, got: %q", out.Stderr)
+	}
+}
+
+func TestRunLogsAudit_InvalidUntil(t *testing.T) {
+	resetCmdFlags(t)
+	logsAuditUntil = "garbage"
+
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("should not make HTTP request")
+	})
+	out := captureAll(t, func() {
+		err := runLogsAudit(logsAuditCmd, nil)
+		if err != errSilent {
+			t.Fatalf("expected errSilent, got: %v", err)
+		}
+	})
+	if !strings.Contains(out.Stderr, "--until") {
+		t.Errorf("stderr should mention --until, got: %q", out.Stderr)
+	}
+	if strings.Contains(out.Stderr, "--since") {
+		t.Errorf("stderr should NOT mention --since for --until error, got: %q", out.Stderr)
+	}
+}
+
+func TestRunLogsAudit_RawWithJSONRejected(t *testing.T) {
+	resetCmdFlags(t)
+	logsAuditRaw = true
+	flagOutput = "json"
+
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("should not make any HTTP request")
+	})
+	out := captureAll(t, func() {
+		err := runLogsAudit(logsAuditCmd, nil)
+		if err != errSilent {
+			t.Fatalf("expected errSilent, got: %v", err)
+		}
+	})
+	if !strings.Contains(out.Stderr, "--raw cannot be combined with --output json") {
+		t.Errorf("stderr should contain conflict, got: %q", out.Stderr)
+	}
+}
+
+// ============================================================
+// Integration tests — output formats
+// ============================================================
+
+func TestRunLogsAudit_TableOutput(t *testing.T) {
+	resetCmdFlags(t)
+
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(auditLogJSON(
+			model.AuditLogEntry{
+				ID: "uuid-1", TimeStamp: "2026-04-25T10:00:00Z", User: "alice",
+				ObjectType: "Cube", ObjectName: "Sales", Description: "Created",
+			},
+		))
+	})
+
+	out := captureAll(t, func() {
+		if err := runLogsAudit(logsAuditCmd, nil); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	for _, header := range []string{"TIME", "USER", "OBJECT_TYPE", "OBJECT_NAME", "DESCRIPTION"} {
+		if !strings.Contains(out.Stdout, header) {
+			t.Errorf("stdout missing header %q", header)
+		}
+	}
+	for _, want := range []string{"alice", "Cube", "Sales", "Created"} {
+		if !strings.Contains(out.Stdout, want) {
+			t.Errorf("stdout missing %q\noutput:\n%s", want, out.Stdout)
+		}
+	}
+}
+
+func TestRunLogsAudit_JSONOutput(t *testing.T) {
+	resetCmdFlags(t)
+	flagOutput = "json"
+
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(auditLogJSON(
+			model.AuditLogEntry{
+				ID: "uuid-1", TimeStamp: "2026-04-25T10:00:00Z", User: "alice",
+				ObjectType: "Cube", ObjectName: "Sales", Description: "Created",
+			},
+		))
+	})
+
+	out := captureAll(t, func() {
+		if err := runLogsAudit(logsAuditCmd, nil); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	var got []model.AuditLogEntry
+	if err := json.Unmarshal([]byte(out.Stdout), &got); err != nil {
+		t.Fatalf("stdout is not valid JSON array: %v\noutput: %s", err, out.Stdout)
+	}
+	if len(got) != 1 {
+		t.Fatalf("got %d entries, want 1", len(got))
+	}
+	if got[0].User != "alice" || got[0].ObjectType != "Cube" {
+		t.Errorf("got %+v, want alice/Cube", got[0])
+	}
+}
+
+func TestRunLogsAudit_RawOutput(t *testing.T) {
+	resetCmdFlags(t)
+	logsAuditRaw = true
+
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(auditLogJSON(
+			model.AuditLogEntry{
+				ID: "uuid-1", TimeStamp: "2026-04-25T10:00:00Z", User: "alice",
+				ObjectType: "Cube", ObjectName: "Sales", Description: "Created",
+			},
+		))
+	})
+
+	out := captureAll(t, func() {
+		if err := runLogsAudit(logsAuditCmd, nil); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	lines := strings.Split(strings.TrimRight(out.Stdout, "\n"), "\n")
+	if len(lines) != 1 {
+		t.Fatalf("expected 1 raw line, got %d:\n%s", len(lines), out.Stdout)
+	}
+	for _, want := range []string{"alice", "Cube", "Sales", "Created"} {
+		if !strings.Contains(lines[0], want) {
+			t.Errorf("raw line missing %q: %q", want, lines[0])
+		}
+	}
+}
+
+func TestRunLogsAudit_RawSanitizesAllFields(t *testing.T) {
+	resetCmdFlags(t)
+	logsAuditRaw = true
+
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(auditLogJSON(
+			model.AuditLogEntry{
+				ID:          "uuid-1",
+				TimeStamp:   "2026-04-25T10:00:00Z",
+				User:        "ali\nce",
+				ObjectType:  "Cu\rbe",
+				ObjectName:  "Sa\tles",
+				Description: "Cre\nated",
+			},
+		))
+	})
+
+	out := captureAll(t, func() {
+		if err := runLogsAudit(logsAuditCmd, nil); err != nil {
+			t.Fatalf("unexpected: %v", err)
+		}
+	})
+	lines := strings.Split(strings.TrimRight(out.Stdout, "\n"), "\n")
+	if len(lines) != 1 {
+		t.Errorf("expected 1 line after sanitization, got %d:\n%s", len(lines), out.Stdout)
+	}
+}
+
+// ============================================================
+// Integration tests — defaults / ordering
+// ============================================================
+
+func TestRunLogsAudit_DefaultsToTail100(t *testing.T) {
+	resetCmdFlags(t)
+
+	var capturedQuery string
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		capturedQuery = r.URL.RawQuery
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(auditLogJSON())
+	})
+
+	captureAll(t, func() {
+		if err := runLogsAudit(logsAuditCmd, nil); err != nil {
+			t.Fatalf("unexpected: %v", err)
+		}
+	})
+
+	decoded, err := decodedQuery(capturedQuery)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !strings.Contains(decoded, "$top=100") {
+		t.Errorf("query %q should contain $top=100", decoded)
+	}
+	if !strings.Contains(decoded, "$orderby=TimeStamp desc") {
+		t.Errorf("query %q should contain $orderby=TimeStamp desc", decoded)
+	}
+}
+
+func TestRunLogsAudit_ServerSideFilterReachesServer(t *testing.T) {
+	resetCmdFlags(t)
+	logsAuditObjectType = "Cube"
+	logsAuditObjectName = "ImportSales"
+	logsAuditUser = "admin"
+	logsAuditSince = "1h"
+
+	var capturedQuery string
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		capturedQuery = r.URL.RawQuery
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(auditLogJSON())
+	})
+
+	captureAll(t, func() {
+		if err := runLogsAudit(logsAuditCmd, nil); err != nil {
+			t.Fatalf("unexpected: %v", err)
+		}
+	})
+
+	decoded, _ := decodedQuery(capturedQuery)
+	for _, want := range []string{
+		"TimeStamp ge ",
+		"ObjectType eq 'Cube'",
+		"ObjectName eq 'ImportSales'",
+		"User eq 'admin'",
+	} {
+		if !strings.Contains(decoded, want) {
+			t.Errorf("query %q missing %q", decoded, want)
+		}
+	}
+}
+
+func TestRunLogsAudit_TailOrdering(t *testing.T) {
+	resetCmdFlags(t)
+	logsAuditTail = 2
+
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		// Server returns DESC order — newest first
+		w.Write(auditLogJSON(
+			model.AuditLogEntry{ID: "2", TimeStamp: "2026-04-25T11:00:00Z", User: "bob", ObjectType: "Cube", ObjectName: "Sales", Description: "Updated"},
+			model.AuditLogEntry{ID: "1", TimeStamp: "2026-04-25T10:00:00Z", User: "alice", ObjectType: "Cube", ObjectName: "Sales", Description: "Created"},
+		))
+	})
+
+	out := captureAll(t, func() {
+		if err := runLogsAudit(logsAuditCmd, nil); err != nil {
+			t.Fatalf("unexpected: %v", err)
+		}
+	})
+
+	idxAlice := strings.Index(out.Stdout, "alice")
+	idxBob := strings.Index(out.Stdout, "bob")
+	if idxAlice < 0 || idxBob < 0 {
+		t.Fatalf("missing rows, output:\n%s", out.Stdout)
+	}
+	if idxAlice > idxBob {
+		t.Errorf("expected ASC after reverse: alice (older) before bob (newer); got bob first")
+	}
+}
+
+// ============================================================
+// Integration tests — fallback behavior
+// ============================================================
+
+func TestRunLogsAudit_FilterFallbackOnHTTP400(t *testing.T) {
+	resetCmdFlags(t)
+	logsAuditObjectType = "Cube"
+
+	var requestCount int32
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&requestCount, 1)
+		w.Header().Set("Content-Type", "application/json")
+		if n == 1 {
+			w.WriteHeader(http.StatusBadRequest)
+			fmt.Fprint(w, `{"error":"$filter not supported"}`)
+			return
+		}
+		// Second call: no $filter — return mixed types; client should drop non-Cube.
+		w.Write(auditLogJSON(
+			model.AuditLogEntry{ID: "1", TimeStamp: "2026-04-25T10:00:00Z", User: "alice", ObjectType: "Cube", ObjectName: "Sales", Description: "Created"},
+			model.AuditLogEntry{ID: "2", TimeStamp: "2026-04-25T10:01:00Z", User: "bob", ObjectType: "Process", ObjectName: "Import", Description: "Updated"},
+		))
+	})
+
+	out := captureAll(t, func() {
+		if err := runLogsAudit(logsAuditCmd, nil); err != nil {
+			t.Fatalf("unexpected: %v", err)
+		}
+	})
+
+	if !strings.Contains(out.Stderr, "[warn] Server-side filter not supported") {
+		t.Errorf("stderr should print fallback warning, got: %q", out.Stderr)
+	}
+	if !strings.Contains(out.Stdout, "Cube") {
+		t.Errorf("stdout should contain Cube row, got:\n%s", out.Stdout)
+	}
+	if strings.Contains(out.Stdout, "Process") {
+		t.Errorf("stdout should NOT contain Process after client-filter, got:\n%s", out.Stdout)
+	}
+}
+
+func TestRunLogsAudit_FallbackUntilOnlyRetriesAsc(t *testing.T) {
+	resetCmdFlags(t)
+	logsAuditUntil = "2030-01-01T00:00:00Z"
+
+	var capturedRetryQuery string
+	var requestCount int32
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&requestCount, 1)
+		w.Header().Set("Content-Type", "application/json")
+		if n == 1 {
+			w.WriteHeader(http.StatusBadRequest)
+			fmt.Fprint(w, `{"error":"$filter not supported"}`)
+			return
+		}
+		capturedRetryQuery = r.URL.RawQuery
+		w.Write(auditLogJSON())
+	})
+
+	out := captureAll(t, func() {
+		if err := runLogsAudit(logsAuditCmd, nil); err != nil {
+			t.Fatalf("unexpected: %v", err)
+		}
+	})
+
+	decoded, _ := decodedQuery(capturedRetryQuery)
+	if !strings.Contains(decoded, "$orderby=TimeStamp asc") {
+		t.Errorf("retry for --until-only must explicitly request ASC; got %q", decoded)
+	}
+	if strings.Contains(decoded, "$orderby=TimeStamp desc") {
+		t.Errorf("retry for --until-only should not use DESC; got %q", decoded)
+	}
+	if !strings.Contains(out.Stderr, "--until cannot be enforced server-side") {
+		t.Errorf("stderr should warn that --until is unenforceable under fallback, got: %q", out.Stderr)
+	}
+}
+
+func TestRunLogsAudit_FallbackTrimToTail(t *testing.T) {
+	resetCmdFlags(t)
+	logsAuditTail = 3
+	logsAuditObjectType = "Cube"
+
+	const wantBuffered = 3 * fallbackTailMultiplier // 30
+
+	var capturedRetryQuery string
+	var requestCount int32
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&requestCount, 1)
+		w.Header().Set("Content-Type", "application/json")
+		if n == 1 {
+			w.WriteHeader(http.StatusBadRequest)
+			fmt.Fprint(w, `{"error":"$filter not supported"}`)
+			return
+		}
+		capturedRetryQuery = r.URL.RawQuery
+		// Return a mix: 7 Cube rows interleaved with Process rows. With buffer we
+		// should find them and trim to tail=3.
+		entries := make([]model.AuditLogEntry, 0, 40)
+		for i := 0; i < 40; i++ {
+			objType := "Process"
+			if i < 7 {
+				objType = "Cube"
+			}
+			entries = append(entries, model.AuditLogEntry{
+				ID:          fmt.Sprintf("%d", i+1),
+				TimeStamp:   time.Date(2026, 4, 25, 10, 0, i, 0, time.UTC).Format(time.RFC3339),
+				User:        "u",
+				ObjectType:  objType,
+				ObjectName:  "Sales",
+				Description: "Changed",
+			})
+		}
+		w.Write(auditLogJSON(entries...))
+	})
+
+	out := captureAll(t, func() {
+		if err := runLogsAudit(logsAuditCmd, nil); err != nil {
+			t.Fatalf("unexpected: %v", err)
+		}
+	})
+
+	decoded, _ := decodedQuery(capturedRetryQuery)
+	if !strings.Contains(decoded, fmt.Sprintf("$top=%d", wantBuffered)) {
+		t.Errorf("retry query %q should buffer $top to %d (=tail*multiplier)", decoded, wantBuffered)
+	}
+	// Only Cube rows should remain; at most --tail=3 after truncation.
+	if strings.Contains(out.Stdout, "Process") {
+		t.Errorf("stdout should not contain Process after client filter:\n%s", out.Stdout)
+	}
+	cubeCount := strings.Count(out.Stdout, "Cube")
+	if cubeCount != 3 {
+		t.Errorf("expected exactly 3 Cube rows after truncation, got %d:\n%s", cubeCount, out.Stdout)
+	}
+}
+
+// ============================================================
+// Integration tests — audit log disabled
+// ============================================================
+
+func TestRunLogsAudit_AuditLogDisabledFriendlyError(t *testing.T) {
+	resetCmdFlags(t)
+
+	var requestCount int32
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&requestCount, 1)
+		w.WriteHeader(http.StatusBadRequest)
+		fmt.Fprint(w, `{"error":{"message":"Audit log is disabled."}}`)
+	})
+
+	out := captureAll(t, func() {
+		err := runLogsAudit(logsAuditCmd, nil)
+		if err != errSilent {
+			t.Fatalf("expected errSilent, got: %v", err)
+		}
+	})
+
+	// No retry on disabled — exactly one request.
+	if got := atomic.LoadInt32(&requestCount); got != 1 {
+		t.Errorf("expected 1 HTTP request (no retry), got %d", got)
+	}
+	if !strings.Contains(out.Stderr, "AuditLog=T") {
+		t.Errorf("stderr should mention AuditLog=T, got: %q", out.Stderr)
+	}
+}
+
+func TestRunLogsAudit_AuditLogDisabledOnFallbackRetry(t *testing.T) {
+	resetCmdFlags(t)
+	logsAuditObjectType = "Cube"
+
+	var requestCount int32
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&requestCount, 1)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		if n == 1 {
+			// First 400: filter not supported → triggers fallback retry.
+			fmt.Fprint(w, `{"error":"$filter not supported"}`)
+		} else {
+			// Second 400: disabled error on the unfiltered retry.
+			fmt.Fprint(w, `{"error":{"message":"Audit log is disabled."}}`)
+		}
+	})
+
+	out := captureAll(t, func() {
+		err := runLogsAudit(logsAuditCmd, nil)
+		if err != errSilent {
+			t.Fatalf("expected errSilent, got: %v", err)
+		}
+	})
+
+	if got := atomic.LoadInt32(&requestCount); got != 2 {
+		t.Errorf("expected 2 HTTP requests (first filter rejection, second disabled), got %d", got)
+	}
+	if !strings.Contains(out.Stderr, "AuditLog=T") {
+		t.Errorf("stderr should contain friendly AuditLog=T message, got: %q", out.Stderr)
+	}
+}
+
+func TestRunLogsAudit_AuthErrorNotTreatedAsDisabled(t *testing.T) {
+	resetCmdFlags(t)
+	logsAuditObjectType = "Cube"
+
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		fmt.Fprint(w, `{"error":"Authentication failed."}`)
+	})
+
+	out := captureAll(t, func() {
+		err := runLogsAudit(logsAuditCmd, nil)
+		if err != errSilent {
+			t.Fatalf("expected errSilent, got: %v", err)
+		}
+	})
+
+	if strings.Contains(out.Stderr, "AuditLog=T") {
+		t.Errorf("auth error should NOT be treated as disabled, but got AuditLog=T in: %q", out.Stderr)
+	}
+	if !strings.Contains(out.Stderr, "Authentication failed") {
+		t.Errorf("stderr should mention auth failure, got: %q", out.Stderr)
+	}
+}
+
+func TestRunLogsAudit_NotFoundNotTreatedAsDisabled(t *testing.T) {
+	resetCmdFlags(t)
+
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		fmt.Fprint(w, `{"error":"audit log endpoint not found"}`)
+	})
+
+	out := captureAll(t, func() {
+		err := runLogsAudit(logsAuditCmd, nil)
+		if err != errSilent {
+			t.Fatalf("expected errSilent, got: %v", err)
+		}
+	})
+
+	if strings.Contains(out.Stderr, "AuditLog=T") {
+		t.Errorf("404 should NOT be treated as disabled, but got AuditLog=T in: %q", out.Stderr)
+	}
+}
+
+func TestRunLogsAudit_AuditLogDisabledJSONMode(t *testing.T) {
+	resetCmdFlags(t)
+	flagOutput = "json"
+
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		fmt.Fprint(w, `{"error":{"message":"Audit log is disabled."}}`)
+	})
+
+	out := captureAll(t, func() {
+		err := runLogsAudit(logsAuditCmd, nil)
+		if err != errSilent {
+			t.Fatalf("expected errSilent, got: %v", err)
+		}
+	})
+
+	// In JSON mode errors are emitted as JSON envelopes to stderr.
+	if !strings.Contains(out.Stderr, "Audit log is disabled") {
+		t.Errorf("JSON-mode error should contain disabled message, got: %q", out.Stderr)
+	}
+}
+
+// ============================================================
+// Integration tests — edge cases
+// ============================================================
+
+func TestRunLogsAudit_EmptyResponseNoCrash(t *testing.T) {
+	resetCmdFlags(t)
+
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(auditLogJSON())
+	})
+
+	out := captureAll(t, func() {
+		if err := runLogsAudit(logsAuditCmd, nil); err != nil {
+			t.Fatalf("unexpected: %v", err)
+		}
+	})
+	// Empty response should print headers (table still renders) but no data rows.
+	if !strings.Contains(out.Stdout, "TIME") {
+		t.Errorf("table headers should still print on empty response, got:\n%s", out.Stdout)
+	}
+}
+
+func TestRunLogsAudit_PaginationWarning(t *testing.T) {
+	resetCmdFlags(t)
+
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"value":[],"@odata.nextLink":"AuditLogEntries?$skiptoken=42"}`)
+	})
+
+	out := captureAll(t, func() {
+		if err := runLogsAudit(logsAuditCmd, nil); err != nil {
+			t.Fatalf("unexpected: %v", err)
+		}
+	})
+
+	if !strings.Contains(out.Stderr, "paginated") {
+		t.Errorf("stderr should warn about paginated response, got: %q", out.Stderr)
+	}
+}
+
+// ============================================================
+// Integration tests — follow mode
+// ============================================================
+
+func TestRunLogsAudit_FollowEmitsNDJSON(t *testing.T) {
+	resetCmdFlags(t)
+
+	entries := []model.AuditLogEntry{
+		{ID: "1", TimeStamp: "2026-04-25T10:00:00Z", User: "alice", ObjectType: "Cube", ObjectName: "Sales", Description: "Created"},
+		{ID: "2", TimeStamp: "2026-04-25T10:00:01Z", User: "bob", ObjectType: "Process", ObjectName: "Import", Description: "Updated"},
+	}
+
+	out := captureStdout(t, func() {
+		printAuditEntries(entries, true, false, true)
+	})
+
+	stdout := strings.TrimSpace(out)
+	if stdout == "" {
+		t.Fatalf("expected NDJSON, got empty stdout")
+	}
+	if strings.HasPrefix(stdout, "[") {
+		t.Errorf("follow+json should be NDJSON not array, got: %q", stdout)
+	}
+	lines := strings.Split(stdout, "\n")
+	if len(lines) != len(entries) {
+		t.Fatalf("expected %d NDJSON lines, got %d", len(entries), len(lines))
+	}
+	for i, line := range lines {
+		var e model.AuditLogEntry
+		if err := json.Unmarshal([]byte(line), &e); err != nil {
+			t.Errorf("line %d not a JSON object: %v: %q", i, err, line)
+		}
+	}
+}
+
+func TestRunLogsAudit_FollowSameBoundaryDedupe(t *testing.T) {
+	resetCmdFlags(t)
+
+	const ts = "2026-04-25T10:00:00Z"
+	entryA := model.AuditLogEntry{ID: "1", TimeStamp: ts, User: "alice", ObjectType: "Cube", ObjectName: "Sales", Description: "Created"}
+	entryB := model.AuditLogEntry{ID: "2", TimeStamp: ts, User: "bob", ObjectType: "Cube", ObjectName: "Inventory", Description: "Deleted"}
+
+	var pollCount int32
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		n := int(atomic.AddInt32(&pollCount, 1))
+		w.Header().Set("Content-Type", "application/json")
+		switch n {
+		case 1:
+			// First poll: A and B both arrive.
+			w.Write(auditLogJSON(entryA, entryB))
+		default:
+			// Subsequent polls keep returning both at the same boundary TS.
+			w.Write(auditLogJSON(entryA, entryB))
+		}
+	})
+
+	cfg, _ := loadConfig()
+	cl, _ := createClient(cfg)
+	ctx, cancel := context.WithCancel(context.Background())
+
+	out := captureAll(t, func() {
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			// Start with watermarkIDs={1} (A already seen) and watermarkTS=ts.
+			followAuditLogs(ctx, cl, ts, map[string]struct{}{"1": {}}, "", "", "", 5*time.Millisecond, false, true)
+		}()
+		for i := 0; i < 200; i++ {
+			if atomic.LoadInt32(&pollCount) >= 3 {
+				break
+			}
+			time.Sleep(5 * time.Millisecond)
+		}
+		cancel()
+		<-done
+	})
+
+	// B should appear exactly once (first poll).
+	if got := strings.Count(out.Stdout, "Inventory"); got != 1 {
+		t.Errorf("entry B (Inventory) should appear exactly once, got %d:\n%s", got, out.Stdout)
+	}
+	// A should never re-appear (it was already in the prior dedup set).
+	if got := strings.Count(out.Stdout, "Sales"); got != 0 {
+		t.Errorf("entry A (Sales) should not be re-emitted, got %d times:\n%s", got, out.Stdout)
+	}
+}

--- a/cmd/logs_audit_test.go
+++ b/cmd/logs_audit_test.go
@@ -33,14 +33,14 @@ func TestBuildAuditFilter(t *testing.T) {
 			"TimeStamp ge 2026-04-25T10:00:00Z and TimeStamp le 2026-04-25T18:00:00Z"},
 		{"object-type only", "", "", "Cube", "", "", "ObjectType eq 'Cube'"},
 		{"object-name only", "", "", "", "Sales", "", "ObjectName eq 'Sales'"},
-		{"user only", "", "", "", "", "admin", "User eq 'admin'"},
+		{"user only", "", "", "", "", "admin", "UserName eq 'admin'"},
 		{"object-type and object-name", "", "", "Cube", "Sales", "", "ObjectType eq 'Cube' and ObjectName eq 'Sales'"},
-		{"object-name and user", "", "", "", "ImportSales", "admin", "ObjectName eq 'ImportSales' and User eq 'admin'"},
+		{"object-name and user", "", "", "", "ImportSales", "admin", "ObjectName eq 'ImportSales' and UserName eq 'admin'"},
 		{"all five", "2026-04-25T10:00:00Z", "2026-04-25T18:00:00Z", "Process", "ImportSales", "admin",
-			"TimeStamp ge 2026-04-25T10:00:00Z and TimeStamp le 2026-04-25T18:00:00Z and ObjectType eq 'Process' and ObjectName eq 'ImportSales' and User eq 'admin'"},
+			"TimeStamp ge 2026-04-25T10:00:00Z and TimeStamp le 2026-04-25T18:00:00Z and ObjectType eq 'Process' and ObjectName eq 'ImportSales' and UserName eq 'admin'"},
 		{"object-type with embedded quote", "", "", "O'Brien", "", "", "ObjectType eq 'O''Brien'"},
 		{"object-name with embedded quote", "", "", "", "O'Brien", "", "ObjectName eq 'O''Brien'"},
-		{"user with embedded quote", "", "", "", "", "O'Brien", "User eq 'O''Brien'"},
+		{"user with embedded quote", "", "", "", "", "O'Brien", "UserName eq 'O''Brien'"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -104,9 +104,9 @@ func TestBuildAuditQuery_EmptyOrderByOmitsOrderby(t *testing.T) {
 
 func TestApplyAuditClientFilters(t *testing.T) {
 	entries := []model.AuditLogEntry{
-		{ID: "1", TimeStamp: "2026-04-25T10:00:00Z", User: "alice", ObjectType: "Cube", ObjectName: "Sales"},
-		{ID: "2", TimeStamp: "2026-04-25T11:00:00Z", User: "bob", ObjectType: "Process", ObjectName: "ImportSales"},
-		{ID: "3", TimeStamp: "2026-04-25T12:00:00Z", User: "alice", ObjectType: "Cube", ObjectName: "Sales"},
+		{ID: "1", TimeStamp: "2026-04-25T10:00:00Z", UserName: "alice", ObjectType: "Cube", ObjectName: "Sales"},
+		{ID: "2", TimeStamp: "2026-04-25T11:00:00Z", UserName: "bob", ObjectType: "Process", ObjectName: "ImportSales"},
+		{ID: "3", TimeStamp: "2026-04-25T12:00:00Z", UserName: "alice", ObjectType: "Cube", ObjectName: "Sales"},
 	}
 
 	t.Run("since drops older", func(t *testing.T) {
@@ -323,7 +323,7 @@ func TestBoundaryAuditIDs(t *testing.T) {
 
 	t.Run("ID-less entries get synthetic dedupe key", func(t *testing.T) {
 		entries := []model.AuditLogEntry{
-			{ID: "", TimeStamp: "2026-04-25T12:00:00Z", User: "u", ObjectType: "Cube", ObjectName: "Sales", Description: "Created"},
+			{ID: "", TimeStamp: "2026-04-25T12:00:00Z", UserName: "u", ObjectType: "Cube", ObjectName: "Sales", Description: "Created"},
 			{ID: "abc", TimeStamp: "2026-04-25T12:00:00Z"},
 		}
 		ts, ids := boundaryAuditIDs(entries)
@@ -352,7 +352,7 @@ func TestAuditIDKey(t *testing.T) {
 	})
 
 	t.Run("synthesizes key when ID empty", func(t *testing.T) {
-		e := model.AuditLogEntry{ID: "", TimeStamp: "2026-04-25T10:00:00Z", User: "u", ObjectType: "Cube", ObjectName: "Sales"}
+		e := model.AuditLogEntry{ID: "", TimeStamp: "2026-04-25T10:00:00Z", UserName: "u", ObjectType: "Cube", ObjectName: "Sales"}
 		got := auditIDKey(e)
 		if got == "" {
 			t.Errorf("auditIDKey for ID='' must synthesize a non-empty key")
@@ -364,8 +364,8 @@ func TestAuditIDKey(t *testing.T) {
 
 	t.Run("distinct same-TS entries get distinct synth keys", func(t *testing.T) {
 		ts := "2026-04-25T10:00:00Z"
-		a := model.AuditLogEntry{ID: "", TimeStamp: ts, User: "u", ObjectType: "Cube", ObjectName: "SalesA"}
-		b := model.AuditLogEntry{ID: "", TimeStamp: ts, User: "u", ObjectType: "Cube", ObjectName: "SalesB"}
+		a := model.AuditLogEntry{ID: "", TimeStamp: ts, UserName: "u", ObjectType: "Cube", ObjectName: "SalesA"}
+		b := model.AuditLogEntry{ID: "", TimeStamp: ts, UserName: "u", ObjectType: "Cube", ObjectName: "SalesB"}
 		if auditIDKey(a) == auditIDKey(b) {
 			t.Errorf("distinct same-timestamp entries must produce distinct synth keys")
 		}
@@ -373,8 +373,8 @@ func TestAuditIDKey(t *testing.T) {
 
 	t.Run("identical entries get identical synth keys", func(t *testing.T) {
 		ts := "2026-04-25T10:00:00Z"
-		a := model.AuditLogEntry{ID: "", TimeStamp: ts, User: "u", ObjectType: "Cube", ObjectName: "Sales"}
-		b := model.AuditLogEntry{ID: "", TimeStamp: ts, User: "u", ObjectType: "Cube", ObjectName: "Sales"}
+		a := model.AuditLogEntry{ID: "", TimeStamp: ts, UserName: "u", ObjectType: "Cube", ObjectName: "Sales"}
+		b := model.AuditLogEntry{ID: "", TimeStamp: ts, UserName: "u", ObjectType: "Cube", ObjectName: "Sales"}
 		if auditIDKey(a) != auditIDKey(b) {
 			t.Errorf("identical entries must produce identical synth keys")
 		}
@@ -426,8 +426,8 @@ func TestIsAuditLogDisabled(t *testing.T) {
 func TestRunLogsAudit_AuditLogEntryRoundTrip(t *testing.T) {
 	body := []byte(`{
 		"value": [
-			{"ID":"uuid-abc","TimeStamp":"2026-04-25T10:00:00Z","User":"alice","ObjectType":"Cube","ObjectName":"Sales","Description":"Created","AuditDetails":"some detail"},
-			{"TimeStamp":"2026-04-25T10:01:00Z","User":"bob","ObjectType":"Process","ObjectName":"ImportSales","Description":"Updated"}
+			{"ID":"uuid-abc","TimeStamp":"2026-04-25T10:00:00Z","UserName":"alice","ObjectType":"Cube","ObjectName":"Sales","Description":"Created"},
+			{"TimeStamp":"2026-04-25T10:01:00Z","UserName":"bob","ObjectType":"Process","ObjectName":"ImportSales","Description":"Updated"}
 		]
 	}`)
 
@@ -443,16 +443,16 @@ func TestRunLogsAudit_AuditLogEntryRoundTrip(t *testing.T) {
 	if e0.ID != "uuid-abc" {
 		t.Errorf("ID = %q, want uuid-abc", e0.ID)
 	}
-	if e0.AuditDetails != "some detail" {
-		t.Errorf("AuditDetails = %q, want 'some detail'", e0.AuditDetails)
+	if e0.UserName != "alice" || e0.ObjectType != "Cube" || e0.ObjectName != "Sales" {
+		t.Errorf("unexpected e0 fields: UserName=%q ObjectType=%q ObjectName=%q", e0.UserName, e0.ObjectType, e0.ObjectName)
 	}
 
 	e1 := resp.Value[1]
 	if e1.ID != "" {
 		t.Errorf("missing ID should unmarshal to empty string, got %q", e1.ID)
 	}
-	if e1.User != "bob" || e1.ObjectType != "Process" {
-		t.Errorf("unexpected fields: User=%q ObjectType=%q", e1.User, e1.ObjectType)
+	if e1.UserName != "bob" || e1.ObjectType != "Process" {
+		t.Errorf("unexpected fields: UserName=%q ObjectType=%q", e1.UserName, e1.ObjectType)
 	}
 }
 
@@ -629,7 +629,7 @@ func TestRunLogsAudit_TableOutput(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		w.Write(auditLogJSON(
 			model.AuditLogEntry{
-				ID: "uuid-1", TimeStamp: "2026-04-25T10:00:00Z", User: "alice",
+				ID: "uuid-1", TimeStamp: "2026-04-25T10:00:00Z", UserName: "alice",
 				ObjectType: "Cube", ObjectName: "Sales", Description: "Created",
 			},
 		))
@@ -661,7 +661,7 @@ func TestRunLogsAudit_JSONOutput(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		w.Write(auditLogJSON(
 			model.AuditLogEntry{
-				ID: "uuid-1", TimeStamp: "2026-04-25T10:00:00Z", User: "alice",
+				ID: "uuid-1", TimeStamp: "2026-04-25T10:00:00Z", UserName: "alice",
 				ObjectType: "Cube", ObjectName: "Sales", Description: "Created",
 			},
 		))
@@ -680,7 +680,7 @@ func TestRunLogsAudit_JSONOutput(t *testing.T) {
 	if len(got) != 1 {
 		t.Fatalf("got %d entries, want 1", len(got))
 	}
-	if got[0].User != "alice" || got[0].ObjectType != "Cube" {
+	if got[0].UserName != "alice" || got[0].ObjectType != "Cube" {
 		t.Errorf("got %+v, want alice/Cube", got[0])
 	}
 }
@@ -693,7 +693,7 @@ func TestRunLogsAudit_RawOutput(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		w.Write(auditLogJSON(
 			model.AuditLogEntry{
-				ID: "uuid-1", TimeStamp: "2026-04-25T10:00:00Z", User: "alice",
+				ID: "uuid-1", TimeStamp: "2026-04-25T10:00:00Z", UserName: "alice",
 				ObjectType: "Cube", ObjectName: "Sales", Description: "Created",
 			},
 		))
@@ -726,7 +726,7 @@ func TestRunLogsAudit_RawSanitizesAllFields(t *testing.T) {
 			model.AuditLogEntry{
 				ID:          "uuid-1",
 				TimeStamp:   "2026-04-25T10:00:00Z",
-				User:        "ali\nce",
+				UserName:        "ali\nce",
 				ObjectType:  "Cu\rbe",
 				ObjectName:  "Sa\tles",
 				Description: "Cre\nated",
@@ -802,7 +802,7 @@ func TestRunLogsAudit_ServerSideFilterReachesServer(t *testing.T) {
 		"TimeStamp ge ",
 		"ObjectType eq 'Cube'",
 		"ObjectName eq 'ImportSales'",
-		"User eq 'admin'",
+		"UserName eq 'admin'",
 	} {
 		if !strings.Contains(decoded, want) {
 			t.Errorf("query %q missing %q", decoded, want)
@@ -818,8 +818,8 @@ func TestRunLogsAudit_TailOrdering(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		// Server returns DESC order — newest first
 		w.Write(auditLogJSON(
-			model.AuditLogEntry{ID: "2", TimeStamp: "2026-04-25T11:00:00Z", User: "bob", ObjectType: "Cube", ObjectName: "Sales", Description: "Updated"},
-			model.AuditLogEntry{ID: "1", TimeStamp: "2026-04-25T10:00:00Z", User: "alice", ObjectType: "Cube", ObjectName: "Sales", Description: "Created"},
+			model.AuditLogEntry{ID: "2", TimeStamp: "2026-04-25T11:00:00Z", UserName: "bob", ObjectType: "Cube", ObjectName: "Sales", Description: "Updated"},
+			model.AuditLogEntry{ID: "1", TimeStamp: "2026-04-25T10:00:00Z", UserName: "alice", ObjectType: "Cube", ObjectName: "Sales", Description: "Created"},
 		))
 	})
 
@@ -858,8 +858,8 @@ func TestRunLogsAudit_FilterFallbackOnHTTP400(t *testing.T) {
 		}
 		// Second call: no $filter — return mixed types; client should drop non-Cube.
 		w.Write(auditLogJSON(
-			model.AuditLogEntry{ID: "1", TimeStamp: "2026-04-25T10:00:00Z", User: "alice", ObjectType: "Cube", ObjectName: "Sales", Description: "Created"},
-			model.AuditLogEntry{ID: "2", TimeStamp: "2026-04-25T10:01:00Z", User: "bob", ObjectType: "Process", ObjectName: "Import", Description: "Updated"},
+			model.AuditLogEntry{ID: "1", TimeStamp: "2026-04-25T10:00:00Z", UserName: "alice", ObjectType: "Cube", ObjectName: "Sales", Description: "Created"},
+			model.AuditLogEntry{ID: "2", TimeStamp: "2026-04-25T10:01:00Z", UserName: "bob", ObjectType: "Process", ObjectName: "Import", Description: "Updated"},
 		))
 	})
 
@@ -898,7 +898,7 @@ func TestRunLogsAudit_FilterRejectionMentioningEntityNameStillFallsBack(t *testi
 			return
 		}
 		w.Write(auditLogJSON(
-			model.AuditLogEntry{ID: "1", TimeStamp: "2026-04-25T10:00:00Z", User: "alice", ObjectType: "Cube", ObjectName: "Sales", Description: "Created"},
+			model.AuditLogEntry{ID: "1", TimeStamp: "2026-04-25T10:00:00Z", UserName: "alice", ObjectType: "Cube", ObjectName: "Sales", Description: "Created"},
 		))
 	})
 
@@ -987,7 +987,7 @@ func TestRunLogsAudit_FallbackTrimToTail(t *testing.T) {
 			entries = append(entries, model.AuditLogEntry{
 				ID:          fmt.Sprintf("%d", i+1),
 				TimeStamp:   time.Date(2026, 4, 25, 10, 0, i, 0, time.UTC).Format(time.RFC3339),
-				User:        "u",
+				UserName:        "u",
 				ObjectType:  objType,
 				ObjectName:  "Sales",
 				Description: "Changed",
@@ -1195,8 +1195,8 @@ func TestRunLogsAudit_FollowEmitsNDJSON(t *testing.T) {
 	resetCmdFlags(t)
 
 	entries := []model.AuditLogEntry{
-		{ID: "1", TimeStamp: "2026-04-25T10:00:00Z", User: "alice", ObjectType: "Cube", ObjectName: "Sales", Description: "Created"},
-		{ID: "2", TimeStamp: "2026-04-25T10:00:01Z", User: "bob", ObjectType: "Process", ObjectName: "Import", Description: "Updated"},
+		{ID: "1", TimeStamp: "2026-04-25T10:00:00Z", UserName: "alice", ObjectType: "Cube", ObjectName: "Sales", Description: "Created"},
+		{ID: "2", TimeStamp: "2026-04-25T10:00:01Z", UserName: "bob", ObjectType: "Process", ObjectName: "Import", Description: "Updated"},
 	}
 
 	out := captureStdout(t, func() {
@@ -1226,8 +1226,8 @@ func TestRunLogsAudit_FollowSameBoundaryDedupe(t *testing.T) {
 	resetCmdFlags(t)
 
 	const ts = "2026-04-25T10:00:00Z"
-	entryA := model.AuditLogEntry{ID: "1", TimeStamp: ts, User: "alice", ObjectType: "Cube", ObjectName: "Sales", Description: "Created"}
-	entryB := model.AuditLogEntry{ID: "2", TimeStamp: ts, User: "bob", ObjectType: "Cube", ObjectName: "Inventory", Description: "Deleted"}
+	entryA := model.AuditLogEntry{ID: "1", TimeStamp: ts, UserName: "alice", ObjectType: "Cube", ObjectName: "Sales", Description: "Created"}
+	entryB := model.AuditLogEntry{ID: "2", TimeStamp: ts, UserName: "bob", ObjectType: "Cube", ObjectName: "Inventory", Description: "Deleted"}
 
 	var pollCount int32
 	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {

--- a/cmd/logs_audit_test.go
+++ b/cmd/logs_audit_test.go
@@ -883,7 +883,7 @@ func TestRunLogsAudit_FilterFallbackOnHTTP400(t *testing.T) {
 // Regression for #80 review feedback: a filter-rejection body that echoes
 // the entity-set name "AuditLogEntries" must NOT be misclassified as a
 // disabled-audit error. The client must fall back to client-side filtering
-// (request count == 2, fallback warning emitted, no AuditLog=T error).
+// (request count == 2, fallback warning emitted, no AuditLogOn=T error).
 func TestRunLogsAudit_FilterRejectionMentioningEntityNameStillFallsBack(t *testing.T) {
 	resetCmdFlags(t)
 	logsAuditObjectType = "Cube"
@@ -914,7 +914,7 @@ func TestRunLogsAudit_FilterRejectionMentioningEntityNameStillFallsBack(t *testi
 	if !strings.Contains(out.Stderr, "[warn] Server-side filter not supported") {
 		t.Errorf("stderr should print fallback warning, got: %q", out.Stderr)
 	}
-	if strings.Contains(out.Stderr, "AuditLog=T") {
+	if strings.Contains(out.Stderr, "AuditLogOn=T") {
 		t.Errorf("filter-rejection body must NOT trigger the disabled-audit error, got: %q", out.Stderr)
 	}
 	if !strings.Contains(out.Stdout, "Cube") {
@@ -1041,8 +1041,8 @@ func TestRunLogsAudit_AuditLogDisabledFriendlyError(t *testing.T) {
 	if got := atomic.LoadInt32(&requestCount); got != 1 {
 		t.Errorf("expected 1 HTTP request (no retry), got %d", got)
 	}
-	if !strings.Contains(out.Stderr, "AuditLog=T") {
-		t.Errorf("stderr should mention AuditLog=T, got: %q", out.Stderr)
+	if !strings.Contains(out.Stderr, "AuditLogOn=T") {
+		t.Errorf("stderr should mention AuditLogOn=T, got: %q", out.Stderr)
 	}
 }
 
@@ -1074,8 +1074,8 @@ func TestRunLogsAudit_AuditLogDisabledOnFallbackRetry(t *testing.T) {
 	if got := atomic.LoadInt32(&requestCount); got != 2 {
 		t.Errorf("expected 2 HTTP requests (first filter rejection, second disabled), got %d", got)
 	}
-	if !strings.Contains(out.Stderr, "AuditLog=T") {
-		t.Errorf("stderr should contain friendly AuditLog=T message, got: %q", out.Stderr)
+	if !strings.Contains(out.Stderr, "AuditLogOn=T") {
+		t.Errorf("stderr should contain friendly AuditLogOn=T message, got: %q", out.Stderr)
 	}
 }
 
@@ -1095,8 +1095,8 @@ func TestRunLogsAudit_AuthErrorNotTreatedAsDisabled(t *testing.T) {
 		}
 	})
 
-	if strings.Contains(out.Stderr, "AuditLog=T") {
-		t.Errorf("auth error should NOT be treated as disabled, but got AuditLog=T in: %q", out.Stderr)
+	if strings.Contains(out.Stderr, "AuditLogOn=T") {
+		t.Errorf("auth error should NOT be treated as disabled, but got AuditLogOn=T in: %q", out.Stderr)
 	}
 	if !strings.Contains(out.Stderr, "Authentication failed") {
 		t.Errorf("stderr should mention auth failure, got: %q", out.Stderr)
@@ -1118,8 +1118,8 @@ func TestRunLogsAudit_NotFoundNotTreatedAsDisabled(t *testing.T) {
 		}
 	})
 
-	if strings.Contains(out.Stderr, "AuditLog=T") {
-		t.Errorf("404 should NOT be treated as disabled, but got AuditLog=T in: %q", out.Stderr)
+	if strings.Contains(out.Stderr, "AuditLogOn=T") {
+		t.Errorf("404 should NOT be treated as disabled, but got AuditLogOn=T in: %q", out.Stderr)
 	}
 }
 

--- a/cmd/logs_audit_test.go
+++ b/cmd/logs_audit_test.go
@@ -409,6 +409,12 @@ func TestIsAuditLogDisabled(t *testing.T) {
 		// return false.
 		{"filter rejection body mentions entity-set name", fmt.Errorf("HTTP 400: $filter is not supported for AuditLogEntries"), false},
 		{"orderby rejection body mentions entity-set name", fmt.Errorf("HTTP 501: AuditLogEntries: $orderby not supported"), false},
+		// Regression: filter-rejection bodies that spell the feature
+		// name with a space ("audit log") would otherwise satisfy the
+		// feature-phrase gate and short-circuit fallback. The presence
+		// of "filter" / "orderby" must keep them in the fallback path.
+		{"filter rejection body uses natural-language phrase", fmt.Errorf("HTTP 400: $filter is not supported for the audit log"), false},
+		{"orderby rejection body uses natural-language phrase", fmt.Errorf("HTTP 501: $orderby on the audit log is not supported"), false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -916,6 +922,49 @@ func TestRunLogsAudit_FilterRejectionMentioningEntityNameStillFallsBack(t *testi
 	}
 	if strings.Contains(out.Stderr, "AuditLogOn=T") {
 		t.Errorf("filter-rejection body must NOT trigger the disabled-audit error, got: %q", out.Stderr)
+	}
+	if !strings.Contains(out.Stdout, "Cube") {
+		t.Errorf("stdout should contain the Cube row, got:\n%s", out.Stdout)
+	}
+}
+
+// Regression for round 4 review: a filter-rejection body that uses the
+// natural-language phrase "audit log" (with a space — distinct from the
+// entity-set name AuditLogEntries) must NOT be misclassified as a
+// disabled-audit error. The "filter" / "orderby" exclusion keeps the
+// flow in the fallback path; request count == 2, no AuditLogOn=T error.
+func TestRunLogsAudit_FilterRejectionWithNaturalLanguagePhraseFallsBack(t *testing.T) {
+	resetCmdFlags(t)
+	logsAuditObjectType = "Cube"
+
+	var requestCount int32
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&requestCount, 1)
+		w.Header().Set("Content-Type", "application/json")
+		if n == 1 {
+			w.WriteHeader(http.StatusBadRequest)
+			fmt.Fprint(w, `{"error":"$filter is not supported for the audit log"}`)
+			return
+		}
+		w.Write(auditLogJSON(
+			model.AuditLogEntry{ID: "1", TimeStamp: "2026-04-25T10:00:00Z", UserName: "alice", ObjectType: "Cube", ObjectName: "Sales", Description: "Created"},
+		))
+	})
+
+	out := captureAll(t, func() {
+		if err := runLogsAudit(logsAuditCmd, nil); err != nil {
+			t.Fatalf("unexpected: %v", err)
+		}
+	})
+
+	if got := atomic.LoadInt32(&requestCount); got != 2 {
+		t.Errorf("expected exactly 2 requests (initial + fallback), got %d", got)
+	}
+	if !strings.Contains(out.Stderr, "[warn] Server-side filter not supported") {
+		t.Errorf("stderr should print fallback warning, got: %q", out.Stderr)
+	}
+	if strings.Contains(out.Stderr, "AuditLogOn=T") {
+		t.Errorf("natural-language filter rejection must NOT trigger the disabled-audit error, got: %q", out.Stderr)
 	}
 	if !strings.Contains(out.Stdout, "Cube") {
 		t.Errorf("stdout should contain the Cube row, got:\n%s", out.Stdout)

--- a/cmd/testhelpers_test.go
+++ b/cmd/testhelpers_test.go
@@ -236,6 +236,15 @@ func zeroAllFlags() {
 	logsTxInterval = 5 * time.Second
 	logsTxTail = 0
 	logsTxRaw = false
+	logsAuditSince = ""
+	logsAuditUntil = ""
+	logsAuditObjectType = ""
+	logsAuditObjectName = ""
+	logsAuditUser = ""
+	logsAuditFollow = false
+	logsAuditInterval = 5 * time.Second
+	logsAuditTail = 0
+	logsAuditRaw = false
 }
 
 // cubesJSON returns JSON for a TM1 Cubes response.
@@ -430,6 +439,18 @@ func transactionLogJSON(entries ...model.TransactionLogEntry) []byte {
 	}{Value: entries}
 	if resp.Value == nil {
 		resp.Value = []model.TransactionLogEntry{}
+	}
+	data, _ := json.Marshal(resp)
+	return data
+}
+
+// auditLogJSON returns JSON for a TM1 AuditLogEntries response.
+func auditLogJSON(entries ...model.AuditLogEntry) []byte {
+	resp := struct {
+		Value []model.AuditLogEntry `json:"value"`
+	}{Value: entries}
+	if resp.Value == nil {
+		resp.Value = []model.AuditLogEntry{}
 	}
 	data, _ := json.Marshal(resp)
 	return data

--- a/internal/model/auditlog.go
+++ b/internal/model/auditlog.go
@@ -1,0 +1,24 @@
+package model
+
+// AuditLogEntry represents a single entry from GET /AuditLogEntries.
+// Fields follow the TM1 v11 REST schema for tm1.AuditLogEntry.
+//
+// ID is Edm.String per IBM docs; older TM1 versions may omit it (empty == absent).
+// AuditDetails is optional and not always populated; it carries free-form
+// per-object change details when present.
+type AuditLogEntry struct {
+	ID           string `json:"ID,omitempty"`
+	TimeStamp    string `json:"TimeStamp"`
+	User         string `json:"User,omitempty"`
+	ObjectType   string `json:"ObjectType,omitempty"`
+	ObjectName   string `json:"ObjectName,omitempty"`
+	Description  string `json:"Description,omitempty"`
+	AuditDetails string `json:"AuditDetails,omitempty"`
+}
+
+// AuditLogResponse is the OData collection wrapper for GET /AuditLogEntries.
+// NextLink is set when the response is paginated; callers must surface it.
+type AuditLogResponse struct {
+	Value    []AuditLogEntry `json:"value"`
+	NextLink string          `json:"@odata.nextLink,omitempty"`
+}

--- a/internal/model/auditlog.go
+++ b/internal/model/auditlog.go
@@ -1,19 +1,21 @@
 package model
 
 // AuditLogEntry represents a single entry from GET /AuditLogEntries.
-// Fields follow the TM1 v11 REST schema for tm1.AuditLogEntry.
+// Fields follow the TM1 PA REST schema for tm1.AuditLogEntry — note the
+// audit log uses UserName (not User as in TransactionLogEntry); the two
+// entity types diverge here.
 //
-// ID is Edm.String per IBM docs; older TM1 versions may omit it (empty == absent).
-// AuditDetails is optional and not always populated; it carries free-form
-// per-object change details when present.
+// ID is Edm.String per IBM docs; older TM1 versions may omit it (empty
+// == absent). AuditDetails is a navigation property in the schema and
+// only populates with $expand=AuditDetails — not requested here, so it
+// is intentionally not modelled.
 type AuditLogEntry struct {
-	ID           string `json:"ID,omitempty"`
-	TimeStamp    string `json:"TimeStamp"`
-	User         string `json:"User,omitempty"`
-	ObjectType   string `json:"ObjectType,omitempty"`
-	ObjectName   string `json:"ObjectName,omitempty"`
-	Description  string `json:"Description,omitempty"`
-	AuditDetails string `json:"AuditDetails,omitempty"`
+	ID          string `json:"ID,omitempty"`
+	TimeStamp   string `json:"TimeStamp"`
+	UserName    string `json:"UserName,omitempty"`
+	ObjectType  string `json:"ObjectType,omitempty"`
+	ObjectName  string `json:"ObjectName,omitempty"`
+	Description string `json:"Description,omitempty"`
 }
 
 // AuditLogResponse is the OData collection wrapper for GET /AuditLogEntries.

--- a/internal/model/auditlog.go
+++ b/internal/model/auditlog.go
@@ -5,10 +5,16 @@ package model
 // audit log uses UserName (not User as in TransactionLogEntry); the two
 // entity types diverge here.
 //
-// ID is Edm.String per IBM docs; older TM1 versions may omit it (empty
-// == absent). AuditDetails is a navigation property in the schema and
-// only populates with $expand=AuditDetails — not requested here, so it
-// is intentionally not modelled.
+// ID is modelled as string to match the project convention for audit-
+// style logs (see MessageLogEntry); response payload examples in IBM
+// docs render audit IDs as JSON strings. Older TM1 versions may omit
+// the field entirely (empty == absent). If a TM1 release ever emits
+// numeric IDs here, swap this to json.RawMessage with a tolerant
+// renderer rather than int64 — message log IDs are also string.
+//
+// AuditDetails is a navigation property in the schema and only
+// populates with $expand=AuditDetails — not requested here, so it is
+// intentionally not modelled.
 type AuditLogEntry struct {
 	ID          string `json:"ID,omitempty"`
 	TimeStamp   string `json:"TimeStamp"`


### PR DESCRIPTION
## Summary
- New `tm1cli logs audit` subcommand querying `GET /AuditLogEntries` with `--object-type`, `--object-name`, `--user`, `--since`, `--until`, `--tail`, `--follow`, `--interval`, `--raw`, plus table/JSON/NDJSON output.
- Friendly error when audit logging is off — points the admin at `AuditLogOn=T` in `tm1s.cfg` (verified against a real tm1s.cfg from an IBM-affiliated repo).
- Mirrors the `logs tx` (#79) pattern: server-side `$filter`/`$orderby` with safe filter-rejection fallback (ASC retry for `--until`-only forensic queries), monotonic watermark dedupe in `--follow`, paginated-response warning, raw-line control-char sanitization.

Closes #80

## Schema notes
- `AuditLogEntry.UserName` (not `User`) — the audit log entity diverges from the transaction log here. Verified against tm1py's `AuditLogService` source.
- `ID` modelled as string (consistent with `MessageLogEntry`); the model docs the trade-off in case a future TM1 release emits numeric IDs.
- `AuditDetails` is a navigation property requiring `$expand` to populate, so it is intentionally not modelled — adding it would be dead bytes today.

## Disabled-audit detection
- Runs on the initial fetch AND on the retry-after-filter-rejection path so a server that requires both fallback AND has audit disabled still surfaces the friendly error rather than the raw filter-rejection.
- Tightened to require the phrase `audit log` (with space) or `auditing` so the lowercased entity-set name `auditlogentries` does not produce false positives that suppress the required client-side fallback.
- Skipped on HTTP 401/403/404 to keep auth/not-found errors distinct.

## Test plan
- [x] `go vet ./...` clean
- [x] `go build ./...` clean
- [x] `go test ./...` — **1092 / 1092 pass** (87 audit-specific tests covering: filter/query builders with OData escape, fallback over-fetch + post-trim to `--tail`, `--until`-only ASC retry, disabled detection table cases, entity-name false-positive regression, fallback-then-disabled, auth-not-as-disabled, 404-not-as-disabled, JSON-mode error envelope, empty response, pagination warning, follow NDJSON initial batch, follow same-boundary dedupe, raw sanitization for every string field).
- [ ] Manual smoke test against a real TM1 server with `AuditLogOn=T` (recommend before merge).
- [ ] Manual smoke test against a server with `AuditLogOn=F` to verify the friendly error wording.

## Commits
1. `feat(#80): add AuditLogEntry and AuditLogResponse model types`
2. `feat(#80): implement logs audit subcommand`
3. `test(#80): add logs audit unit and integration tests`
4. `docs(#80): add logs audit example block to README`
5. `refactor(#80): bring follow-loop watermark comment to parity with logs tx`
6. `fix(#80): address external review feedback — round 1` (tighten disabled-keyword gate to avoid false positive on entity-set name)
7. `fix(#80): address external review feedback — round 2` (UserName field, drop AuditDetails)
8. `fix(#80): address external review feedback — round 3` (AuditLogOn=T parameter name, clean follow-loop termination on mid-stream disable)
