### PR TITLE
feat(#76): threads cancel — cancel a stuck TM1 thread

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -15,6 +15,30 @@ import (
 // Execute() exits non-zero without cobra re-printing the message.
 var errSilent = errors.New("")
 
+// silentErrCoded carries a process exit code while signaling that the
+// message has already been printed to stderr. Use it instead of
+// errSilent when the command needs an exit code other than 1
+// (e.g. exit 3 for "not found").
+type silentErrCoded struct{ code int }
+
+func (e *silentErrCoded) Error() string { return "" }
+
+// errExit returns a silent error that exits the process with the given code.
+func errExit(code int) error { return &silentErrCoded{code: code} }
+
+// exitCodeForError returns the process exit code for err: 0 for nil,
+// the encoded code for *silentErrCoded (including wrapped), 1 otherwise.
+func exitCodeForError(err error) int {
+	if err == nil {
+		return 0
+	}
+	var coded *silentErrCoded
+	if errors.As(err, &coded) {
+		return coded.code
+	}
+	return 1
+}
+
 var (
 	Version     = "dev"
 	flagServer  string
@@ -41,7 +65,7 @@ Environment Variables:
 
 func Execute() {
 	if err := rootCmd.Execute(); err != nil {
-		os.Exit(1)
+		os.Exit(exitCodeForError(err))
 	}
 }
 

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,9 +1,32 @@
 package cmd
 
 import (
+	"errors"
+	"fmt"
 	"testing"
 	"tm1cli/internal/config"
 )
+
+func TestExitCodeForError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want int
+	}{
+		{"nil → 0", nil, 0},
+		{"plain error → 1", errors.New("boom"), 1},
+		{"errSilent → 1", errSilent, 1},
+		{"errExit(3) → 3", errExit(3), 3},
+		{"wrapped errExit(7) → 7", fmt.Errorf("wrap: %w", errExit(7)), 7},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := exitCodeForError(tt.err); got != tt.want {
+				t.Errorf("exitCodeForError(%v) = %d, want %d", tt.err, got, tt.want)
+			}
+		})
+	}
+}
 
 func TestGetOutputFormat(t *testing.T) {
 	tests := []struct {

--- a/cmd/testhelpers_test.go
+++ b/cmd/testhelpers_test.go
@@ -220,6 +220,8 @@ func zeroAllFlags() {
 	threadsMinElapsed = ""
 	threadsLimit = 0
 	threadsAll = false
+	threadsCancelYes = false
+	threadsCancelDryRun = false
 	logsMsgSince = ""
 	logsMsgLevel = ""
 	logsMsgUser = ""

--- a/cmd/threads.go
+++ b/cmd/threads.go
@@ -1,10 +1,15 @@
 package cmd
 
 import (
+	"bufio"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"os"
+	"strconv"
 	"strings"
 	"time"
+	"tm1cli/internal/client"
 	"tm1cli/internal/model"
 	"tm1cli/internal/output"
 
@@ -12,11 +17,13 @@ import (
 )
 
 var (
-	threadsUser       string
-	threadsState      string
-	threadsMinElapsed string
-	threadsLimit      int
-	threadsAll        bool
+	threadsUser         string
+	threadsState        string
+	threadsMinElapsed   string
+	threadsLimit        int
+	threadsAll          bool
+	threadsCancelYes    bool
+	threadsCancelDryRun bool
 )
 
 var threadsCmd = &cobra.Command{
@@ -161,13 +168,147 @@ func displayThreads(threads []model.Thread, total int, limit int, jsonMode bool)
 	output.PrintSummary(len(shown), total, "--user, --state, or --min-elapsed to filter or --all")
 }
 
+var threadsCancelCmd = &cobra.Command{
+	Use:   "cancel <id>",
+	Short: "Cancel a running TM1 thread",
+	Long: `Cancel a running thread on the TM1 server.
+
+REST API: POST /Threads('<id>')/tm1.CancelOperation
+
+Use this to interrupt a stuck query, hung TI process, or long-running
+operation that is holding locks.
+
+WARNING: cancelling a thread aborts in-flight work. Uncommitted writes
+are rolled back and any process running on the thread terminates with
+an error. Use with care.
+
+The command prompts for confirmation by default. Use --yes to skip the
+prompt for scripting.
+
+Use --dry-run to look up the thread and preview what would be cancelled
+without actually cancelling it. --dry-run takes precedence over --yes.
+
+Exit codes:
+  0  thread cancelled successfully
+  1  generic error (auth, network, server)
+  3  thread not found`,
+	Example: `  tm1cli threads cancel 1234
+  tm1cli threads cancel 1234 --yes
+  tm1cli threads cancel 1234 --dry-run
+  tm1cli threads cancel 1234 --output json`,
+	Args: cobra.ExactArgs(1),
+	RunE: runThreadsCancel,
+}
+
+// threadEndpoint formats a TM1 Threads-collection endpoint with quoted
+// key syntax (matches IBM PA REST docs). id must already be validated
+// as digits-only at the call site; no escaping is performed.
+func threadEndpoint(id, suffix string) string {
+	if suffix == "" {
+		return fmt.Sprintf("Threads('%s')", id)
+	}
+	return fmt.Sprintf("Threads('%s')/%s", id, suffix)
+}
+
+func runThreadsCancel(cmd *cobra.Command, args []string) error {
+	id := args[0]
+
+	cfg, err := loadConfig()
+	if err != nil {
+		output.PrintError(err.Error(), isJSONOutput(nil))
+		return errSilent
+	}
+	jsonMode := isJSONOutput(cfg)
+
+	if _, err := strconv.ParseUint(id, 10, 64); err != nil {
+		output.PrintError(fmt.Sprintf("Invalid thread ID %q (must be numeric).", id), jsonMode)
+		return errSilent
+	}
+
+	cl, err := createClient(cfg)
+	if err != nil {
+		output.PrintError(err.Error(), jsonMode)
+		return errSilent
+	}
+
+	if threadsCancelDryRun {
+		thread, err := fetchThread(cl, id)
+		if err != nil {
+			return handleThreadCancelError(err, id, jsonMode)
+		}
+		if jsonMode {
+			output.PrintJSON(map[string]interface{}{
+				"status": "dry-run",
+				"id":     id,
+				"thread": thread,
+			})
+		} else {
+			fmt.Printf("[dry-run] Would cancel thread '%s' (name=%s, state=%s, function=%s, elapsed=%s).\n",
+				id, thread.Name, thread.State, thread.Function, formatThreadDuration(thread.ElapsedTime))
+		}
+		return nil
+	}
+
+	if !threadsCancelYes {
+		fmt.Fprintf(os.Stderr, "Warning: cancelling thread '%s' aborts in-flight work and may roll back uncommitted writes.\n", id)
+		if !promptYesNo(bufio.NewReader(os.Stdin), "Continue?") {
+			return nil
+		}
+	}
+
+	if _, err := cl.Post(threadEndpoint(id, "tm1.CancelOperation"), map[string]interface{}{}); err != nil {
+		return handleThreadCancelError(err, id, jsonMode)
+	}
+
+	if jsonMode {
+		output.PrintJSON(map[string]string{"status": "cancelled", "id": id})
+	} else {
+		fmt.Printf("Cancelled thread '%s'.\n", id)
+	}
+	return nil
+}
+
+func fetchThread(cl *client.Client, id string) (*model.Thread, error) {
+	data, err := cl.Get(threadEndpoint(id, ""))
+	if err != nil {
+		return nil, err
+	}
+	var t model.Thread
+	if err := json.Unmarshal(data, &t); err != nil {
+		return nil, fmt.Errorf("Cannot parse server response.")
+	}
+	return &t, nil
+}
+
+// handleThreadCancelError funnels common failure modes through one place:
+// not-found maps to exit code 3 (per the issue), 403 to a friendlier
+// message. Falls back to the raw client error otherwise. The 403 detection
+// uses the client's "HTTP 403: ..." string contract; if internal/client
+// later exposes a typed status error, swap this match for it.
+func handleThreadCancelError(err error, id string, jsonMode bool) error {
+	if errors.Is(err, client.ErrNotFound) {
+		output.PrintError(fmt.Sprintf("Thread '%s' not found.", id), jsonMode)
+		return errExit(3)
+	}
+	if strings.HasPrefix(err.Error(), "HTTP 403") {
+		output.PrintError("Permission denied. Cancelling threads requires admin privileges.", jsonMode)
+		return errSilent
+	}
+	output.PrintError(err.Error(), jsonMode)
+	return errSilent
+}
+
 func init() {
 	rootCmd.AddCommand(threadsCmd)
 	threadsCmd.AddCommand(threadsListCmd)
+	threadsCmd.AddCommand(threadsCancelCmd)
 
 	threadsListCmd.Flags().StringVar(&threadsUser, "user", "", "Filter by thread name/user (case-insensitive, partial match)")
 	threadsListCmd.Flags().StringVar(&threadsState, "state", "", "Filter by state (Idle|Run|Wait|CommitWait|Rollback)")
 	threadsListCmd.Flags().StringVar(&threadsMinElapsed, "min-elapsed", "", "Minimum elapsed time filter (e.g. 10s, 1m30s)")
 	threadsListCmd.Flags().IntVar(&threadsLimit, "limit", 0, "Max results to show (default from settings)")
 	threadsListCmd.Flags().BoolVar(&threadsAll, "all", false, "Show all results, no limit")
+
+	threadsCancelCmd.Flags().BoolVar(&threadsCancelYes, "yes", false, "Skip confirmation prompt")
+	threadsCancelCmd.Flags().BoolVar(&threadsCancelDryRun, "dry-run", false, "Preview cancel without sending it")
 }

--- a/cmd/threads_test.go
+++ b/cmd/threads_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"strings"
 	"testing"
@@ -289,5 +290,377 @@ func TestThreadsListFilterSkipsTop(t *testing.T) {
 
 	if strings.Contains(gotURL, "$top=") {
 		t.Errorf("$top must not be sent when --state filter is active (could silently omit matching threads), got: %s", gotURL)
+	}
+}
+
+// --- Integration: threads cancel ---
+
+// cancelHandlerOpts controls the per-test behavior of newCancelHandler.
+type cancelHandlerOpts struct {
+	thread       *model.Thread // body returned on GET when getStatus is 0/200
+	getStatus    int           // override GET status; 0 = 200 (or 404 if thread is nil)
+	cancelStatus int           // POST status; 0 = 200
+	posts        *int
+	gets         *int
+	postPaths    *[]string
+	getPaths     *[]string
+}
+
+func newCancelHandler(opts cancelHandlerOpts) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == "GET" && strings.Contains(r.URL.Path, "/Threads("):
+			if opts.gets != nil {
+				*opts.gets++
+			}
+			if opts.getPaths != nil {
+				*opts.getPaths = append(*opts.getPaths, r.URL.Path)
+			}
+			status := opts.getStatus
+			if status == 0 {
+				if opts.thread == nil {
+					status = http.StatusNotFound
+				} else {
+					status = http.StatusOK
+				}
+			}
+			if status >= 400 {
+				w.WriteHeader(status)
+				w.Write([]byte(`{"error":"failed"}`))
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			body, _ := json.Marshal(opts.thread)
+			w.Write(body)
+		case r.Method == "POST" && strings.Contains(r.URL.Path, "tm1.CancelOperation"):
+			if opts.posts != nil {
+				*opts.posts++
+			}
+			if opts.postPaths != nil {
+				*opts.postPaths = append(*opts.postPaths, r.URL.Path)
+			}
+			status := opts.cancelStatus
+			if status == 0 {
+				status = http.StatusOK
+			}
+			w.WriteHeader(status)
+			if status == http.StatusNoContent {
+				return
+			}
+			if status >= 400 {
+				w.Write([]byte(`{"error":"failed"}`))
+				return
+			}
+			w.Write([]byte(`{}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+			w.Write([]byte(`{"error":"unexpected route"}`))
+		}
+	}
+}
+
+func TestThreadsCancel_Success(t *testing.T) {
+	resetCmdFlags(t)
+	posts := 0
+	paths := []string{}
+	setupMockTM1(t, newCancelHandler(cancelHandlerOpts{
+		posts:     &posts,
+		postPaths: &paths,
+	}))
+
+	cap := captureAll(t, func() {
+		rootCmd.SetArgs([]string{"threads", "cancel", "123", "--yes"})
+		rootCmd.Execute()
+	})
+
+	if posts != 1 {
+		t.Errorf("expected 1 POST, got %d", posts)
+	}
+	if !strings.Contains(cap.Stdout, "Cancelled thread '123'") {
+		t.Errorf("expected success message in stdout, got: %s", cap.Stdout)
+	}
+	if len(paths) != 1 || !strings.Contains(paths[0], "Threads('123')/tm1.CancelOperation") {
+		t.Errorf("expected POST to Threads('123')/tm1.CancelOperation, got: %v", paths)
+	}
+}
+
+func TestThreadsCancel_204NoContent(t *testing.T) {
+	resetCmdFlags(t)
+	setupMockTM1(t, newCancelHandler(cancelHandlerOpts{
+		cancelStatus: http.StatusNoContent,
+	}))
+
+	cap := captureAll(t, func() {
+		rootCmd.SetArgs([]string{"threads", "cancel", "123", "--yes"})
+		rootCmd.Execute()
+	})
+
+	if !strings.Contains(cap.Stdout, "Cancelled thread '123'") {
+		t.Errorf("expected success on 204, got: %s", cap.Stdout)
+	}
+}
+
+func TestThreadsCancel_NotFoundExitCode(t *testing.T) {
+	resetCmdFlags(t)
+	setupMockTM1(t, newCancelHandler(cancelHandlerOpts{
+		cancelStatus: http.StatusNotFound,
+	}))
+
+	var execErr error
+	cap := captureAll(t, func() {
+		rootCmd.SetArgs([]string{"threads", "cancel", "9999", "--yes"})
+		execErr = rootCmd.Execute()
+	})
+
+	if !strings.Contains(cap.Stderr, "Thread '9999' not found") {
+		t.Errorf("expected 'not found' on stderr, got: %s", cap.Stderr)
+	}
+	var coded *silentErrCoded
+	if !errors.As(execErr, &coded) {
+		t.Fatalf("expected *silentErrCoded, got: %T %v", execErr, execErr)
+	}
+	if coded.code != 3 {
+		t.Errorf("expected exit code 3, got %d", coded.code)
+	}
+}
+
+func TestThreadsCancel_PermissionDenied(t *testing.T) {
+	resetCmdFlags(t)
+	setupMockTM1(t, newCancelHandler(cancelHandlerOpts{
+		cancelStatus: http.StatusForbidden,
+	}))
+
+	var execErr error
+	cap := captureAll(t, func() {
+		rootCmd.SetArgs([]string{"threads", "cancel", "123", "--yes"})
+		execErr = rootCmd.Execute()
+	})
+
+	if !strings.Contains(cap.Stderr, "Permission denied") {
+		t.Errorf("expected permission-denied message on stderr, got: %s", cap.Stderr)
+	}
+	// Should be plain errSilent (exit 1), NOT a coded exit.
+	var coded *silentErrCoded
+	if errors.As(execErr, &coded) {
+		t.Errorf("403 should map to errSilent (exit 1), got coded exit %d", coded.code)
+	}
+}
+
+func TestThreadsCancel_YesBypassesPrompt(t *testing.T) {
+	resetCmdFlags(t)
+	posts := 0
+	setupMockTM1(t, newCancelHandler(cancelHandlerOpts{posts: &posts}))
+
+	cap := captureAll(t, func() {
+		rootCmd.SetArgs([]string{"threads", "cancel", "123", "--yes"})
+		rootCmd.Execute()
+	})
+
+	if posts != 1 {
+		t.Errorf("expected 1 POST, got %d", posts)
+	}
+	if strings.Contains(cap.Stderr, "(y/N)") {
+		t.Errorf("--yes should suppress prompt, but prompt text appeared: %s", cap.Stderr)
+	}
+}
+
+func TestThreadsCancel_PromptDecline(t *testing.T) {
+	resetCmdFlags(t)
+	posts := 0
+	setupMockTM1(t, newCancelHandler(cancelHandlerOpts{posts: &posts}))
+	injectStdin(t, "n\n")
+
+	cap := captureAll(t, func() {
+		rootCmd.SetArgs([]string{"threads", "cancel", "123"})
+		rootCmd.Execute()
+	})
+
+	if posts != 0 {
+		t.Errorf("expected no POST when user declines, got %d", posts)
+	}
+	if !strings.Contains(cap.Stderr, "aborts in-flight work") {
+		t.Errorf("expected in-flight-work warning, got: %s", cap.Stderr)
+	}
+}
+
+func TestThreadsCancel_PromptAccept(t *testing.T) {
+	resetCmdFlags(t)
+	posts := 0
+	setupMockTM1(t, newCancelHandler(cancelHandlerOpts{posts: &posts}))
+	injectStdin(t, "y\n")
+
+	cap := captureAll(t, func() {
+		rootCmd.SetArgs([]string{"threads", "cancel", "123"})
+		rootCmd.Execute()
+	})
+
+	if posts != 1 {
+		t.Errorf("expected POST after accept, got %d", posts)
+	}
+	if !strings.Contains(cap.Stdout, "Cancelled thread '123'") {
+		t.Errorf("expected success message, got: %s", cap.Stdout)
+	}
+}
+
+func TestThreadsCancel_DryRun(t *testing.T) {
+	resetCmdFlags(t)
+	posts := 0
+	gets := 0
+	getPaths := []string{}
+	setupMockTM1(t, newCancelHandler(cancelHandlerOpts{
+		thread:    &model.Thread{ID: 123, Name: "Admin", State: "Run", Function: "GET", ElapsedTime: 5.0},
+		posts:     &posts,
+		gets:      &gets,
+		getPaths:  &getPaths,
+	}))
+
+	cap := captureAll(t, func() {
+		rootCmd.SetArgs([]string{"threads", "cancel", "123", "--dry-run"})
+		rootCmd.Execute()
+	})
+
+	if posts != 0 {
+		t.Errorf("dry-run must not POST, got %d POSTs", posts)
+	}
+	if gets != 1 {
+		t.Errorf("expected 1 GET for thread lookup, got %d", gets)
+	}
+	if len(getPaths) != 1 || !strings.Contains(getPaths[0], "Threads('123')") {
+		t.Errorf("expected GET to Threads('123'), got: %v", getPaths)
+	}
+	if !strings.Contains(cap.Stdout, "[dry-run] Would cancel thread '123'") {
+		t.Errorf("expected dry-run preview, got: %s", cap.Stdout)
+	}
+	if !strings.Contains(cap.Stdout, "name=Admin") {
+		t.Errorf("expected thread details in dry-run output, got: %s", cap.Stdout)
+	}
+}
+
+func TestThreadsCancel_DryRunYesStillNoPost(t *testing.T) {
+	resetCmdFlags(t)
+	posts := 0
+	setupMockTM1(t, newCancelHandler(cancelHandlerOpts{
+		thread: &model.Thread{ID: 123, Name: "Admin", State: "Run"},
+		posts:  &posts,
+	}))
+
+	cap := captureAll(t, func() {
+		rootCmd.SetArgs([]string{"threads", "cancel", "123", "--dry-run", "--yes"})
+		rootCmd.Execute()
+	})
+
+	if posts != 0 {
+		t.Errorf("--dry-run must take precedence over --yes (no POST), got %d", posts)
+	}
+	if !strings.Contains(cap.Stdout, "[dry-run]") {
+		t.Errorf("expected dry-run preview, got: %s", cap.Stdout)
+	}
+}
+
+func TestThreadsCancel_DryRunNotFound(t *testing.T) {
+	resetCmdFlags(t)
+	setupMockTM1(t, newCancelHandler(cancelHandlerOpts{
+		getStatus: http.StatusNotFound,
+	}))
+
+	var execErr error
+	cap := captureAll(t, func() {
+		rootCmd.SetArgs([]string{"threads", "cancel", "9999", "--dry-run"})
+		execErr = rootCmd.Execute()
+	})
+
+	if !strings.Contains(cap.Stderr, "Thread '9999' not found") {
+		t.Errorf("expected not-found error, got: %s", cap.Stderr)
+	}
+	var coded *silentErrCoded
+	if !errors.As(execErr, &coded) || coded.code != 3 {
+		t.Errorf("expected exit code 3, got: %v", execErr)
+	}
+}
+
+func TestThreadsCancel_InvalidID(t *testing.T) {
+	resetCmdFlags(t)
+	posts := 0
+	gets := 0
+	setupMockTM1(t, newCancelHandler(cancelHandlerOpts{
+		posts: &posts,
+		gets:  &gets,
+	}))
+
+	cap := captureAll(t, func() {
+		rootCmd.SetArgs([]string{"threads", "cancel", "abc", "--yes"})
+		rootCmd.Execute()
+	})
+
+	if posts != 0 || gets != 0 {
+		t.Errorf("invalid ID must not trigger HTTP traffic, got %d POSTs / %d GETs", posts, gets)
+	}
+	if !strings.Contains(cap.Stderr, "Invalid thread ID") {
+		t.Errorf("expected validation error, got: %s", cap.Stderr)
+	}
+}
+
+func TestThreadsCancel_JSON_Success(t *testing.T) {
+	resetCmdFlags(t)
+	setupMockTM1(t, newCancelHandler(cancelHandlerOpts{}))
+
+	out := captureStdout(t, func() {
+		rootCmd.SetArgs([]string{"threads", "cancel", "123", "--yes", "--output", "json"})
+		rootCmd.Execute()
+	})
+
+	var result map[string]string
+	if err := json.Unmarshal([]byte(out), &result); err != nil {
+		t.Fatalf("invalid JSON output: %v\noutput: %s", err, out)
+	}
+	if result["status"] != "cancelled" || result["id"] != "123" {
+		t.Errorf("unexpected JSON result: %+v", result)
+	}
+}
+
+func TestThreadsCancel_JSON_NotFound(t *testing.T) {
+	resetCmdFlags(t)
+	setupMockTM1(t, newCancelHandler(cancelHandlerOpts{
+		cancelStatus: http.StatusNotFound,
+	}))
+
+	var execErr error
+	cap := captureAll(t, func() {
+		rootCmd.SetArgs([]string{"threads", "cancel", "9999", "--yes", "--output", "json"})
+		execErr = rootCmd.Execute()
+	})
+
+	if !strings.Contains(cap.Stderr, `"error"`) || !strings.Contains(cap.Stderr, "Thread '9999' not found") {
+		t.Errorf("expected JSON-shaped error, got: %s", cap.Stderr)
+	}
+	var coded *silentErrCoded
+	if !errors.As(execErr, &coded) || coded.code != 3 {
+		t.Errorf("expected exit code 3, got: %v", execErr)
+	}
+}
+
+func TestThreadsCancel_JSON_PromptDoesNotCorruptStdout(t *testing.T) {
+	resetCmdFlags(t)
+	posts := 0
+	setupMockTM1(t, newCancelHandler(cancelHandlerOpts{posts: &posts}))
+	injectStdin(t, "y\n")
+
+	cap := captureAll(t, func() {
+		rootCmd.SetArgs([]string{"threads", "cancel", "123", "--output", "json"})
+		rootCmd.Execute()
+	})
+
+	if strings.Contains(cap.Stdout, "(y/N)") || strings.Contains(cap.Stdout, "Continue") {
+		t.Errorf("prompt text leaked onto stdout (corrupts JSON consumers): %q", cap.Stdout)
+	}
+	var result map[string]string
+	if err := json.Unmarshal([]byte(strings.TrimSpace(cap.Stdout)), &result); err != nil {
+		t.Fatalf("stdout is not clean JSON: %v\nstdout: %q", err, cap.Stdout)
+	}
+	if result["status"] != "cancelled" || result["id"] != "123" {
+		t.Errorf("unexpected JSON: %+v", result)
+	}
+	if posts != 1 {
+		t.Errorf("expected POST after accept, got %d", posts)
 	}
 }

--- a/cmd/threads_test.go
+++ b/cmd/threads_test.go
@@ -508,10 +508,10 @@ func TestThreadsCancel_DryRun(t *testing.T) {
 	gets := 0
 	getPaths := []string{}
 	setupMockTM1(t, newCancelHandler(cancelHandlerOpts{
-		thread:    &model.Thread{ID: 123, Name: "Admin", State: "Run", Function: "GET", ElapsedTime: 5.0},
-		posts:     &posts,
-		gets:      &gets,
-		getPaths:  &getPaths,
+		thread:   &model.Thread{ID: 123, Name: "Admin", State: "Run", Function: "GET", ElapsedTime: 5.0},
+		posts:    &posts,
+		gets:     &gets,
+		getPaths: &getPaths,
 	}))
 
 	cap := captureAll(t, func() {


### PR DESCRIPTION
## Summary
- Add `tm1cli threads cancel <id>` admin subcommand to cancel a running TM1 thread by ID. `POST /Threads('<id>')/tm1.CancelOperation`.
- Prompts for confirmation by default; `--yes` skips it for scripts; `--dry-run` looks up the thread server-side and previews what would be cancelled without sending the POST. `--dry-run` takes precedence over `--yes`.
- Exit code 3 reserved for "thread not found" so scripts can react specifically. Introduces `silentErrCoded`/`errExit`/`exitCodeForError` in `cmd/root.go` so future commands can signal custom exit codes through cobra without disturbing the existing `errSilent` (exit-1) sentinel.

Closes #76

## Test plan
- [x] `go test ./...` — 1155 passing across 6 packages
- [x] 14 new tests covering: success, 204 No Content, not-found (exit 3), permission denied (403), `--yes` bypass, prompt accept, prompt decline, dry-run with thread details, `--dry-run --yes` precedence, dry-run not-found, invalid ID, JSON success, JSON not-found, JSON+prompt stdout isolation
- [x] `go vet ./...` clean
- [x] `gofmt -d` clean for new hunks
- [ ] Manual smoke test against a live TM1 server (cancel a long-running thread; verify `--dry-run` shows thread details; verify exit code 3 on bogus ID)