### PR TITLE
feat(#81): server save-data — trigger SaveDataAll

### DIFF
--- a/cmd/server_savedata.go
+++ b/cmd/server_savedata.go
@@ -95,10 +95,12 @@ func runServerSaveData(cmd *cobra.Command, args []string) error {
 	}
 	cl.SetTimeout(saveDataTimeout)
 
-	start := time.Now().UTC()
+	// Use monotonic time for elapsed (NTP/clock-jump safe); UTC times are for display.
+	startMono := time.Now()
+	start := startMono.UTC()
 	_, err = cl.Post("SaveDataAll", nil)
-	end := time.Now().UTC()
-	elapsed := end.Sub(start)
+	elapsed := time.Since(startMono)
+	end := startMono.Add(elapsed).UTC()
 
 	if err != nil {
 		switch {

--- a/cmd/server_savedata.go
+++ b/cmd/server_savedata.go
@@ -22,9 +22,6 @@ var (
 
 const defaultSaveDataTimeout = 5 * time.Minute
 
-// SaveDataResult is the structured output emitted by `server save-data`.
-// Timestamps are stored as time.Time so the JSON encoder renders them as
-// RFC3339; the table renderer formats them on its own.
 type SaveDataResult struct {
 	Status    string    `json:"status"`
 	Start     time.Time `json:"start"`
@@ -84,9 +81,7 @@ func runServerSaveData(cmd *cobra.Command, args []string) error {
 	}
 
 	if !saveDataYes {
-		// Prompt always goes to stderr so JSON consumers keep stdout clean;
-		// if stdin is closed (script context with no --yes), promptYesNo
-		// returns false on EOF and we exit without making any HTTP calls.
+		// promptYesNo returns false on EOF, so a closed stdin (script with no --yes) declines safely.
 		fmt.Fprintln(os.Stderr, "SaveDataAll will briefly pause user activity on the TM1 server while data is flushed to disk.")
 		if !promptYesNo(bufio.NewReader(os.Stdin), "Continue?") {
 			return nil
@@ -117,8 +112,7 @@ func runServerSaveData(cmd *cobra.Command, args []string) error {
 		case strings.HasPrefix(err.Error(), "HTTP 403"):
 			output.PrintError("Permission denied. SaveDataAll requires admin privileges.", jsonMode)
 		default:
-			// 401 falls through here so the existing "Authentication failed"
-			// message bubbles up unchanged.
+			// 401 lands here so the existing "Authentication failed" message bubbles up unchanged.
 			output.PrintError(err.Error(), jsonMode)
 		}
 		return errSilent

--- a/cmd/server_savedata.go
+++ b/cmd/server_savedata.go
@@ -1,0 +1,161 @@
+package cmd
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+	"tm1cli/internal/client"
+	"tm1cli/internal/output"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	saveDataYes     bool
+	saveDataDryRun  bool
+	saveDataWait    bool
+	saveDataTimeout time.Duration
+)
+
+const defaultSaveDataTimeout = 5 * time.Minute
+
+// SaveDataResult is the structured output emitted by `server save-data`.
+// Timestamps are stored as time.Time so the JSON encoder renders them as
+// RFC3339; the table renderer formats them on its own.
+type SaveDataResult struct {
+	Status    string    `json:"status"`
+	Start     time.Time `json:"start"`
+	End       time.Time `json:"end"`
+	ElapsedMS int64     `json:"elapsed_ms"`
+	Elapsed   string    `json:"elapsed"`
+}
+
+var serverCmd = &cobra.Command{
+	Use:   "server",
+	Short: "Server-wide TM1 operations",
+	Long:  `Server-wide operations against the TM1 server (e.g. SaveDataAll).`,
+}
+
+var serverSaveDataCmd = &cobra.Command{
+	Use:   "save-data",
+	Short: "Trigger a server-wide SaveDataAll",
+	Long: `Trigger a server-wide SaveDataAll on the TM1 server.
+
+REST API: POST /SaveDataAll
+
+WARNING: SaveDataAll briefly pauses user activity on the server while the
+in-memory state is flushed to disk. On large models this can take several
+minutes. The command prompts for confirmation unless --yes is given.
+
+The TM1 SaveDataAll endpoint is synchronous: this command always waits for
+completion. Use --timeout to cap the wait (default 5m). The --wait flag is
+accepted for forward compatibility and is currently a no-op.`,
+	Example: `  tm1cli server save-data
+  tm1cli server save-data --yes
+  tm1cli server save-data --timeout 10m
+  tm1cli server save-data --dry-run
+  tm1cli server save-data --output json --yes`,
+	RunE: runServerSaveData,
+}
+
+func runServerSaveData(cmd *cobra.Command, args []string) error {
+	cfg, err := loadConfig()
+	if err != nil {
+		output.PrintError(err.Error(), isJSONOutput(nil))
+		return errSilent
+	}
+	jsonMode := isJSONOutput(cfg)
+
+	if saveDataTimeout <= 0 {
+		output.PrintError("--timeout must be greater than 0.", jsonMode)
+		return errSilent
+	}
+
+	if saveDataDryRun {
+		if jsonMode {
+			output.PrintJSON(map[string]string{"status": "dry-run"})
+		} else {
+			fmt.Println("[dry-run] Would POST /SaveDataAll.")
+		}
+		return nil
+	}
+
+	if !saveDataYes {
+		// Prompt always goes to stderr so JSON consumers keep stdout clean;
+		// if stdin is closed (script context with no --yes), promptYesNo
+		// returns false on EOF and we exit without making any HTTP calls.
+		fmt.Fprintln(os.Stderr, "SaveDataAll will briefly pause user activity on the TM1 server while data is flushed to disk.")
+		if !promptYesNo(bufio.NewReader(os.Stdin), "Continue?") {
+			return nil
+		}
+	}
+
+	cl, err := createClient(cfg)
+	if err != nil {
+		output.PrintError(err.Error(), jsonMode)
+		return errSilent
+	}
+	cl.SetTimeout(saveDataTimeout)
+
+	start := time.Now().UTC()
+	_, err = cl.Post("SaveDataAll", nil)
+	end := time.Now().UTC()
+	elapsed := end.Sub(start)
+
+	if err != nil {
+		switch {
+		case errors.Is(err, client.ErrTimeout):
+			output.PrintError(
+				fmt.Sprintf("SaveDataAll did not complete within %s. The save may still be in progress on the server.", saveDataTimeout),
+				jsonMode,
+			)
+		case errors.Is(err, client.ErrNotFound):
+			output.PrintError("SaveDataAll endpoint not found on this server.", jsonMode)
+		case strings.HasPrefix(err.Error(), "HTTP 403"):
+			output.PrintError("Permission denied. SaveDataAll requires admin privileges.", jsonMode)
+		default:
+			// 401 falls through here so the existing "Authentication failed"
+			// message bubbles up unchanged.
+			output.PrintError(err.Error(), jsonMode)
+		}
+		return errSilent
+	}
+
+	displaySaveDataResult(SaveDataResult{
+		Status:    "ok",
+		Start:     start,
+		End:       end,
+		ElapsedMS: elapsed.Milliseconds(),
+		Elapsed:   elapsed.Round(time.Millisecond).String(),
+	}, jsonMode)
+	return nil
+}
+
+func displaySaveDataResult(r SaveDataResult, jsonMode bool) {
+	if jsonMode {
+		output.PrintJSON(r)
+		return
+	}
+	output.PrintTable(
+		[]string{"PROPERTY", "VALUE"},
+		[][]string{
+			{"Status", r.Status},
+			{"Start", r.Start.Format(time.RFC3339)},
+			{"End", r.End.Format(time.RFC3339)},
+			{"Elapsed", r.Elapsed},
+		},
+	)
+}
+
+func init() {
+	rootCmd.AddCommand(serverCmd)
+	serverCmd.AddCommand(serverSaveDataCmd)
+
+	serverSaveDataCmd.Flags().BoolVar(&saveDataYes, "yes", false, "Skip confirmation prompt")
+	serverSaveDataCmd.Flags().BoolVar(&saveDataDryRun, "dry-run", false, "Preview without contacting the server")
+	serverSaveDataCmd.Flags().BoolVar(&saveDataWait, "wait", false, "Block on completion (currently always blocks; reserved for future async support)")
+	serverSaveDataCmd.Flags().DurationVar(&saveDataTimeout, "timeout", defaultSaveDataTimeout, "Maximum time to wait for SaveDataAll to complete")
+}

--- a/cmd/server_savedata_test.go
+++ b/cmd/server_savedata_test.go
@@ -115,9 +115,7 @@ func TestServerSaveData_TableOutput_Shape(t *testing.T) {
 
 func TestServerSaveData_JSONOutputContainsTimestamps(t *testing.T) {
 	resetCmdFlags(t)
-	setupMockTM1(t, newSaveDataHandler(saveDataHandlerOpts{
-		delay: 50 * time.Millisecond,
-	}))
+	setupMockTM1(t, newSaveDataHandler(saveDataHandlerOpts{}))
 
 	cap := captureAll(t, func() {
 		rootCmd.SetArgs([]string{"server", "save-data", "--yes", "--output", "json"})

--- a/cmd/server_savedata_test.go
+++ b/cmd/server_savedata_test.go
@@ -13,11 +13,11 @@ import (
 
 // saveDataHandlerOpts controls the per-test behavior of newSaveDataHandler.
 type saveDataHandlerOpts struct {
-	status        int           // status returned by POST /SaveDataAll (default 200)
-	delay         time.Duration // optional sleep before responding
-	postsCaptured *int32        // optional counter incremented on each POST hit
-	pathsCaptured *[]string     // optional capture of POST URL paths
-	bodiesCaptured *[][]byte    // optional capture of POST request bodies
+	status         int           // status returned by POST /SaveDataAll (default 200)
+	delay          time.Duration // optional sleep before responding
+	postsCaptured  *int32        // optional counter incremented on each POST hit
+	pathsCaptured  *[]string     // optional capture of POST URL paths
+	bodiesCaptured *[][]byte     // optional capture of POST request bodies
 }
 
 func newSaveDataHandler(opts saveDataHandlerOpts) http.HandlerFunc {

--- a/cmd/server_savedata_test.go
+++ b/cmd/server_savedata_test.go
@@ -1,0 +1,357 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// saveDataHandlerOpts controls the per-test behavior of newSaveDataHandler.
+type saveDataHandlerOpts struct {
+	status        int           // status returned by POST /SaveDataAll (default 200)
+	delay         time.Duration // optional sleep before responding
+	postsCaptured *int32        // optional counter incremented on each POST hit
+	pathsCaptured *[]string     // optional capture of POST URL paths
+	bodiesCaptured *[][]byte    // optional capture of POST request bodies
+}
+
+func newSaveDataHandler(opts saveDataHandlerOpts) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if !(r.Method == "POST" && strings.HasSuffix(r.URL.Path, "/SaveDataAll")) {
+			w.WriteHeader(http.StatusNotFound)
+			w.Write([]byte(`{"error":"unexpected route"}`))
+			return
+		}
+		if opts.postsCaptured != nil {
+			atomic.AddInt32(opts.postsCaptured, 1)
+		}
+		if opts.pathsCaptured != nil {
+			*opts.pathsCaptured = append(*opts.pathsCaptured, r.URL.Path)
+		}
+		if opts.bodiesCaptured != nil {
+			body, _ := io.ReadAll(r.Body)
+			*opts.bodiesCaptured = append(*opts.bodiesCaptured, body)
+		}
+		if opts.delay > 0 {
+			time.Sleep(opts.delay)
+		}
+		status := opts.status
+		if status == 0 {
+			status = http.StatusOK
+		}
+		w.WriteHeader(status)
+		if status == http.StatusNoContent {
+			return
+		}
+		w.Write([]byte(`{}`))
+	}
+}
+
+func TestServerSaveData_Success(t *testing.T) {
+	resetCmdFlags(t)
+	var posts int32
+	paths := []string{}
+	setupMockTM1(t, newSaveDataHandler(saveDataHandlerOpts{
+		postsCaptured: &posts,
+		pathsCaptured: &paths,
+	}))
+
+	cap := captureAll(t, func() {
+		rootCmd.SetArgs([]string{"server", "save-data", "--yes"})
+		rootCmd.Execute()
+	})
+
+	if got := atomic.LoadInt32(&posts); got != 1 {
+		t.Errorf("expected 1 POST, got %d", got)
+	}
+	if len(paths) != 1 || !strings.HasSuffix(paths[0], "/SaveDataAll") {
+		t.Errorf("expected POST path ending /SaveDataAll, got: %v", paths)
+	}
+	if !strings.Contains(cap.Stdout, "Status") || !strings.Contains(cap.Stdout, "ok") {
+		t.Errorf("expected Status / ok in stdout, got: %s", cap.Stdout)
+	}
+}
+
+func TestServerSaveData_RequestBodyIsEmpty(t *testing.T) {
+	resetCmdFlags(t)
+	bodies := [][]byte{}
+	setupMockTM1(t, newSaveDataHandler(saveDataHandlerOpts{
+		bodiesCaptured: &bodies,
+	}))
+
+	captureAll(t, func() {
+		rootCmd.SetArgs([]string{"server", "save-data", "--yes"})
+		rootCmd.Execute()
+	})
+
+	if len(bodies) != 1 {
+		t.Fatalf("expected 1 captured body, got %d", len(bodies))
+	}
+	if len(bodies[0]) != 0 {
+		t.Errorf("expected zero-length POST body, got %d bytes: %q", len(bodies[0]), string(bodies[0]))
+	}
+}
+
+func TestServerSaveData_TableOutput_Shape(t *testing.T) {
+	resetCmdFlags(t)
+	setupMockTM1(t, newSaveDataHandler(saveDataHandlerOpts{}))
+
+	cap := captureAll(t, func() {
+		rootCmd.SetArgs([]string{"server", "save-data", "--yes"})
+		rootCmd.Execute()
+	})
+
+	for _, want := range []string{"PROPERTY", "VALUE", "Status", "Start", "End", "Elapsed"} {
+		if !strings.Contains(cap.Stdout, want) {
+			t.Errorf("table output missing %q\nstdout: %s", want, cap.Stdout)
+		}
+	}
+}
+
+func TestServerSaveData_JSONOutputContainsTimestamps(t *testing.T) {
+	resetCmdFlags(t)
+	setupMockTM1(t, newSaveDataHandler(saveDataHandlerOpts{
+		delay: 50 * time.Millisecond,
+	}))
+
+	cap := captureAll(t, func() {
+		rootCmd.SetArgs([]string{"server", "save-data", "--yes", "--output", "json"})
+		rootCmd.Execute()
+	})
+
+	var got struct {
+		Status    string    `json:"status"`
+		Start     time.Time `json:"start"`
+		End       time.Time `json:"end"`
+		ElapsedMS int64     `json:"elapsed_ms"`
+		Elapsed   string    `json:"elapsed"`
+	}
+	if err := json.Unmarshal([]byte(cap.Stdout), &got); err != nil {
+		t.Fatalf("stdout is not valid JSON: %v\nstdout: %s", err, cap.Stdout)
+	}
+	if got.Status != "ok" {
+		t.Errorf("status = %q, want %q", got.Status, "ok")
+	}
+	if got.Start.IsZero() || got.End.IsZero() {
+		t.Errorf("expected non-zero timestamps, start=%v end=%v", got.Start, got.End)
+	}
+	if got.ElapsedMS < 0 {
+		t.Errorf("elapsed_ms = %d, want >= 0", got.ElapsedMS)
+	}
+	if got.Elapsed == "" {
+		t.Errorf("expected non-empty elapsed string")
+	}
+}
+
+func TestServerSaveData_DryRunMakesNoHTTPCalls(t *testing.T) {
+	resetCmdFlags(t)
+	httpCalls := 0
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		httpCalls++
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	cap := captureAll(t, func() {
+		rootCmd.SetArgs([]string{"server", "save-data", "--dry-run"})
+		rootCmd.Execute()
+	})
+
+	if httpCalls != 0 {
+		t.Errorf("expected 0 HTTP calls on --dry-run, got %d", httpCalls)
+	}
+	if !strings.Contains(cap.Stdout, "[dry-run] Would POST /SaveDataAll.") {
+		t.Errorf("expected dry-run preview, got: %s", cap.Stdout)
+	}
+}
+
+func TestServerSaveData_PromptDecline(t *testing.T) {
+	resetCmdFlags(t)
+	var posts int32
+	setupMockTM1(t, newSaveDataHandler(saveDataHandlerOpts{
+		postsCaptured: &posts,
+	}))
+	injectStdin(t, "n\n")
+
+	cap := captureAll(t, func() {
+		rootCmd.SetArgs([]string{"server", "save-data"})
+		rootCmd.Execute()
+	})
+
+	if got := atomic.LoadInt32(&posts); got != 0 {
+		t.Errorf("expected zero POSTs after decline, got %d", got)
+	}
+	if !strings.Contains(cap.Stderr, "pause user activity") {
+		t.Errorf("expected pause warning in stderr, got: %s", cap.Stderr)
+	}
+}
+
+func TestServerSaveData_PromptAccept(t *testing.T) {
+	resetCmdFlags(t)
+	var posts int32
+	setupMockTM1(t, newSaveDataHandler(saveDataHandlerOpts{
+		postsCaptured: &posts,
+	}))
+	injectStdin(t, "y\n")
+
+	cap := captureAll(t, func() {
+		rootCmd.SetArgs([]string{"server", "save-data"})
+		rootCmd.Execute()
+	})
+
+	if got := atomic.LoadInt32(&posts); got != 1 {
+		t.Errorf("expected 1 POST after accept, got %d", got)
+	}
+	if !strings.Contains(cap.Stdout, "Status") {
+		t.Errorf("expected success row in stdout, got: %s", cap.Stdout)
+	}
+}
+
+func TestServerSaveData_PromptOnClosedStdin_Declines(t *testing.T) {
+	resetCmdFlags(t)
+	var posts int32
+	setupMockTM1(t, newSaveDataHandler(saveDataHandlerOpts{
+		postsCaptured: &posts,
+	}))
+	injectStdin(t, "")
+
+	captureAll(t, func() {
+		rootCmd.SetArgs([]string{"server", "save-data"})
+		rootCmd.Execute()
+	})
+
+	if got := atomic.LoadInt32(&posts); got != 0 {
+		t.Errorf("expected zero POSTs on closed stdin, got %d", got)
+	}
+}
+
+func TestServerSaveData_PermissionDenied(t *testing.T) {
+	resetCmdFlags(t)
+	setupMockTM1(t, newSaveDataHandler(saveDataHandlerOpts{
+		status: http.StatusForbidden,
+	}))
+
+	cap := captureAll(t, func() {
+		rootCmd.SetArgs([]string{"server", "save-data", "--yes"})
+		rootCmd.Execute()
+	})
+
+	if !strings.Contains(cap.Stderr, "Permission denied") || !strings.Contains(cap.Stderr, "admin privileges") {
+		t.Errorf("expected permission denied message in stderr, got: %s", cap.Stderr)
+	}
+}
+
+func TestServerSaveData_AuthFailureBubbles(t *testing.T) {
+	resetCmdFlags(t)
+	setupMockTM1(t, newSaveDataHandler(saveDataHandlerOpts{
+		status: http.StatusUnauthorized,
+	}))
+
+	cap := captureAll(t, func() {
+		rootCmd.SetArgs([]string{"server", "save-data", "--yes"})
+		rootCmd.Execute()
+	})
+
+	if !strings.Contains(cap.Stderr, "Authentication failed") {
+		t.Errorf("expected 'Authentication failed' in stderr, got: %s", cap.Stderr)
+	}
+}
+
+func TestServerSaveData_Timeout(t *testing.T) {
+	resetCmdFlags(t)
+	setupMockTM1(t, newSaveDataHandler(saveDataHandlerOpts{
+		delay: 200 * time.Millisecond,
+	}))
+
+	cap := captureAll(t, func() {
+		rootCmd.SetArgs([]string{"server", "save-data", "--yes", "--timeout", "50ms"})
+		rootCmd.Execute()
+	})
+
+	if !strings.Contains(cap.Stderr, "did not complete within 50ms") {
+		t.Errorf("expected timeout message in stderr, got: %s", cap.Stderr)
+	}
+}
+
+func TestServerSaveData_RejectsZeroTimeout(t *testing.T) {
+	resetCmdFlags(t)
+	httpCalls := 0
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		httpCalls++
+		w.WriteHeader(http.StatusOK)
+	})
+
+	cap := captureAll(t, func() {
+		rootCmd.SetArgs([]string{"server", "save-data", "--yes", "--timeout", "0"})
+		rootCmd.Execute()
+	})
+
+	if httpCalls != 0 {
+		t.Errorf("expected 0 HTTP calls, got %d", httpCalls)
+	}
+	if !strings.Contains(cap.Stderr, "--timeout must be greater than 0") {
+		t.Errorf("expected timeout-zero error in stderr, got: %s", cap.Stderr)
+	}
+}
+
+func TestServerSaveData_NotFound(t *testing.T) {
+	resetCmdFlags(t)
+	setupMockTM1(t, newSaveDataHandler(saveDataHandlerOpts{
+		status: http.StatusNotFound,
+	}))
+
+	cap := captureAll(t, func() {
+		rootCmd.SetArgs([]string{"server", "save-data", "--yes"})
+		rootCmd.Execute()
+	})
+
+	if !strings.Contains(cap.Stderr, "SaveDataAll endpoint not found") {
+		t.Errorf("expected not-found message in stderr, got: %s", cap.Stderr)
+	}
+}
+
+func TestServerSaveData_WaitFlagAccepted(t *testing.T) {
+	resetCmdFlags(t)
+	var posts int32
+	setupMockTM1(t, newSaveDataHandler(saveDataHandlerOpts{
+		postsCaptured: &posts,
+	}))
+
+	cap := captureAll(t, func() {
+		rootCmd.SetArgs([]string{"server", "save-data", "--yes", "--wait"})
+		rootCmd.Execute()
+	})
+
+	if got := atomic.LoadInt32(&posts); got != 1 {
+		t.Errorf("expected 1 POST with --wait set, got %d", got)
+	}
+	if !strings.Contains(cap.Stdout, "Status") {
+		t.Errorf("expected success output, got: %s", cap.Stdout)
+	}
+}
+
+func TestServerSaveData_Help_MentionsPause(t *testing.T) {
+	resetCmdFlags(t)
+	var buf bytes.Buffer
+	rootCmd.SetOut(&buf)
+	rootCmd.SetErr(&buf)
+	defer func() {
+		rootCmd.SetOut(nil)
+		rootCmd.SetErr(nil)
+	}()
+
+	rootCmd.SetArgs([]string{"server", "save-data", "--help"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("--help returned error: %v", err)
+	}
+	out := buf.String()
+	for _, want := range []string{"pause", "WARNING"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("--help output missing %q\noutput: %s", want, out)
+		}
+	}
+}

--- a/cmd/testhelpers_test.go
+++ b/cmd/testhelpers_test.go
@@ -252,6 +252,10 @@ func zeroAllFlags() {
 	sessionsAll = false
 	sessionsCloseYes = false
 	sessionsCloseDryRun = false
+	saveDataYes = false
+	saveDataDryRun = false
+	saveDataWait = false
+	saveDataTimeout = defaultSaveDataTimeout
 }
 
 // cubesJSON returns JSON for a TM1 Cubes response.

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -202,7 +202,6 @@ func (c *Client) wrapError(err error) error {
 	return fmt.Errorf("Connection error: %s", errStr)
 }
 
-
 func (c *Client) httpError(status int, body []byte, endpoint string) error {
 	switch status {
 	case 401:

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -20,9 +20,7 @@ import (
 // ErrNotFound is returned when the TM1 server responds with HTTP 404.
 var ErrNotFound = errors.New("not found")
 
-// ErrTimeout is wrapped into the error returned when the underlying HTTP
-// request exceeds the client's configured timeout. Callers can detect it
-// with errors.Is for clean dispatch on long-running operations.
+// ErrTimeout is wrapped into timeout errors so callers can dispatch with errors.Is.
 var ErrTimeout = errors.New("timeout")
 
 const defaultTimeout = 30 * time.Second
@@ -36,7 +34,6 @@ type Client struct {
 	namespace  string
 	verbose    bool
 	stderr     io.Writer
-	timeout    time.Duration
 }
 
 func NewClient(server config.ServerConfig, password string, tlsVerify bool, verbose bool) (*Client, error) {
@@ -75,18 +72,15 @@ func NewClient(server config.ServerConfig, password string, tlsVerify bool, verb
 		namespace:  server.Namespace,
 		verbose:    verbose,
 		stderr:     os.Stderr,
-		timeout:    defaultTimeout,
 	}, nil
 }
 
-// SetTimeout overrides the per-request HTTP timeout for subsequent calls.
-// Long-running operations (e.g. SaveDataAll) need a longer window than the
-// 30s default. Non-positive values are ignored.
+// SetTimeout overrides the per-request HTTP timeout. Non-positive values are
+// ignored. Long-running operations (e.g. SaveDataAll) extend past the 30s default.
 func (c *Client) SetTimeout(d time.Duration) {
 	if d <= 0 {
 		return
 	}
-	c.timeout = d
 	c.httpClient.Timeout = d
 }
 
@@ -197,7 +191,7 @@ func (c *Client) wrapError(err error) error {
 	errStr := err.Error()
 
 	if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
-		return fmt.Errorf("Request timed out after %s: %w", formatTimeout(c.timeout), ErrTimeout)
+		return fmt.Errorf("Request timed out after %s: %w", c.httpClient.Timeout, ErrTimeout)
 	}
 	if strings.Contains(errStr, "connection refused") {
 		return fmt.Errorf("Cannot connect to %s. Is TM1 server running?", c.baseURL)
@@ -208,21 +202,6 @@ func (c *Client) wrapError(err error) error {
 	return fmt.Errorf("Connection error: %s", errStr)
 }
 
-// formatTimeout renders a duration the way the user would type it on the
-// CLI, falling back to time.Duration.String for sub-second or compound
-// values. Used to keep error messages and --timeout values in sync.
-func formatTimeout(d time.Duration) string {
-	if d <= 0 {
-		return "0s"
-	}
-	if d%time.Minute == 0 {
-		return fmt.Sprintf("%dm", int(d/time.Minute))
-	}
-	if d%time.Second == 0 {
-		return fmt.Sprintf("%ds", int(d/time.Second))
-	}
-	return d.String()
-}
 
 func (c *Client) httpError(status int, body []byte, endpoint string) error {
 	switch status {

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -20,6 +20,13 @@ import (
 // ErrNotFound is returned when the TM1 server responds with HTTP 404.
 var ErrNotFound = errors.New("not found")
 
+// ErrTimeout is wrapped into the error returned when the underlying HTTP
+// request exceeds the client's configured timeout. Callers can detect it
+// with errors.Is for clean dispatch on long-running operations.
+var ErrTimeout = errors.New("timeout")
+
+const defaultTimeout = 30 * time.Second
+
 type Client struct {
 	httpClient *http.Client
 	baseURL    string
@@ -29,6 +36,7 @@ type Client struct {
 	namespace  string
 	verbose    bool
 	stderr     io.Writer
+	timeout    time.Duration
 }
 
 func NewClient(server config.ServerConfig, password string, tlsVerify bool, verbose bool) (*Client, error) {
@@ -50,7 +58,7 @@ func NewClient(server config.ServerConfig, password string, tlsVerify bool, verb
 	httpClient := &http.Client{
 		Jar:       jar,
 		Transport: transport,
-		Timeout:   30 * time.Second,
+		Timeout:   defaultTimeout,
 	}
 
 	baseURL := strings.TrimRight(server.URL, "/")
@@ -67,7 +75,19 @@ func NewClient(server config.ServerConfig, password string, tlsVerify bool, verb
 		namespace:  server.Namespace,
 		verbose:    verbose,
 		stderr:     os.Stderr,
+		timeout:    defaultTimeout,
 	}, nil
+}
+
+// SetTimeout overrides the per-request HTTP timeout for subsequent calls.
+// Long-running operations (e.g. SaveDataAll) need a longer window than the
+// 30s default. Non-positive values are ignored.
+func (c *Client) SetTimeout(d time.Duration) {
+	if d <= 0 {
+		return
+	}
+	c.timeout = d
+	c.httpClient.Timeout = d
 }
 
 // SetStderr overrides stderr output (for testing).
@@ -177,7 +197,7 @@ func (c *Client) wrapError(err error) error {
 	errStr := err.Error()
 
 	if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
-		return fmt.Errorf("Request timed out after 30s.")
+		return fmt.Errorf("Request timed out after %s: %w", formatTimeout(c.timeout), ErrTimeout)
 	}
 	if strings.Contains(errStr, "connection refused") {
 		return fmt.Errorf("Cannot connect to %s. Is TM1 server running?", c.baseURL)
@@ -186,6 +206,22 @@ func (c *Client) wrapError(err error) error {
 		return fmt.Errorf("Cannot connect to %s. Is TM1 server running?", c.baseURL)
 	}
 	return fmt.Errorf("Connection error: %s", errStr)
+}
+
+// formatTimeout renders a duration the way the user would type it on the
+// CLI, falling back to time.Duration.String for sub-second or compound
+// values. Used to keep error messages and --timeout values in sync.
+func formatTimeout(d time.Duration) string {
+	if d <= 0 {
+		return "0s"
+	}
+	if d%time.Minute == 0 {
+		return fmt.Sprintf("%dm", int(d/time.Minute))
+	}
+	if d%time.Second == 0 {
+		return fmt.Sprintf("%ds", int(d/time.Second))
+	}
+	return d.String()
 }
 
 func (c *Client) httpError(status int, body []byte, endpoint string) error {

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -231,9 +231,6 @@ func TestGetTimeout(t *testing.T) {
 func TestSetTimeout_UpdatesClientTimeout(t *testing.T) {
 	c := newTestClient(t, "http://example.com")
 	c.SetTimeout(2 * time.Second)
-	if c.timeout != 2*time.Second {
-		t.Errorf("c.timeout = %v, want 2s", c.timeout)
-	}
 	if c.httpClient.Timeout != 2*time.Second {
 		t.Errorf("c.httpClient.Timeout = %v, want 2s", c.httpClient.Timeout)
 	}

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -3,6 +3,7 @@ package client
 import (
 	"bytes"
 	"encoding/base64"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -224,6 +225,69 @@ func TestGetTimeout(t *testing.T) {
 	}
 	if !strings.Contains(getErr.Error(), "timed out") {
 		t.Errorf("error = %q, want it to contain 'timed out'", getErr.Error())
+	}
+}
+
+func TestSetTimeout_UpdatesClientTimeout(t *testing.T) {
+	c := newTestClient(t, "http://example.com")
+	c.SetTimeout(2 * time.Second)
+	if c.timeout != 2*time.Second {
+		t.Errorf("c.timeout = %v, want 2s", c.timeout)
+	}
+	if c.httpClient.Timeout != 2*time.Second {
+		t.Errorf("c.httpClient.Timeout = %v, want 2s", c.httpClient.Timeout)
+	}
+}
+
+func TestSetTimeout_IgnoresNonPositive(t *testing.T) {
+	c := newTestClient(t, "http://example.com")
+	original := c.httpClient.Timeout
+
+	c.SetTimeout(0)
+	if c.httpClient.Timeout != original {
+		t.Errorf("SetTimeout(0) changed timeout to %v, want unchanged %v", c.httpClient.Timeout, original)
+	}
+	c.SetTimeout(-time.Second)
+	if c.httpClient.Timeout != original {
+		t.Errorf("SetTimeout(-1s) changed timeout to %v, want unchanged %v", c.httpClient.Timeout, original)
+	}
+}
+
+func TestTimeoutErrorReflectsConfiguredTimeout(t *testing.T) {
+	ts := newTestServer(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(200 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+	})
+	defer ts.Close()
+
+	c := newTestClient(t, ts.URL)
+	c.SetTimeout(50 * time.Millisecond)
+
+	_, err := c.Get("Cubes")
+	if err == nil {
+		t.Fatal("expected timeout error, got nil")
+	}
+	if !strings.Contains(err.Error(), "timed out after 50ms") {
+		t.Errorf("error = %q, want it to contain 'timed out after 50ms'", err.Error())
+	}
+}
+
+func TestTimeoutErrorIsErrTimeout(t *testing.T) {
+	ts := newTestServer(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(200 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+	})
+	defer ts.Close()
+
+	c := newTestClient(t, ts.URL)
+	c.SetTimeout(50 * time.Millisecond)
+
+	_, err := c.Get("Cubes")
+	if err == nil {
+		t.Fatal("expected timeout error, got nil")
+	}
+	if !errors.Is(err, ErrTimeout) {
+		t.Errorf("errors.Is(err, ErrTimeout) = false, want true (err = %v)", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Adds `tm1cli server save-data` (under a new `server` parent command) to trigger `POST /SaveDataAll`, flushing in-memory TM1 state to disk
- Interactive confirmation (skippable with `--yes`) warns about the user-visible pause; supports `--dry-run`, `--timeout` (default 5m), and `--wait` (documented forward-compat no-op since the TM1 endpoint is synchronous)
- Output: PROPERTY/VALUE table by default, structured JSON with `status`/`start`/`end`/`elapsed_ms`/`elapsed` when `--output json`

Supporting client changes:
- `client.ErrTimeout` sentinel for clean `errors.Is` dispatch
- `client.SetTimeout(d)` to override the 30s default per-command
- Dynamic timeout error message (uses configured timeout, not hardcoded "30s")
- Elapsed measurement uses monotonic clock (NTP/clock-jump safe)

## Test plan
- [x] `go build ./...` clean
- [x] `go test ./...` — 1,174 passed across 6 packages
- [x] 15 new integration tests in `cmd/server_savedata_test.go` cover success, JSON timestamp shape, table shape, dry-run zero-HTTP, prompt accept/decline/closed-stdin, 401/403/404, custom timeout, zero-timeout rejection, `--wait` acceptance, empty request body, and `--help` warning text
- [x] 3 new unit tests in `internal/client/client_test.go` cover `SetTimeout`, ignored non-positive values, dynamic timeout error message, and `errors.Is(err, ErrTimeout)`

Closes #81