### PR TITLE
chore: bump Makefile version to 0.5.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION := 0.4.0
+VERSION := 0.5.0
 
 build:
 	go build -ldflags "-X tm1cli/cmd.Version=$(VERSION)" -o tm1cli


### PR DESCRIPTION
Bumps `Makefile` `VERSION` from 0.4.0 to 0.5.0 following the v0.5.0 release.

A matching PR will be opened against `main` so both branches stay in sync.