### PR TITLE
chore: bump Makefile version to 0.5.0 (main)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION := 0.4.0
+VERSION := 0.5.0
 
 build:
 	go build -ldflags "-X tm1cli/cmd.Version=$(VERSION)" -o tm1cli


### PR DESCRIPTION
Bumps `Makefile` `VERSION` from 0.4.0 to 0.5.0 on `main` following the v0.5.0 release.

Sister PR for `dev`: #120