### PR TITLE
feat(#82): add chores list and show commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,25 @@ tm1cli threads list --all                 # no 50-row limit
 tm1cli threads list --output json         # full 14-field JSON output
 ```
 
+### Chores
+
+```bash
+tm1cli chores list                        # list user chores (system chores hidden by default)
+tm1cli chores list --active               # only active chores
+tm1cli chores list --inactive             # only inactive chores
+tm1cli chores list --filter "load"        # filter by name (partial, case-insensitive)
+tm1cli chores list --show-system          # include system chores (names starting with })
+tm1cli chores list --all                  # no 50-row limit
+tm1cli chores list --output json          # raw chore objects (Frequency stays as ISO 8601)
+
+tm1cli chores show "DailyLoad"            # step-by-step task list with parameters
+tm1cli chores show "DailyLoad" --output json
+```
+
+`Frequency` is rendered human-readable in table mode (e.g. `P1DT0H0M0S` →
+`Every 1 day`); JSON preserves the raw ISO 8601 duration. `chores show`
+exits with code 3 when the named chore does not exist.
+
 ### Logs
 
 ```bash

--- a/cmd/chores.go
+++ b/cmd/chores.go
@@ -65,7 +65,7 @@ Exit codes:
 // odataKey escapes a TM1 entity name for OData URL keys: doubles single
 // quotes per the OData literal spec, then URL-path-escapes for transport.
 func odataKey(name string) string {
-	return url.PathEscape(strings.ReplaceAll(name, "'", "''"))
+	return url.PathEscape(odataEscape(name))
 }
 
 // formatChoreFrequency converts ISO 8601 duration strings (e.g. "P1D",
@@ -196,9 +196,10 @@ func runChoresList(cmd *cobra.Command, args []string) error {
 
 	const base = "Chores?$select=Name,Active,StartTime,DSTSensitivity,Frequency&$expand=Tasks($select=Step)"
 
-	chores, err := fetchChores(cl, base, choresFilter, jsonMode)
+	chores, err := fetchChores(cl, base, choresFilter)
 	if err != nil {
-		return err
+		output.PrintError(err.Error(), jsonMode)
+		return errSilent
 	}
 
 	chores = filterChoresByActive(chores, choresActive, choresInactive)
@@ -207,20 +208,15 @@ func runChoresList(cmd *cobra.Command, args []string) error {
 }
 
 // fetchChores tries server-side $filter first, falling back to client-side
-// filtering with a [warn] when the server rejects the filter.
-func fetchChores(cl *client.Client, base, filter string, jsonMode bool) ([]model.Chore, error) {
+// filtering with a [warn] when the server rejects the filter. Returns the raw
+// fetch error so the caller controls how it's reported.
+func fetchChores(cl *client.Client, base, filter string) ([]model.Chore, error) {
 	if filter == "" {
-		chores, err := getChores(cl, base)
-		if err != nil {
-			output.PrintError(err.Error(), jsonMode)
-			return nil, errSilent
-		}
-		return chores, nil
+		return getChores(cl, base)
 	}
 
-	safe := strings.ReplaceAll(filter, "'", "''")
 	v := url.Values{}
-	v.Set("$filter", fmt.Sprintf("contains(tolower(Name),tolower('%s'))", safe))
+	v.Set("$filter", fmt.Sprintf("contains(tolower(Name),tolower('%s'))", odataEscape(filter)))
 	if chores, err := getChores(cl, base+"&"+v.Encode()); err == nil {
 		return chores, nil
 	}
@@ -228,8 +224,7 @@ func fetchChores(cl *client.Client, base, filter string, jsonMode bool) ([]model
 	output.PrintWarning("Server-side filter not supported, filtering locally...")
 	chores, err := getChores(cl, base)
 	if err != nil {
-		output.PrintError(err.Error(), jsonMode)
-		return nil, errSilent
+		return nil, err
 	}
 	return filterChoresByName(chores, filter), nil
 }

--- a/cmd/chores.go
+++ b/cmd/chores.go
@@ -215,11 +215,13 @@ func runChoresList(cmd *cobra.Command, args []string) error {
 
 	const base = "Chores?$select=Name,Active,StartTime,DSTSensitive,Frequency&$expand=Tasks($select=Step)"
 
-	// $top is only safe to apply server-side when no client-side filters
-	// will further trim results — otherwise we may silently omit matches.
+	// Match cubes/dims: only --filter forces a full fetch (server-side
+	// $filter may not be honored, requiring client-side substring matching
+	// over the complete set). The +500 cushion absorbs --show-system /
+	// --active / --inactive client-side trimming so they don't silently lose
+	// matches at the truncation boundary.
 	fetchEndpoint := base
-	clientSideFilters := choresFilter != "" || !showSystem || choresActive || choresInactive
-	if limit > 0 && !clientSideFilters {
+	if limit > 0 && choresFilter == "" {
 		fetchEndpoint = fmt.Sprintf("%s&$top=%d", base, limit+500)
 	}
 

--- a/cmd/chores.go
+++ b/cmd/chores.go
@@ -213,7 +213,7 @@ func runChoresList(cmd *cobra.Command, args []string) error {
 	showSystem := getShowSystem(cfg, choresShowSystem)
 	limit := getLimit(cfg, choresLimit, choresAll)
 
-	const base = "Chores?$select=Name,Active,StartTime,DSTSensitivity,Frequency&$expand=Tasks($select=Step)"
+	const base = "Chores?$select=Name,Active,StartTime,DSTSensitive,Frequency&$expand=Tasks($select=Step)"
 
 	// $top is only safe to apply server-side when no client-side filters
 	// will further trim results — otherwise we may silently omit matches.
@@ -322,14 +322,14 @@ func displayChores(chores []model.Chore, limit int, jsonMode bool) {
 		output.PrintJSON(shown)
 		return
 	}
-	headers := []string{"NAME", "ACTIVE", "STARTTIME", "DSTSENSITIVITY", "FREQUENCY", "TASKS"}
+	headers := []string{"NAME", "ACTIVE", "STARTTIME", "DSTSENSITIVE", "FREQUENCY", "TASKS"}
 	rows := make([][]string, len(shown))
 	for i, c := range shown {
 		rows[i] = []string{
 			c.Name,
 			strconv.FormatBool(c.Active),
 			c.StartTime,
-			strconv.FormatBool(c.DSTSensitivity),
+			strconv.FormatBool(c.DSTSensitive),
 			formatChoreFrequency(c.Frequency),
 			strconv.Itoa(len(c.Tasks)),
 		}
@@ -382,7 +382,7 @@ func runChoresShow(cmd *cobra.Command, args []string) error {
 	fmt.Printf("Name:           %s\n", chore.Name)
 	fmt.Printf("Active:         %s\n", strconv.FormatBool(chore.Active))
 	fmt.Printf("StartTime:      %s\n", chore.StartTime)
-	fmt.Printf("DSTSensitivity: %s\n", strconv.FormatBool(chore.DSTSensitivity))
+	fmt.Printf("DSTSensitive:   %s\n", strconv.FormatBool(chore.DSTSensitive))
 	fmt.Printf("Frequency:      %s\n", formatChoreFrequency(chore.Frequency))
 	fmt.Println()
 

--- a/cmd/chores.go
+++ b/cmd/chores.go
@@ -187,8 +187,10 @@ func runChoresList(cmd *cobra.Command, args []string) error {
 		return errSilent
 	}
 
-	// Belt-and-suspenders: cobra's MarkFlagsMutuallyExclusive may not fire
-	// when RunE is invoked directly in tests, so guard at runtime too.
+	// --active and --inactive are mutually exclusive. We enforce this at
+	// runtime instead of cobra.MarkFlagsMutuallyExclusive because pflag.Changed
+	// leaks across rootCmd.Execute() calls in the test harness, which makes
+	// the cobra-side check trip on flags that were "set" in a prior test.
 	if choresActive && choresInactive {
 		output.PrintError("--active and --inactive are mutually exclusive.", jsonMode)
 		return errSilent

--- a/cmd/chores.go
+++ b/cmd/chores.go
@@ -1,0 +1,378 @@
+package cmd
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/url"
+	"sort"
+	"strconv"
+	"strings"
+	"tm1cli/internal/client"
+	"tm1cli/internal/model"
+	"tm1cli/internal/output"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	choresFilter   string
+	choresActive   bool
+	choresInactive bool
+)
+
+var choresCmd = &cobra.Command{
+	Use:   "chores",
+	Short: "View TM1 chores and schedules",
+	Long:  `View TM1 chores (scheduled task chains) and their step-by-step task lists.`,
+}
+
+var choresListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List all chores",
+	Long: `List all chores on the TM1 server.
+
+REST API: GET /Chores
+
+Frequency is rendered human-readable in table mode (e.g. "Every 1 day"); JSON
+mode preserves the raw ISO 8601 duration so it remains machine-readable.`,
+	Example: `  tm1cli chores list
+  tm1cli chores list --active
+  tm1cli chores list --filter "load"
+  tm1cli chores list --output json`,
+	RunE: runChoresList,
+}
+
+var choresShowCmd = &cobra.Command{
+	Use:   "show <name>",
+	Short: "Show a chore's task list",
+	Long: `Show the step-by-step task list for a chore: each step's process and parameters.
+
+REST API: GET /Chores('name')?$expand=Tasks($expand=Process,Parameters)
+
+Tasks are sorted by step number ascending. JSON mode returns the raw chore object.
+
+Exit codes:
+  0  chore found and displayed
+  1  generic error (auth, network, server)
+  3  chore not found`,
+	Example: `  tm1cli chores show "DailyLoad"
+  tm1cli chores show "DailyLoad" --output json`,
+	Args: cobra.ExactArgs(1),
+	RunE: runChoresShow,
+}
+
+// odataKey escapes a TM1 entity name for OData URL keys: doubles single
+// quotes per the OData literal spec, then URL-path-escapes for transport.
+func odataKey(name string) string {
+	return url.PathEscape(strings.ReplaceAll(name, "'", "''"))
+}
+
+// formatChoreFrequency converts ISO 8601 duration strings (e.g. "P1D",
+// "P1DT0H0M0S", "PT30M") into human-readable phrases. Returns the original
+// string on any parse failure (e.g. "P1W", "P1Y", "P1DT") so callers always
+// see meaningful output.
+func formatChoreFrequency(s string) string {
+	days, hours, minutes, seconds, ok := parseISO8601Duration(s)
+	if !ok {
+		return s
+	}
+	var parts []string
+	if days != 0 {
+		parts = append(parts, plural(days, "day"))
+	}
+	if hours != 0 {
+		parts = append(parts, plural(hours, "hour"))
+	}
+	if minutes != 0 {
+		parts = append(parts, plural(minutes, "minute"))
+	}
+	if seconds != 0 {
+		parts = append(parts, plural(seconds, "second"))
+	}
+	if len(parts) == 0 {
+		return "Every 0 seconds"
+	}
+	return "Every " + strings.Join(parts, " ")
+}
+
+// parseISO8601Duration parses the subset P[nD][T[nH][nM][nS]] used by TM1
+// chore frequencies. Returns ok=false for unsupported designators (Y, W,
+// month-M before T) or malformed input.
+func parseISO8601Duration(s string) (days, hours, minutes, seconds int, ok bool) {
+	if len(s) < 2 || s[0] != 'P' {
+		return 0, 0, 0, 0, false
+	}
+	rest := s[1:]
+	var datePart, timePart string
+	if i := strings.Index(rest, "T"); i >= 0 {
+		datePart = rest[:i]
+		timePart = rest[i+1:]
+		if timePart == "" {
+			return 0, 0, 0, 0, false
+		}
+	} else {
+		datePart = rest
+	}
+	if datePart != "" {
+		n, designator, remaining, parseOk := nextDurationField(datePart)
+		if !parseOk || designator != 'D' || remaining != "" {
+			return 0, 0, 0, 0, false
+		}
+		days = n
+	}
+	for timePart != "" {
+		n, designator, remaining, parseOk := nextDurationField(timePart)
+		if !parseOk {
+			return 0, 0, 0, 0, false
+		}
+		switch designator {
+		case 'H':
+			if hours != 0 || minutes != 0 || seconds != 0 {
+				return 0, 0, 0, 0, false
+			}
+			hours = n
+		case 'M':
+			if minutes != 0 || seconds != 0 {
+				return 0, 0, 0, 0, false
+			}
+			minutes = n
+		case 'S':
+			if seconds != 0 {
+				return 0, 0, 0, 0, false
+			}
+			seconds = n
+		default:
+			return 0, 0, 0, 0, false
+		}
+		timePart = remaining
+	}
+	return days, hours, minutes, seconds, true
+}
+
+// nextDurationField scans leading digits then a single uppercase designator.
+// Returns ok=false if the digit run is empty or the designator is missing.
+func nextDurationField(s string) (n int, designator byte, rest string, ok bool) {
+	i := 0
+	for i < len(s) && s[i] >= '0' && s[i] <= '9' {
+		i++
+	}
+	if i == 0 || i == len(s) {
+		return 0, 0, "", false
+	}
+	parsed, err := strconv.Atoi(s[:i])
+	if err != nil {
+		return 0, 0, "", false
+	}
+	return parsed, s[i], s[i+1:], true
+}
+
+func plural(n int, unit string) string {
+	if n == 1 {
+		return "1 " + unit
+	}
+	return fmt.Sprintf("%d %ss", n, unit)
+}
+
+func runChoresList(cmd *cobra.Command, args []string) error {
+	cfg, err := loadConfig()
+	if err != nil {
+		output.PrintError(err.Error(), isJSONOutput(nil))
+		return errSilent
+	}
+	jsonMode := isJSONOutput(cfg)
+	cl, err := createClient(cfg)
+	if err != nil {
+		output.PrintError(err.Error(), jsonMode)
+		return errSilent
+	}
+
+	// Belt-and-suspenders: cobra's MarkFlagsMutuallyExclusive may not fire
+	// when RunE is invoked directly in tests, so guard at runtime too.
+	if choresActive && choresInactive {
+		output.PrintError("--active and --inactive are mutually exclusive.", jsonMode)
+		return errSilent
+	}
+
+	const base = "Chores?$select=Name,Active,StartTime,DSTSensitivity,Frequency&$expand=Tasks($select=Step)"
+
+	chores, err := fetchChores(cl, base, choresFilter, jsonMode)
+	if err != nil {
+		return err
+	}
+
+	chores = filterChoresByActive(chores, choresActive, choresInactive)
+	displayChores(chores, jsonMode)
+	return nil
+}
+
+// fetchChores tries server-side $filter first, falling back to client-side
+// filtering with a [warn] when the server rejects the filter.
+func fetchChores(cl *client.Client, base, filter string, jsonMode bool) ([]model.Chore, error) {
+	if filter == "" {
+		chores, err := getChores(cl, base)
+		if err != nil {
+			output.PrintError(err.Error(), jsonMode)
+			return nil, errSilent
+		}
+		return chores, nil
+	}
+
+	safe := strings.ReplaceAll(filter, "'", "''")
+	v := url.Values{}
+	v.Set("$filter", fmt.Sprintf("contains(tolower(Name),tolower('%s'))", safe))
+	if chores, err := getChores(cl, base+"&"+v.Encode()); err == nil {
+		return chores, nil
+	}
+
+	output.PrintWarning("Server-side filter not supported, filtering locally...")
+	chores, err := getChores(cl, base)
+	if err != nil {
+		output.PrintError(err.Error(), jsonMode)
+		return nil, errSilent
+	}
+	return filterChoresByName(chores, filter), nil
+}
+
+func getChores(cl *client.Client, endpoint string) ([]model.Chore, error) {
+	data, err := cl.Get(endpoint)
+	if err != nil {
+		return nil, err
+	}
+	var resp model.ChoreResponse
+	if err := json.Unmarshal(data, &resp); err != nil {
+		return nil, fmt.Errorf("Cannot parse server response.")
+	}
+	return resp.Value, nil
+}
+
+func filterChoresByName(chores []model.Chore, filter string) []model.Chore {
+	lower := strings.ToLower(filter)
+	var out []model.Chore
+	for _, c := range chores {
+		if strings.Contains(strings.ToLower(c.Name), lower) {
+			out = append(out, c)
+		}
+	}
+	return out
+}
+
+func filterChoresByActive(chores []model.Chore, active, inactive bool) []model.Chore {
+	if !active && !inactive {
+		return chores
+	}
+	var out []model.Chore
+	for _, c := range chores {
+		if active && c.Active {
+			out = append(out, c)
+		} else if inactive && !c.Active {
+			out = append(out, c)
+		}
+	}
+	return out
+}
+
+func displayChores(chores []model.Chore, jsonMode bool) {
+	if jsonMode {
+		if chores == nil {
+			chores = []model.Chore{}
+		}
+		output.PrintJSON(chores)
+		return
+	}
+	headers := []string{"NAME", "ACTIVE", "STARTTIME", "DSTSENSITIVITY", "FREQUENCY", "TASKS"}
+	rows := make([][]string, len(chores))
+	for i, c := range chores {
+		rows[i] = []string{
+			c.Name,
+			strconv.FormatBool(c.Active),
+			c.StartTime,
+			strconv.FormatBool(c.DSTSensitivity),
+			formatChoreFrequency(c.Frequency),
+			strconv.Itoa(len(c.Tasks)),
+		}
+	}
+	output.PrintTable(headers, rows)
+}
+
+func runChoresShow(cmd *cobra.Command, args []string) error {
+	name := args[0]
+
+	cfg, err := loadConfig()
+	if err != nil {
+		output.PrintError(err.Error(), isJSONOutput(nil))
+		return errSilent
+	}
+	jsonMode := isJSONOutput(cfg)
+	cl, err := createClient(cfg)
+	if err != nil {
+		output.PrintError(err.Error(), jsonMode)
+		return errSilent
+	}
+
+	endpoint := fmt.Sprintf("Chores('%s')?$expand=Tasks($expand=Process($select=Name),Parameters)", odataKey(name))
+	data, err := cl.Get(endpoint)
+	if err != nil {
+		if errors.Is(err, client.ErrNotFound) {
+			output.PrintError(fmt.Sprintf("Chore '%s' not found.", name), jsonMode)
+			return errExit(3)
+		}
+		output.PrintError(err.Error(), jsonMode)
+		return errSilent
+	}
+
+	var chore model.Chore
+	if err := json.Unmarshal(data, &chore); err != nil {
+		output.PrintError("Cannot parse server response.", jsonMode)
+		return errSilent
+	}
+
+	sort.SliceStable(chore.Tasks, func(i, j int) bool {
+		return chore.Tasks[i].Step < chore.Tasks[j].Step
+	})
+
+	if jsonMode {
+		output.PrintJSON(chore)
+		return nil
+	}
+
+	fmt.Printf("Name:           %s\n", chore.Name)
+	fmt.Printf("Active:         %s\n", strconv.FormatBool(chore.Active))
+	fmt.Printf("StartTime:      %s\n", chore.StartTime)
+	fmt.Printf("DSTSensitivity: %s\n", strconv.FormatBool(chore.DSTSensitivity))
+	fmt.Printf("Frequency:      %s\n", formatChoreFrequency(chore.Frequency))
+	fmt.Println()
+
+	headers := []string{"STEP", "PROCESS", "PARAMETERS"}
+	rows := make([][]string, len(chore.Tasks))
+	for i, t := range chore.Tasks {
+		rows[i] = []string{
+			strconv.Itoa(t.Step),
+			t.Process.Name,
+			renderChoreParams(t.Parameters),
+		}
+	}
+	output.PrintTable(headers, rows)
+	return nil
+}
+
+func renderChoreParams(params []model.ChoreTaskParam) string {
+	if len(params) == 0 {
+		return "(none)"
+	}
+	parts := make([]string, len(params))
+	for i, p := range params {
+		parts[i] = fmt.Sprintf("%s=%v", p.Name, p.Value)
+	}
+	return strings.Join(parts, ", ")
+}
+
+func init() {
+	rootCmd.AddCommand(choresCmd)
+	choresCmd.AddCommand(choresListCmd)
+	choresCmd.AddCommand(choresShowCmd)
+
+	choresListCmd.Flags().StringVar(&choresFilter, "filter", "", "Filter by name (case-insensitive, partial match)")
+	choresListCmd.Flags().BoolVar(&choresActive, "active", false, "Show only active chores")
+	choresListCmd.Flags().BoolVar(&choresInactive, "inactive", false, "Show only inactive chores")
+}

--- a/cmd/chores.go
+++ b/cmd/chores.go
@@ -16,9 +16,12 @@ import (
 )
 
 var (
-	choresFilter   string
-	choresActive   bool
-	choresInactive bool
+	choresFilter     string
+	choresActive     bool
+	choresInactive   bool
+	choresLimit      int
+	choresAll        bool
+	choresShowSystem bool
 )
 
 var choresCmd = &cobra.Command{
@@ -34,11 +37,16 @@ var choresListCmd = &cobra.Command{
 
 REST API: GET /Chores
 
+System chores (names starting with }) are hidden by default. Results are
+limited to 50 by default; use --all to show everything.
+
 Frequency is rendered human-readable in table mode (e.g. "Every 1 day"); JSON
 mode preserves the raw ISO 8601 duration so it remains machine-readable.`,
 	Example: `  tm1cli chores list
   tm1cli chores list --active
   tm1cli chores list --filter "load"
+  tm1cli chores list --all
+  tm1cli chores list --show-system
   tm1cli chores list --output json`,
 	RunE: runChoresList,
 }
@@ -196,17 +204,42 @@ func runChoresList(cmd *cobra.Command, args []string) error {
 		return errSilent
 	}
 
+	showSystem := getShowSystem(cfg, choresShowSystem)
+	limit := getLimit(cfg, choresLimit, choresAll)
+
 	const base = "Chores?$select=Name,Active,StartTime,DSTSensitivity,Frequency&$expand=Tasks($select=Step)"
 
-	chores, err := fetchChores(cl, base, choresFilter)
+	// $top is only safe to apply server-side when no client-side filters
+	// will further trim results — otherwise we may silently omit matches.
+	fetchEndpoint := base
+	clientSideFilters := choresFilter != "" || !showSystem || choresActive || choresInactive
+	if limit > 0 && !clientSideFilters {
+		fetchEndpoint = fmt.Sprintf("%s&$top=%d", base, limit+500)
+	}
+
+	chores, err := fetchChores(cl, fetchEndpoint, choresFilter)
 	if err != nil {
 		output.PrintError(err.Error(), jsonMode)
 		return errSilent
 	}
 
+	chores = filterSystemChores(chores, showSystem)
 	chores = filterChoresByActive(chores, choresActive, choresInactive)
-	displayChores(chores, jsonMode)
+	displayChores(chores, limit, jsonMode)
 	return nil
+}
+
+func filterSystemChores(chores []model.Chore, showSystem bool) []model.Chore {
+	if showSystem {
+		return chores
+	}
+	var out []model.Chore
+	for _, c := range chores {
+		if !strings.HasPrefix(c.Name, "}") {
+			out = append(out, c)
+		}
+	}
+	return out
 }
 
 // fetchChores tries server-side $filter first, falling back to client-side
@@ -269,17 +302,23 @@ func filterChoresByActive(chores []model.Chore, active, inactive bool) []model.C
 	return out
 }
 
-func displayChores(chores []model.Chore, jsonMode bool) {
+func displayChores(chores []model.Chore, limit int, jsonMode bool) {
+	total := len(chores)
+	shown := chores
+	if limit > 0 && len(shown) > limit {
+		shown = shown[:limit]
+	}
+
 	if jsonMode {
-		if chores == nil {
-			chores = []model.Chore{}
+		if shown == nil {
+			shown = []model.Chore{}
 		}
-		output.PrintJSON(chores)
+		output.PrintJSON(shown)
 		return
 	}
 	headers := []string{"NAME", "ACTIVE", "STARTTIME", "DSTSENSITIVITY", "FREQUENCY", "TASKS"}
-	rows := make([][]string, len(chores))
-	for i, c := range chores {
+	rows := make([][]string, len(shown))
+	for i, c := range shown {
 		rows[i] = []string{
 			c.Name,
 			strconv.FormatBool(c.Active),
@@ -290,6 +329,7 @@ func displayChores(chores []model.Chore, jsonMode bool) {
 		}
 	}
 	output.PrintTable(headers, rows)
+	output.PrintSummary(len(shown), total)
 }
 
 func runChoresShow(cmd *cobra.Command, args []string) error {
@@ -372,4 +412,7 @@ func init() {
 	choresListCmd.Flags().StringVar(&choresFilter, "filter", "", "Filter by name (case-insensitive, partial match)")
 	choresListCmd.Flags().BoolVar(&choresActive, "active", false, "Show only active chores")
 	choresListCmd.Flags().BoolVar(&choresInactive, "inactive", false, "Show only inactive chores")
+	choresListCmd.Flags().IntVar(&choresLimit, "limit", 0, "Max results to show (default from settings)")
+	choresListCmd.Flags().BoolVar(&choresAll, "all", false, "Show all results, no limit")
+	choresListCmd.Flags().BoolVar(&choresShowSystem, "show-system", false, "Include system chores (names starting with })")
 }

--- a/cmd/chores.go
+++ b/cmd/chores.go
@@ -33,6 +33,9 @@ var choresCmd = &cobra.Command{
 var choresListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List all chores",
+	// Suppress cobra's auto-appended usage block on RunE errors so stderr in
+	// --output json mode stays a single, parseable JSON object.
+	SilenceUsage: true,
 	Long: `List all chores on the TM1 server.
 
 REST API: GET /Chores
@@ -54,6 +57,9 @@ mode preserves the raw ISO 8601 duration so it remains machine-readable.`,
 var choresShowCmd = &cobra.Command{
 	Use:   "show <name>",
 	Short: "Show a chore's task list",
+	// Suppress cobra's auto-appended usage block on RunE errors so stderr in
+	// --output json mode stays a single, parseable JSON object.
+	SilenceUsage: true,
 	Long: `Show the step-by-step task list for a chore: each step's process and parameters.
 
 REST API: GET /Chores('name')?$expand=Tasks($expand=Process,Parameters)

--- a/cmd/chores_test.go
+++ b/cmd/chores_test.go
@@ -590,21 +590,17 @@ func TestChoresShow_NotFoundJSON(t *testing.T) {
 		rootCmd.Execute()
 	})
 
-	// Cobra appends Usage info after RunE returns a non-nil error, so we
-	// extract the JSON portion (everything up to the first "}" that closes
-	// the top-level object) and parse that. The error message contains
-	// "Missing", confirming the JSON renderer was used.
-	end := strings.Index(stderr, "}\n")
-	if end < 0 {
-		t.Fatalf("expected JSON object on stderr, got: %s", stderr)
-	}
-	jsonPart := stderr[:end+1]
+	// SilenceUsage on choresShowCmd ensures cobra does not append a Usage
+	// block after our JSON error, so the entire stderr is a single JSON object.
 	var obj map[string]interface{}
-	if err := json.Unmarshal([]byte(jsonPart), &obj); err != nil {
-		t.Fatalf("expected JSON error object, got: %s\nfull stderr: %s", jsonPart, stderr)
+	if err := json.Unmarshal([]byte(stderr), &obj); err != nil {
+		t.Fatalf("expected pure JSON error object on stderr, got: %s", stderr)
 	}
 	if _, ok := obj["error"]; !ok {
 		t.Errorf("expected 'error' key in JSON object, got: %v", obj)
+	}
+	if strings.Contains(stderr, "Usage:") {
+		t.Errorf("stderr must not contain cobra Usage block in --output json mode, got: %s", stderr)
 	}
 }
 

--- a/cmd/chores_test.go
+++ b/cmd/chores_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"strings"
 	"testing"
@@ -673,6 +674,136 @@ func TestChoresShow_TasksSortedByStep(t *testing.T) {
 	}
 	if got.Tasks[0].Step != 1 || got.Tasks[1].Step != 2 || got.Tasks[2].Step != 3 {
 		t.Errorf("JSON tasks not sorted: %+v", got.Tasks)
+	}
+}
+
+// --- Unit: filterSystemChores ---
+
+func TestFilterSystemChores(t *testing.T) {
+	chores := []model.Chore{
+		{Name: "DailyLoad"},
+		{Name: "}StatsRefresh"},
+		{Name: "WeeklyReport"},
+	}
+	got := filterSystemChores(chores, false)
+	if len(got) != 2 || got[0].Name != "DailyLoad" || got[1].Name != "WeeklyReport" {
+		t.Errorf("system chore not filtered: %+v", got)
+	}
+	gotAll := filterSystemChores(chores, true)
+	if len(gotAll) != 3 {
+		t.Errorf("expected all chores when showSystem=true, got %d", len(gotAll))
+	}
+}
+
+// --- Integration: --show-system, --limit, --all ---
+
+func TestChoresList_HidesSystemByDefault(t *testing.T) {
+	resetCmdFlags(t)
+	chores := []model.Chore{
+		{Name: "DailyLoad", Active: true, Frequency: "P1D"},
+		{Name: "}StatsRefresh", Active: true, Frequency: "P1D"},
+	}
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(choresJSON(chores...))
+	})
+
+	out := captureStdout(t, func() {
+		rootCmd.SetArgs([]string{"chores", "list"})
+		rootCmd.Execute()
+	})
+
+	if !strings.Contains(out, "DailyLoad") {
+		t.Errorf("expected user chore in output: %s", out)
+	}
+	if strings.Contains(out, "}StatsRefresh") {
+		t.Errorf("system chore should be hidden by default: %s", out)
+	}
+}
+
+func TestChoresList_ShowSystemFlag(t *testing.T) {
+	resetCmdFlags(t)
+	chores := []model.Chore{
+		{Name: "DailyLoad", Active: true, Frequency: "P1D"},
+		{Name: "}StatsRefresh", Active: true, Frequency: "P1D"},
+	}
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(choresJSON(chores...))
+	})
+
+	out := captureStdout(t, func() {
+		rootCmd.SetArgs([]string{"chores", "list", "--show-system"})
+		rootCmd.Execute()
+	})
+
+	if !strings.Contains(out, "}StatsRefresh") {
+		t.Errorf("--show-system should reveal system chores: %s", out)
+	}
+}
+
+func TestChoresList_DefaultLimitTruncates(t *testing.T) {
+	resetCmdFlags(t)
+	chores := make([]model.Chore, 55)
+	for i := range chores {
+		chores[i] = model.Chore{Name: fmt.Sprintf("Chore%02d", i), Active: true, Frequency: "P1D"}
+	}
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(choresJSON(chores...))
+	})
+
+	cap := captureAll(t, func() {
+		rootCmd.SetArgs([]string{"chores", "list"})
+		rootCmd.Execute()
+	})
+
+	if !strings.Contains(cap.Stderr, "Showing 50 of 55") {
+		t.Errorf("expected truncation summary, got stderr: %s", cap.Stderr)
+	}
+}
+
+func TestChoresList_AllDisablesLimit(t *testing.T) {
+	resetCmdFlags(t)
+	chores := make([]model.Chore, 55)
+	for i := range chores {
+		chores[i] = model.Chore{Name: fmt.Sprintf("Chore%02d", i), Active: true, Frequency: "P1D"}
+	}
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(choresJSON(chores...))
+	})
+
+	cap := captureAll(t, func() {
+		rootCmd.SetArgs([]string{"chores", "list", "--all"})
+		rootCmd.Execute()
+	})
+
+	if strings.Contains(cap.Stderr, "Showing 50 of 55") {
+		t.Errorf("--all should not truncate, got stderr: %s", cap.Stderr)
+	}
+	// 55 data rows + 1 header line, plus tabwriter padding lines.
+	if strings.Count(cap.Stdout, "\n") < 56 {
+		t.Errorf("expected at least 55 data rows in output, got %d lines", strings.Count(cap.Stdout, "\n"))
+	}
+}
+
+func TestChoresList_TopOmittedWhenClientFiltering(t *testing.T) {
+	resetCmdFlags(t)
+	var gotURL string
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		gotURL = r.URL.RawQuery
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(choresJSON(sampleChores()...))
+	})
+
+	captureAll(t, func() {
+		rootCmd.SetArgs([]string{"chores", "list", "--active"})
+		rootCmd.Execute()
+	})
+
+	if strings.Contains(gotURL, "%24top=") {
+		t.Errorf("$top must not be sent when client-side filters are active: %s", gotURL)
 	}
 }
 

--- a/cmd/chores_test.go
+++ b/cmd/chores_test.go
@@ -551,9 +551,30 @@ func TestChoresShow_NotFound(t *testing.T) {
 	if !strings.Contains(cap.Stderr, "Missing") || !strings.Contains(cap.Stderr, "not found") {
 		t.Errorf("expected not-found error mentioning chore name, got: %s", cap.Stderr)
 	}
-	// We can't easily assert exit code 3 from inside the same process, but
-	// confirming errExit was returned is covered by exitCodeForError logic in
-	// root.go. The error path is exercised by the assertions above.
+}
+
+// TestChoresShow_NotFoundExitCode verifies the not-found path returns the
+// errExit(3) sentinel so the binary exits with code 3, as documented in the
+// command help. We invoke runChoresShow directly so we can inspect the
+// returned error rather than relying on rootCmd.Execute()'s os.Exit.
+func TestChoresShow_NotFoundExitCode(t *testing.T) {
+	resetCmdFlags(t)
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		w.Write([]byte(`{"error":{"code":"NotFound"}}`))
+	})
+
+	var err error
+	captureAll(t, func() {
+		err = runChoresShow(choresShowCmd, []string{"Missing"})
+	})
+
+	if err == nil {
+		t.Fatal("expected non-nil error from runChoresShow on 404")
+	}
+	if got := exitCodeForError(err); got != 3 {
+		t.Errorf("exit code = %d, want 3", got)
+	}
 }
 
 func TestChoresShow_NotFoundJSON(t *testing.T) {

--- a/cmd/chores_test.go
+++ b/cmd/chores_test.go
@@ -784,22 +784,64 @@ func TestChoresList_AllDisablesLimit(t *testing.T) {
 	}
 }
 
-func TestChoresList_TopOmittedWhenClientFiltering(t *testing.T) {
+// TestChoresList_TopOmittedWithFilter verifies that --filter suppresses
+// server-side $top so the client has the complete set to substring-match
+// against (the server-side $filter may not be honored on every TM1 version).
+func TestChoresList_TopOmittedWithFilter(t *testing.T) {
 	resetCmdFlags(t)
-	var gotURL string
+	var gotURLs []string
 	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
-		gotURL = r.URL.RawQuery
+		gotURLs = append(gotURLs, r.URL.RawQuery)
 		w.Header().Set("Content-Type", "application/json")
 		w.Write(choresJSON(sampleChores()...))
 	})
 
 	captureAll(t, func() {
-		rootCmd.SetArgs([]string{"chores", "list", "--active"})
+		rootCmd.SetArgs([]string{"chores", "list", "--filter", "daily"})
 		rootCmd.Execute()
 	})
 
-	if strings.Contains(gotURL, "%24top=") {
-		t.Errorf("$top must not be sent when client-side filters are active: %s", gotURL)
+	for _, q := range gotURLs {
+		if strings.Contains(q, "$top=") {
+			t.Errorf("$top must not be sent when --filter is active: %s", q)
+		}
+	}
+}
+
+// TestChoresList_TopSentByDefault verifies the default invocation honors
+// the 50-row limit by sending $top=N+500 server-side, matching the
+// cubes/dims convention so we don't fetch the full collection unnecessarily.
+// --show-system, --active, and --inactive must NOT suppress $top because
+// the +500 cushion absorbs their client-side trimming.
+func TestChoresList_TopSentByDefault(t *testing.T) {
+	cases := []struct {
+		name string
+		args []string
+	}{
+		{"plain default", []string{"chores", "list"}},
+		{"with --show-system", []string{"chores", "list", "--show-system"}},
+		{"with --active", []string{"chores", "list", "--active"}},
+		{"with --inactive", []string{"chores", "list", "--inactive"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			resetCmdFlags(t)
+			var gotURL string
+			setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+				gotURL = r.URL.RawQuery
+				w.Header().Set("Content-Type", "application/json")
+				w.Write(choresJSON(sampleChores()...))
+			})
+
+			captureAll(t, func() {
+				rootCmd.SetArgs(tc.args)
+				rootCmd.Execute()
+			})
+
+			if !strings.Contains(gotURL, "$top=") {
+				t.Errorf("expected $top in URL for %v, got: %s", tc.args, gotURL)
+			}
+		})
 	}
 }
 

--- a/cmd/chores_test.go
+++ b/cmd/chores_test.go
@@ -183,12 +183,12 @@ func sampleChores() []model.Chore {
 	return []model.Chore{
 		{
 			Name: "DailyLoad", Active: true, StartTime: "2025-01-01T08:00:00",
-			DSTSensitivity: false, Frequency: "P1DT0H0M0S",
+			DSTSensitive: false, Frequency: "P1DT0H0M0S",
 			Tasks: []model.ChoreTask{{Step: 0}, {Step: 1}},
 		},
 		{
 			Name: "WeeklyReport", Active: false, StartTime: "2025-01-01T09:00:00",
-			DSTSensitivity: true, Frequency: "P7DT0H0M0S",
+			DSTSensitive: true, Frequency: "P7DT0H0M0S",
 			Tasks: []model.ChoreTask{{Step: 0}},
 		},
 	}
@@ -465,7 +465,7 @@ func TestChoresList_MalformedJSON(t *testing.T) {
 func sampleChoreDetail() model.Chore {
 	return model.Chore{
 		Name: "DailyLoad", Active: true, StartTime: "2025-01-01T08:00:00",
-		DSTSensitivity: false, Frequency: "P1DT0H0M0S",
+		DSTSensitive: false, Frequency: "P1DT0H0M0S",
 		Tasks: []model.ChoreTask{
 			{
 				Step:    0,
@@ -499,7 +499,7 @@ func TestChoresShow_Table(t *testing.T) {
 		"Name:           DailyLoad",
 		"Active:         true",
 		"StartTime:      2025-01-01T08:00:00",
-		"DSTSensitivity: false",
+		"DSTSensitive:   false",
 		"Frequency:      Every 1 day",
 		"STEP", "PROCESS", "PARAMETERS",
 		"LoadSales", "pYear=2024", "RunReport", "(none)",

--- a/cmd/chores_test.go
+++ b/cmd/chores_test.go
@@ -1,0 +1,677 @@
+package cmd
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+	"tm1cli/internal/model"
+)
+
+// --- Unit: formatChoreFrequency / parseISO8601Duration ---
+
+func TestFormatChoreFrequency(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{"P1D", "Every 1 day"},
+		{"P1DT0H0M0S", "Every 1 day"},
+		{"PT1H", "Every 1 hour"},
+		{"PT30M", "Every 30 minutes"},
+		{"PT1M30S", "Every 1 minute 30 seconds"},
+		{"P0DT0H0M0S", "Every 0 seconds"},
+		{"P0D", "Every 0 seconds"},
+		{"P7DT12H0M0S", "Every 7 days 12 hours"},
+		{"P2DT3H4M5S", "Every 2 days 3 hours 4 minutes 5 seconds"},
+		{"PT45S", "Every 45 seconds"},
+		{"garbage", "garbage"},
+		{"", ""},
+		{"P1W", "P1W"},
+		{"P1Y", "P1Y"},
+		{"P1DT", "P1DT"},
+		{"P1H", "P1H"},
+		{"PT", "PT"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			got := formatChoreFrequency(tt.in)
+			if got != tt.want {
+				t.Errorf("formatChoreFrequency(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseISO8601Duration(t *testing.T) {
+	tests := []struct {
+		in                       string
+		days, hours, mins, secs  int
+		ok                       bool
+	}{
+		{"P1D", 1, 0, 0, 0, true},
+		{"P0D", 0, 0, 0, 0, true},
+		{"PT1H30M", 0, 1, 30, 0, true},
+		{"P7DT12H", 7, 12, 0, 0, true},
+		{"PT0H0M0S", 0, 0, 0, 0, true},
+		{"P1W", 0, 0, 0, 0, false},
+		{"P1Y", 0, 0, 0, 0, false},
+		{"P1DT", 0, 0, 0, 0, false},
+		{"P1H", 0, 0, 0, 0, false},
+		{"", 0, 0, 0, 0, false},
+		{"foo", 0, 0, 0, 0, false},
+		{"P", 0, 0, 0, 0, false},
+		// Out-of-order time fields should fail (we accept H,M,S strictly).
+		{"PT1S1H", 0, 0, 0, 0, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			d, h, m, s, ok := parseISO8601Duration(tt.in)
+			if ok != tt.ok {
+				t.Fatalf("ok = %v, want %v", ok, tt.ok)
+			}
+			if !ok {
+				return
+			}
+			if d != tt.days || h != tt.hours || m != tt.mins || s != tt.secs {
+				t.Errorf("got d=%d h=%d m=%d s=%d, want d=%d h=%d m=%d s=%d",
+					d, h, m, s, tt.days, tt.hours, tt.mins, tt.secs)
+			}
+		})
+	}
+}
+
+// --- Unit: odataKey ---
+
+func TestOdataKey(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{"Daily", "Daily"},
+		{"Daily Load", "Daily%20Load"},
+		{"Daily's Load", "Daily%27%27s%20Load"},
+		{"a/b", "a%2Fb"},
+		{"It's a name's", "It%27%27s%20a%20name%27%27s"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			got := odataKey(tt.in)
+			if got != tt.want {
+				t.Errorf("odataKey(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+// --- Unit: filters ---
+
+func TestFilterChoresByActive(t *testing.T) {
+	chores := []model.Chore{
+		{Name: "A", Active: true},
+		{Name: "B", Active: false},
+		{Name: "C", Active: true},
+	}
+	tests := []struct {
+		name             string
+		active, inactive bool
+		wantNames        []string
+	}{
+		{"no flags returns all", false, false, []string{"A", "B", "C"}},
+		{"active returns only active", true, false, []string{"A", "C"}},
+		{"inactive returns only inactive", false, true, []string{"B"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := filterChoresByActive(chores, tt.active, tt.inactive)
+			if len(got) != len(tt.wantNames) {
+				t.Fatalf("got %d, want %d", len(got), len(tt.wantNames))
+			}
+			for i, name := range tt.wantNames {
+				if got[i].Name != name {
+					t.Errorf("got[%d].Name = %q, want %q", i, got[i].Name, name)
+				}
+			}
+		})
+	}
+}
+
+func TestFilterChoresByName(t *testing.T) {
+	chores := []model.Chore{
+		{Name: "DailyLoad"},
+		{Name: "WeeklyReport"},
+		{Name: "dailyBackup"},
+	}
+	got := filterChoresByName(chores, "daily")
+	if len(got) != 2 {
+		t.Fatalf("got %d, want 2", len(got))
+	}
+	if got[0].Name != "DailyLoad" || got[1].Name != "dailyBackup" {
+		t.Errorf("unexpected matches: %+v", got)
+	}
+}
+
+// --- Unit: renderChoreParams ---
+
+func TestRenderChoreParams(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []model.ChoreTaskParam
+		want string
+	}{
+		{"empty", nil, "(none)"},
+		{"single string", []model.ChoreTaskParam{{Name: "pYear", Value: "2024"}}, "pYear=2024"},
+		{"multiple", []model.ChoreTaskParam{
+			{Name: "pYear", Value: float64(2024)},
+			{Name: "pSource", Value: "file.csv"},
+		}, "pYear=2024, pSource=file.csv"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := renderChoreParams(tt.in)
+			if got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// --- Integration: chores list ---
+
+func sampleChores() []model.Chore {
+	return []model.Chore{
+		{
+			Name: "DailyLoad", Active: true, StartTime: "2025-01-01T08:00:00",
+			DSTSensitivity: false, Frequency: "P1DT0H0M0S",
+			Tasks: []model.ChoreTask{{Step: 0}, {Step: 1}},
+		},
+		{
+			Name: "WeeklyReport", Active: false, StartTime: "2025-01-01T09:00:00",
+			DSTSensitivity: true, Frequency: "P7DT0H0M0S",
+			Tasks: []model.ChoreTask{{Step: 0}},
+		},
+	}
+}
+
+func TestChoresList_Table(t *testing.T) {
+	resetCmdFlags(t)
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(choresJSON(sampleChores()...))
+	})
+
+	cap := captureAll(t, func() {
+		rootCmd.SetArgs([]string{"chores", "list"})
+		rootCmd.Execute()
+	})
+
+	for _, want := range []string{"DailyLoad", "WeeklyReport", "Every 1 day", "Every 7 days", "true", "false"} {
+		if !strings.Contains(cap.Stdout, want) {
+			t.Errorf("stdout missing %q\nstdout: %s", want, cap.Stdout)
+		}
+	}
+	// Tasks count rendered.
+	if !strings.Contains(cap.Stdout, "2") || !strings.Contains(cap.Stdout, "1") {
+		t.Errorf("expected tasks counts 1 and 2 in stdout: %s", cap.Stdout)
+	}
+}
+
+func TestChoresList_JSON(t *testing.T) {
+	resetCmdFlags(t)
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(choresJSON(sampleChores()...))
+	})
+
+	out := captureStdout(t, func() {
+		rootCmd.SetArgs([]string{"chores", "list", "--output", "json"})
+		rootCmd.Execute()
+	})
+
+	var got []model.Chore
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("invalid JSON: %v\noutput: %s", err, out)
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %d chores, want 2", len(got))
+	}
+	// JSON preserves raw ISO 8601 frequency.
+	if got[0].Frequency != "P1DT0H0M0S" {
+		t.Errorf("Frequency = %q, want raw ISO 8601 P1DT0H0M0S", got[0].Frequency)
+	}
+}
+
+func TestChoresList_Empty(t *testing.T) {
+	resetCmdFlags(t)
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(choresJSON())
+	})
+
+	out := captureStdout(t, func() {
+		rootCmd.SetArgs([]string{"chores", "list", "--output", "json"})
+		rootCmd.Execute()
+	})
+
+	var got []model.Chore
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("expected empty list, got %+v", got)
+	}
+}
+
+func TestChoresList_ZeroTasks(t *testing.T) {
+	resetCmdFlags(t)
+	chore := model.Chore{Name: "EmptyChore", Active: true, Frequency: "P1D"}
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(choresJSON(chore))
+	})
+
+	out := captureStdout(t, func() {
+		rootCmd.SetArgs([]string{"chores", "list"})
+		rootCmd.Execute()
+	})
+
+	if !strings.Contains(out, "EmptyChore") {
+		t.Errorf("missing chore name: %s", out)
+	}
+	// Tasks column reads 0.
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	if len(lines) < 2 {
+		t.Fatalf("expected header+row, got: %s", out)
+	}
+	if !strings.HasSuffix(strings.TrimSpace(lines[1]), "0") {
+		t.Errorf("expected row to end with task count 0, got: %q", lines[1])
+	}
+}
+
+func TestChoresList_FilterServerSide(t *testing.T) {
+	resetCmdFlags(t)
+	var gotURL string
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		gotURL = r.URL.String()
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(choresJSON(sampleChores()[:1]...))
+	})
+
+	captureAll(t, func() {
+		rootCmd.SetArgs([]string{"chores", "list", "--filter", "load"})
+		rootCmd.Execute()
+	})
+
+	if !strings.Contains(gotURL, "%24filter=") {
+		t.Errorf("expected $filter in URL: %s", gotURL)
+	}
+	if !strings.Contains(gotURL, "contains") {
+		t.Errorf("expected contains() in URL: %s", gotURL)
+	}
+}
+
+func TestChoresList_FilterFallback(t *testing.T) {
+	resetCmdFlags(t)
+	calls := 0
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		if strings.Contains(r.URL.RawQuery, "%24filter=") {
+			w.WriteHeader(http.StatusBadRequest)
+			w.Write([]byte(`{"error":"filter not supported"}`))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(choresJSON(sampleChores()...))
+	})
+
+	cap := captureAll(t, func() {
+		rootCmd.SetArgs([]string{"chores", "list", "--filter", "Daily"})
+		rootCmd.Execute()
+	})
+
+	if !strings.Contains(cap.Stderr, "Server-side filter not supported") {
+		t.Errorf("expected fallback warning, got stderr: %s", cap.Stderr)
+	}
+	if !strings.Contains(cap.Stdout, "DailyLoad") {
+		t.Errorf("expected DailyLoad in stdout: %s", cap.Stdout)
+	}
+	if strings.Contains(cap.Stdout, "WeeklyReport") {
+		t.Errorf("WeeklyReport should be filtered out client-side: %s", cap.Stdout)
+	}
+	if calls != 2 {
+		t.Errorf("expected 2 server calls (filtered + unfiltered), got %d", calls)
+	}
+}
+
+func TestChoresList_Active(t *testing.T) {
+	resetCmdFlags(t)
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(choresJSON(sampleChores()...))
+	})
+
+	out := captureStdout(t, func() {
+		rootCmd.SetArgs([]string{"chores", "list", "--active"})
+		rootCmd.Execute()
+	})
+
+	if !strings.Contains(out, "DailyLoad") {
+		t.Errorf("expected active chore in output: %s", out)
+	}
+	if strings.Contains(out, "WeeklyReport") {
+		t.Errorf("inactive chore should be filtered out: %s", out)
+	}
+}
+
+func TestChoresList_Inactive(t *testing.T) {
+	resetCmdFlags(t)
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(choresJSON(sampleChores()...))
+	})
+
+	out := captureStdout(t, func() {
+		rootCmd.SetArgs([]string{"chores", "list", "--inactive"})
+		rootCmd.Execute()
+	})
+
+	if !strings.Contains(out, "WeeklyReport") {
+		t.Errorf("expected inactive chore in output: %s", out)
+	}
+	if strings.Contains(out, "DailyLoad") {
+		t.Errorf("active chore should be filtered out: %s", out)
+	}
+}
+
+func TestChoresList_ActiveAndFilter(t *testing.T) {
+	resetCmdFlags(t)
+	chores := []model.Chore{
+		{Name: "DailyLoad", Active: true, Frequency: "P1D"},
+		{Name: "DailyReport", Active: false, Frequency: "P1D"},
+		{Name: "WeeklyArchive", Active: true, Frequency: "P7D"},
+	}
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		// Mimic TM1's server-side $filter: when present, return only matching names.
+		w.Header().Set("Content-Type", "application/json")
+		if strings.Contains(r.URL.RawQuery, "%24filter=") {
+			var subset []model.Chore
+			for _, c := range chores {
+				if strings.Contains(strings.ToLower(c.Name), "daily") {
+					subset = append(subset, c)
+				}
+			}
+			w.Write(choresJSON(subset...))
+			return
+		}
+		w.Write(choresJSON(chores...))
+	})
+
+	out := captureStdout(t, func() {
+		rootCmd.SetArgs([]string{"chores", "list", "--active", "--filter", "daily"})
+		rootCmd.Execute()
+	})
+
+	if !strings.Contains(out, "DailyLoad") {
+		t.Errorf("expected DailyLoad: %s", out)
+	}
+	if strings.Contains(out, "DailyReport") {
+		t.Errorf("DailyReport (inactive) should be filtered: %s", out)
+	}
+	if strings.Contains(out, "WeeklyArchive") {
+		t.Errorf("WeeklyArchive (no name match) should be filtered: %s", out)
+	}
+}
+
+func TestChoresList_ActiveInactiveMutexError(t *testing.T) {
+	resetCmdFlags(t)
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(choresJSON())
+	})
+
+	cap := captureAll(t, func() {
+		rootCmd.SetArgs([]string{"chores", "list", "--active", "--inactive"})
+		rootCmd.Execute()
+	})
+
+	if cap.Stderr == "" {
+		t.Error("expected error on stderr when both --active and --inactive set")
+	}
+	if !strings.Contains(cap.Stderr, "mutually exclusive") {
+		t.Errorf("expected mutex error message, got: %s", cap.Stderr)
+	}
+}
+
+func TestChoresList_MalformedJSON(t *testing.T) {
+	resetCmdFlags(t)
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{not valid json`))
+	})
+
+	cap := captureAll(t, func() {
+		rootCmd.SetArgs([]string{"chores", "list"})
+		rootCmd.Execute()
+	})
+
+	if !strings.Contains(cap.Stderr, "Cannot parse server response") {
+		t.Errorf("expected parse-error message on stderr, got: %s", cap.Stderr)
+	}
+}
+
+// --- Integration: chores show ---
+
+func sampleChoreDetail() model.Chore {
+	return model.Chore{
+		Name: "DailyLoad", Active: true, StartTime: "2025-01-01T08:00:00",
+		DSTSensitivity: false, Frequency: "P1DT0H0M0S",
+		Tasks: []model.ChoreTask{
+			{
+				Step:    0,
+				Process: model.ChoreTaskProcess{Name: "LoadSales"},
+				Parameters: []model.ChoreTaskParam{
+					{Name: "pYear", Value: "2024"},
+				},
+			},
+			{
+				Step:       1,
+				Process:    model.ChoreTaskProcess{Name: "RunReport"},
+				Parameters: []model.ChoreTaskParam{},
+			},
+		},
+	}
+}
+
+func TestChoresShow_Table(t *testing.T) {
+	resetCmdFlags(t)
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(choreDetailJSON(sampleChoreDetail()))
+	})
+
+	out := captureStdout(t, func() {
+		rootCmd.SetArgs([]string{"chores", "show", "DailyLoad"})
+		rootCmd.Execute()
+	})
+
+	for _, want := range []string{
+		"Name:           DailyLoad",
+		"Active:         true",
+		"StartTime:      2025-01-01T08:00:00",
+		"DSTSensitivity: false",
+		"Frequency:      Every 1 day",
+		"STEP", "PROCESS", "PARAMETERS",
+		"LoadSales", "pYear=2024", "RunReport", "(none)",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing %q in output:\n%s", want, out)
+		}
+	}
+}
+
+func TestChoresShow_JSON(t *testing.T) {
+	resetCmdFlags(t)
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(choreDetailJSON(sampleChoreDetail()))
+	})
+
+	out := captureStdout(t, func() {
+		rootCmd.SetArgs([]string{"chores", "show", "DailyLoad", "--output", "json"})
+		rootCmd.Execute()
+	})
+
+	var got model.Chore
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("invalid JSON: %v\noutput: %s", err, out)
+	}
+	if got.Name != "DailyLoad" {
+		t.Errorf("Name = %q, want DailyLoad", got.Name)
+	}
+	if got.Frequency != "P1DT0H0M0S" {
+		t.Errorf("Frequency = %q, want raw P1DT0H0M0S", got.Frequency)
+	}
+	if len(got.Tasks) != 2 {
+		t.Fatalf("got %d tasks, want 2", len(got.Tasks))
+	}
+}
+
+func TestChoresShow_NotFound(t *testing.T) {
+	resetCmdFlags(t)
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		w.Write([]byte(`{"error":{"code":"NotFound"}}`))
+	})
+
+	cap := captureAll(t, func() {
+		rootCmd.SetArgs([]string{"chores", "show", "Missing"})
+		rootCmd.Execute()
+	})
+
+	if !strings.Contains(cap.Stderr, "Missing") || !strings.Contains(cap.Stderr, "not found") {
+		t.Errorf("expected not-found error mentioning chore name, got: %s", cap.Stderr)
+	}
+	// We can't easily assert exit code 3 from inside the same process, but
+	// confirming errExit was returned is covered by exitCodeForError logic in
+	// root.go. The error path is exercised by the assertions above.
+}
+
+func TestChoresShow_NotFoundJSON(t *testing.T) {
+	resetCmdFlags(t)
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		w.Write([]byte(`{}`))
+	})
+
+	stderr := captureStderr(t, func() {
+		rootCmd.SetArgs([]string{"chores", "show", "Missing", "--output", "json"})
+		rootCmd.Execute()
+	})
+
+	// Cobra appends Usage info after RunE returns a non-nil error, so we
+	// extract the JSON portion (everything up to the first "}" that closes
+	// the top-level object) and parse that. The error message contains
+	// "Missing", confirming the JSON renderer was used.
+	end := strings.Index(stderr, "}\n")
+	if end < 0 {
+		t.Fatalf("expected JSON object on stderr, got: %s", stderr)
+	}
+	jsonPart := stderr[:end+1]
+	var obj map[string]interface{}
+	if err := json.Unmarshal([]byte(jsonPart), &obj); err != nil {
+		t.Fatalf("expected JSON error object, got: %s\nfull stderr: %s", jsonPart, stderr)
+	}
+	if _, ok := obj["error"]; !ok {
+		t.Errorf("expected 'error' key in JSON object, got: %v", obj)
+	}
+}
+
+func TestChoresShow_SpecialChars(t *testing.T) {
+	resetCmdFlags(t)
+	var gotPath string
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.EscapedPath()
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(choreDetailJSON(model.Chore{Name: "Daily's Load", Frequency: "P1D"}))
+	})
+
+	captureAll(t, func() {
+		rootCmd.SetArgs([]string{"chores", "show", "Daily's Load"})
+		rootCmd.Execute()
+	})
+
+	// Apostrophe must be doubled (OData literal escape) then percent-encoded.
+	if !strings.Contains(gotPath, "Chores('Daily%27%27s%20Load')") {
+		t.Errorf("expected escaped path Chores('Daily%%27%%27s%%20Load'), got: %s", gotPath)
+	}
+}
+
+func TestChoresShow_TasksSortedByStep(t *testing.T) {
+	resetCmdFlags(t)
+	chore := model.Chore{
+		Name: "OutOfOrder", Frequency: "P1D",
+		Tasks: []model.ChoreTask{
+			{Step: 3, Process: model.ChoreTaskProcess{Name: "ThirdProc"}},
+			{Step: 1, Process: model.ChoreTaskProcess{Name: "FirstProc"}},
+			{Step: 2, Process: model.ChoreTaskProcess{Name: "SecondProc"}},
+		},
+	}
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(choreDetailJSON(chore))
+	})
+
+	out := captureStdout(t, func() {
+		rootCmd.SetArgs([]string{"chores", "show", "OutOfOrder"})
+		rootCmd.Execute()
+	})
+
+	idxFirst := strings.Index(out, "FirstProc")
+	idxSecond := strings.Index(out, "SecondProc")
+	idxThird := strings.Index(out, "ThirdProc")
+	if idxFirst < 0 || idxSecond < 0 || idxThird < 0 {
+		t.Fatalf("missing process names in output: %s", out)
+	}
+	if !(idxFirst < idxSecond && idxSecond < idxThird) {
+		t.Errorf("tasks not sorted by step (got order First=%d Second=%d Third=%d):\n%s",
+			idxFirst, idxSecond, idxThird, out)
+	}
+
+	// JSON output should also be sorted.
+	resetCmdFlags(t)
+	jsonOut := captureStdout(t, func() {
+		rootCmd.SetArgs([]string{"chores", "show", "OutOfOrder", "--output", "json"})
+		rootCmd.Execute()
+	})
+	var got model.Chore
+	if err := json.Unmarshal([]byte(jsonOut), &got); err != nil {
+		t.Fatalf("invalid JSON: %v\n%s", err, jsonOut)
+	}
+	if len(got.Tasks) != 3 {
+		t.Fatalf("got %d tasks, want 3", len(got.Tasks))
+	}
+	if got.Tasks[0].Step != 1 || got.Tasks[1].Step != 2 || got.Tasks[2].Step != 3 {
+		t.Errorf("JSON tasks not sorted: %+v", got.Tasks)
+	}
+}
+
+func TestChoresShow_NoTasks(t *testing.T) {
+	resetCmdFlags(t)
+	chore := model.Chore{Name: "Bare", Frequency: "P1D", Tasks: []model.ChoreTask{}}
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(choreDetailJSON(chore))
+	})
+
+	out := captureStdout(t, func() {
+		rootCmd.SetArgs([]string{"chores", "show", "Bare"})
+		rootCmd.Execute()
+	})
+
+	if !strings.Contains(out, "Name:           Bare") {
+		t.Errorf("expected header block, got: %s", out)
+	}
+	if !strings.Contains(out, "STEP") {
+		t.Errorf("expected STEP header even when empty, got: %s", out)
+	}
+}

--- a/cmd/testhelpers_test.go
+++ b/cmd/testhelpers_test.go
@@ -256,6 +256,9 @@ func zeroAllFlags() {
 	saveDataDryRun = false
 	saveDataWait = false
 	saveDataTimeout = defaultSaveDataTimeout
+	choresFilter = ""
+	choresActive = false
+	choresInactive = false
 }
 
 // cubesJSON returns JSON for a TM1 Cubes response.
@@ -482,6 +485,24 @@ func sessionsJSON(sessions ...model.Session) []byte {
 // activeSessionJSON returns JSON for a TM1 ActiveSession response.
 func activeSessionJSON(id int64) []byte {
 	data, _ := json.Marshal(model.ActiveSessionRef{ID: id})
+	return data
+}
+
+// choresJSON returns JSON for a TM1 Chores collection response.
+func choresJSON(chores ...model.Chore) []byte {
+	resp := struct {
+		Value []model.Chore `json:"value"`
+	}{Value: chores}
+	if resp.Value == nil {
+		resp.Value = []model.Chore{}
+	}
+	data, _ := json.Marshal(resp)
+	return data
+}
+
+// choreDetailJSON returns JSON for a single TM1 Chore (show endpoint).
+func choreDetailJSON(chore model.Chore) []byte {
+	data, _ := json.Marshal(chore)
 	return data
 }
 

--- a/cmd/testhelpers_test.go
+++ b/cmd/testhelpers_test.go
@@ -259,6 +259,9 @@ func zeroAllFlags() {
 	choresFilter = ""
 	choresActive = false
 	choresInactive = false
+	choresLimit = 0
+	choresAll = false
+	choresShowSystem = false
 }
 
 // cubesJSON returns JSON for a TM1 Cubes response.

--- a/internal/model/chore.go
+++ b/internal/model/chore.go
@@ -4,7 +4,7 @@ type Chore struct {
 	Name           string      `json:"Name"`
 	Active         bool        `json:"Active"`
 	StartTime      string      `json:"StartTime"`
-	DSTSensitivity bool        `json:"DSTSensitivity"`
+	DSTSensitive   bool        `json:"DSTSensitive"`
 	Frequency      string      `json:"Frequency"`
 	Tasks          []ChoreTask `json:"Tasks,omitempty"`
 }

--- a/internal/model/chore.go
+++ b/internal/model/chore.go
@@ -1,0 +1,29 @@
+package model
+
+type Chore struct {
+	Name           string      `json:"Name"`
+	Active         bool        `json:"Active"`
+	StartTime      string      `json:"StartTime"`
+	DSTSensitivity bool        `json:"DSTSensitivity"`
+	Frequency      string      `json:"Frequency"`
+	Tasks          []ChoreTask `json:"Tasks,omitempty"`
+}
+
+type ChoreResponse struct {
+	Value []Chore `json:"value"`
+}
+
+type ChoreTask struct {
+	Step       int              `json:"Step"`
+	Process    ChoreTaskProcess `json:"Process"`
+	Parameters []ChoreTaskParam `json:"Parameters"`
+}
+
+type ChoreTaskProcess struct {
+	Name string `json:"Name"`
+}
+
+type ChoreTaskParam struct {
+	Name  string      `json:"Name"`
+	Value interface{} `json:"Value"`
+}


### PR DESCRIPTION
## Summary
- Adds `tm1cli chores list` and `tm1cli chores show <name>` for browsing TM1 chores (scheduled task chains).
- `list` columns: Name, Active, StartTime, DSTSensitive, Frequency, Tasks (count). Flags: `--filter`, `--active`/`--inactive` (mutually exclusive), `--limit`/`--all`, `--show-system`.
- `show` expands tasks via `$expand=Tasks($expand=Process,Parameters)`, renders a header block + STEP/PROCESS/PARAMETERS table, sorts tasks by Step (in both table and JSON output), exits with code 3 on not found.
- Frequency rendered human-readable in table mode (`P1DT0H0M0S` → "Every 1 day"); JSON preserves raw ISO 8601.
- Reuses existing `odataEscape`; new `odataKey` helper composes it with `url.PathEscape` for entity-key URLs.
- Server-side `$filter` with client-side fallback on rejection (matches `process list`/`cubes list` pattern).
- `SilenceUsage: true` on both subcommands so `--output json` error stderr stays a single parseable JSON object.

## Test plan
- [x] `go build ./...` clean
- [x] `go test ./...` — 1,251 tests pass across 6 packages
- [x] 75+ chores-specific tests covering: ISO 8601 parsing (16 cases incl. P1W/P1Y/P1DT fallbacks), OData key escaping (apostrophes + spaces), filters (name/active/inactive/system), mutex check, server-side `$filter` + fallback, default 50-row truncation, `--all` disables limit, `--show-system` reveals system chores, `$top` sent by default but suppressed only by `--filter`, sort-by-step in both table and JSON output, exit code 3 on 404, JSON not-found stderr is pure JSON (no Usage suffix), special-character names round-trip through URL escaping, `DSTSensitive` field uses correct TM1 wire name.
- [ ] Smoke test against a real TM1 server before tagging the v0.6.0 release.

## Design notes
- `--active` and `--inactive` enforced via runtime check, not `cobra.MarkFlagsMutuallyExclusive` — `pflag.Changed` leaks across `Execute()` calls in the test harness, which would trip the cobra-side check on flags set in a prior test.
- `$top=N+500` over-fetch cushion absorbs `--show-system`/`--active`/`--inactive` client-side trimming so they don't silently lose matches at the truncation boundary; only `--filter` forces an unbounded fetch (matches `cubes list` and `dims list`).

Closes #82