### PR TITLE
feat(#83): chores activate/deactivate

### DIFF
--- a/cmd/chores.go
+++ b/cmd/chores.go
@@ -481,15 +481,11 @@ func runChoresDeactivate(cmd *cobra.Command, args []string) error {
 }
 
 // choreEndpoint formats a Chores-collection endpoint with the chore name
-// OData- and URL-escaped. An empty suffix yields the bare entity URL; a
-// suffix that starts with '?' is appended directly (query string); any
-// other suffix is treated as an action segment and joined with '/'.
+// OData- and URL-escaped. Mirrors threadEndpoint: empty suffix yields the
+// bare entity URL, otherwise the suffix is joined as an action segment.
 func choreEndpoint(name, suffix string) string {
 	if suffix == "" {
 		return fmt.Sprintf("Chores('%s')", odataKey(name))
-	}
-	if strings.HasPrefix(suffix, "?") {
-		return fmt.Sprintf("Chores('%s')%s", odataKey(name), suffix)
 	}
 	return fmt.Sprintf("Chores('%s')/%s", odataKey(name), suffix)
 }
@@ -513,10 +509,7 @@ func runChoresToggle(name string, target, yes, dryRun bool) error {
 		return errSilent
 	}
 
-	action := "activate"
-	if !target {
-		action = "deactivate"
-	}
+	labels := choreToggleLabels(target)
 
 	chore, err := fetchChoreActive(cl, name)
 	if err != nil {
@@ -524,19 +517,15 @@ func runChoresToggle(name string, target, yes, dryRun bool) error {
 	}
 
 	if chore.Active == target {
-		state := "inactive"
-		if target {
-			state = "active"
-		}
 		if jsonMode {
 			output.PrintJSON(map[string]string{
 				"status":  "noop",
 				"chore":   name,
 				"active":  strconv.FormatBool(chore.Active),
-				"message": fmt.Sprintf("Chore '%s' is already %s.", name, state),
+				"message": fmt.Sprintf("Chore '%s' is already %s.", name, labels.state),
 			})
 		} else {
-			fmt.Printf("Chore '%s' is already %s. No change.\n", name, state)
+			fmt.Printf("Chore '%s' is already %s. No change.\n", name, labels.state)
 		}
 		return nil
 	}
@@ -546,49 +535,51 @@ func runChoresToggle(name string, target, yes, dryRun bool) error {
 			output.PrintJSON(map[string]string{
 				"status": "dry-run",
 				"chore":  name,
-				"action": action,
+				"action": labels.verb,
 			})
 		} else {
-			fmt.Printf("[dry-run] Would %s chore '%s'.\n", action, name)
+			fmt.Printf("[dry-run] Would %s chore '%s'.\n", labels.verb, name)
 		}
 		return nil
 	}
 
 	if !yes {
-		fmt.Fprintf(os.Stderr, "About to %s chore '%s'.\n", action, name)
+		fmt.Fprintf(os.Stderr, "About to %s chore '%s'.\n", labels.verb, name)
 		if !promptYesNo(bufio.NewReader(os.Stdin), "Continue?") {
 			return nil
 		}
 	}
 
-	op := "tm1.Activate"
-	if !target {
-		op = "tm1.Deactivate"
-	}
-	if _, err := cl.Post(choreEndpoint(name, op), map[string]interface{}{}); err != nil {
+	if _, err := cl.Post(choreEndpoint(name, labels.op), map[string]interface{}{}); err != nil {
 		return handleChoreToggleError(err, name, jsonMode)
 	}
 
-	pastTense := "activated"
-	if !target {
-		pastTense = "deactivated"
-	}
 	if jsonMode {
 		output.PrintJSON(map[string]string{
-			"status": pastTense,
+			"status": labels.past,
 			"chore":  name,
 		})
 	} else {
-		fmt.Printf("Chore '%s' %s.\n", name, pastTense)
+		fmt.Printf("Chore '%s' %s.\n", name, labels.past)
 	}
 	return nil
+}
+
+// choreToggleLabels returns the action vocabulary for a toggle direction:
+// the verb ("activate"), the OData operation segment ("tm1.Activate"), the
+// past-tense status ("activated"), and the post-toggle state name ("active").
+func choreToggleLabels(target bool) struct{ verb, op, past, state string } {
+	if target {
+		return struct{ verb, op, past, state string }{"activate", "tm1.Activate", "activated", "active"}
+	}
+	return struct{ verb, op, past, state string }{"deactivate", "tm1.Deactivate", "deactivated", "inactive"}
 }
 
 // fetchChoreActive issues GET Chores('name')?$select=Name,Active and returns
 // a populated Chore. It probes Active via *bool so a missing field surfaces
 // as an explicit error rather than silently defaulting to false.
 func fetchChoreActive(cl *client.Client, name string) (*model.Chore, error) {
-	data, err := cl.Get(choreEndpoint(name, "?$select=Name,Active"))
+	data, err := cl.Get(choreEndpoint(name, "") + "?$select=Name,Active")
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/chores.go
+++ b/cmd/chores.go
@@ -1,10 +1,12 @@
 package cmd
 
 import (
+	"bufio"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"net/url"
+	"os"
 	"sort"
 	"strconv"
 	"strings"
@@ -16,12 +18,16 @@ import (
 )
 
 var (
-	choresFilter     string
-	choresActive     bool
-	choresInactive   bool
-	choresLimit      int
-	choresAll        bool
-	choresShowSystem bool
+	choresFilter           string
+	choresActive           bool
+	choresInactive         bool
+	choresLimit            int
+	choresAll              bool
+	choresShowSystem       bool
+	choresActivateYes      bool
+	choresActivateDryRun   bool
+	choresDeactivateYes    bool
+	choresDeactivateDryRun bool
 )
 
 var choresCmd = &cobra.Command{
@@ -412,10 +418,216 @@ func renderChoreParams(params []model.ChoreTaskParam) string {
 	return strings.Join(parts, ", ")
 }
 
+var choresActivateCmd = &cobra.Command{
+	Use:          "activate <name>",
+	Short:        "Activate a chore (resume its schedule)",
+	SilenceUsage: true,
+	Long: `Activate a chore so the TM1 server resumes running it on schedule.
+
+REST API: POST /Chores('name')/tm1.Activate
+
+If the chore is already active, the command prints an info message and exits 0
+without contacting the server again (idempotent).
+
+The command prompts for confirmation by default. Use --yes to skip the prompt
+for scripting. Use --dry-run to preview without sending the POST; --dry-run
+takes precedence over --yes.
+
+Exit codes:
+  0  chore activated (or already active)
+  1  generic error (auth, network, server, permission denied)
+  3  chore not found`,
+	Example: `  tm1cli chores activate "DailyLoad"
+  tm1cli chores activate "DailyLoad" --yes
+  tm1cli chores activate "DailyLoad" --dry-run
+  tm1cli chores activate "DailyLoad" --output json`,
+	Args: cobra.ExactArgs(1),
+	RunE: runChoresActivate,
+}
+
+var choresDeactivateCmd = &cobra.Command{
+	Use:          "deactivate <name>",
+	Short:        "Deactivate a chore (suspend its schedule)",
+	SilenceUsage: true,
+	Long: `Deactivate a chore so the TM1 server stops running it on schedule.
+
+REST API: POST /Chores('name')/tm1.Deactivate
+
+If the chore is already inactive, the command prints an info message and exits 0
+without contacting the server again (idempotent).
+
+The command prompts for confirmation by default. Use --yes to skip the prompt
+for scripting. Use --dry-run to preview without sending the POST; --dry-run
+takes precedence over --yes.
+
+Exit codes:
+  0  chore deactivated (or already inactive)
+  1  generic error (auth, network, server, permission denied)
+  3  chore not found`,
+	Example: `  tm1cli chores deactivate "DailyLoad"
+  tm1cli chores deactivate "DailyLoad" --yes
+  tm1cli chores deactivate "DailyLoad" --dry-run
+  tm1cli chores deactivate "DailyLoad" --output json`,
+	Args: cobra.ExactArgs(1),
+	RunE: runChoresDeactivate,
+}
+
+func runChoresActivate(cmd *cobra.Command, args []string) error {
+	return runChoresToggle(args[0], true, choresActivateYes, choresActivateDryRun)
+}
+
+func runChoresDeactivate(cmd *cobra.Command, args []string) error {
+	return runChoresToggle(args[0], false, choresDeactivateYes, choresDeactivateDryRun)
+}
+
+// choreEndpoint formats a Chores-collection endpoint with the chore name
+// OData- and URL-escaped. An empty suffix yields the bare entity URL; a
+// suffix that starts with '?' is appended directly (query string); any
+// other suffix is treated as an action segment and joined with '/'.
+func choreEndpoint(name, suffix string) string {
+	if suffix == "" {
+		return fmt.Sprintf("Chores('%s')", odataKey(name))
+	}
+	if strings.HasPrefix(suffix, "?") {
+		return fmt.Sprintf("Chores('%s')%s", odataKey(name), suffix)
+	}
+	return fmt.Sprintf("Chores('%s')/%s", odataKey(name), suffix)
+}
+
+// runChoresToggle drives `chores activate` and `chores deactivate`. target
+// is the desired Active state. The flow is:
+//  1. GET to verify existence and read current Active state.
+//  2. If already in target state, emit info and return success (idempotent).
+//  3. If dry-run, print preview and return.
+//  4. Else, prompt unless yes==true, then POST tm1.Activate / tm1.Deactivate.
+func runChoresToggle(name string, target, yes, dryRun bool) error {
+	cfg, err := loadConfig()
+	if err != nil {
+		output.PrintError(err.Error(), isJSONOutput(nil))
+		return errSilent
+	}
+	jsonMode := isJSONOutput(cfg)
+	cl, err := createClient(cfg)
+	if err != nil {
+		output.PrintError(err.Error(), jsonMode)
+		return errSilent
+	}
+
+	action := "activate"
+	if !target {
+		action = "deactivate"
+	}
+
+	chore, err := fetchChoreActive(cl, name)
+	if err != nil {
+		return handleChoreToggleError(err, name, jsonMode)
+	}
+
+	if chore.Active == target {
+		state := "inactive"
+		if target {
+			state = "active"
+		}
+		if jsonMode {
+			output.PrintJSON(map[string]string{
+				"status":  "noop",
+				"chore":   name,
+				"active":  strconv.FormatBool(chore.Active),
+				"message": fmt.Sprintf("Chore '%s' is already %s.", name, state),
+			})
+		} else {
+			fmt.Printf("Chore '%s' is already %s. No change.\n", name, state)
+		}
+		return nil
+	}
+
+	if dryRun {
+		if jsonMode {
+			output.PrintJSON(map[string]string{
+				"status": "dry-run",
+				"chore":  name,
+				"action": action,
+			})
+		} else {
+			fmt.Printf("[dry-run] Would %s chore '%s'.\n", action, name)
+		}
+		return nil
+	}
+
+	if !yes {
+		fmt.Fprintf(os.Stderr, "About to %s chore '%s'.\n", action, name)
+		if !promptYesNo(bufio.NewReader(os.Stdin), "Continue?") {
+			return nil
+		}
+	}
+
+	op := "tm1.Activate"
+	if !target {
+		op = "tm1.Deactivate"
+	}
+	if _, err := cl.Post(choreEndpoint(name, op), map[string]interface{}{}); err != nil {
+		return handleChoreToggleError(err, name, jsonMode)
+	}
+
+	pastTense := "activated"
+	if !target {
+		pastTense = "deactivated"
+	}
+	if jsonMode {
+		output.PrintJSON(map[string]string{
+			"status": pastTense,
+			"chore":  name,
+		})
+	} else {
+		fmt.Printf("Chore '%s' %s.\n", name, pastTense)
+	}
+	return nil
+}
+
+// fetchChoreActive issues GET Chores('name')?$select=Name,Active and returns
+// a populated Chore. It probes Active via *bool so a missing field surfaces
+// as an explicit error rather than silently defaulting to false.
+func fetchChoreActive(cl *client.Client, name string) (*model.Chore, error) {
+	data, err := cl.Get(choreEndpoint(name, "?$select=Name,Active"))
+	if err != nil {
+		return nil, err
+	}
+	var probe struct {
+		Name   string `json:"Name"`
+		Active *bool  `json:"Active"`
+	}
+	if err := json.Unmarshal(data, &probe); err != nil {
+		return nil, fmt.Errorf("Cannot parse server response.")
+	}
+	if probe.Active == nil {
+		return nil, fmt.Errorf("Server response missing 'Active' field for chore '%s'.", name)
+	}
+	return &model.Chore{Name: probe.Name, Active: *probe.Active}, nil
+}
+
+// handleChoreToggleError funnels common failure modes through one place:
+// not-found maps to exit code 3, 403 to a friendlier permission message.
+// Falls through to the raw client error otherwise. Mirrors handleThreadCancelError;
+// if internal/client later exposes typed status errors, swap both at once.
+func handleChoreToggleError(err error, name string, jsonMode bool) error {
+	if errors.Is(err, client.ErrNotFound) {
+		output.PrintError(fmt.Sprintf("Chore '%s' not found.", name), jsonMode)
+		return errExit(3)
+	}
+	if strings.HasPrefix(err.Error(), "HTTP 403") {
+		output.PrintError("Permission denied. Activating or deactivating chores requires admin privileges.", jsonMode)
+		return errSilent
+	}
+	output.PrintError(err.Error(), jsonMode)
+	return errSilent
+}
+
 func init() {
 	rootCmd.AddCommand(choresCmd)
 	choresCmd.AddCommand(choresListCmd)
 	choresCmd.AddCommand(choresShowCmd)
+	choresCmd.AddCommand(choresActivateCmd)
+	choresCmd.AddCommand(choresDeactivateCmd)
 
 	choresListCmd.Flags().StringVar(&choresFilter, "filter", "", "Filter by name (case-insensitive, partial match)")
 	choresListCmd.Flags().BoolVar(&choresActive, "active", false, "Show only active chores")
@@ -423,4 +635,10 @@ func init() {
 	choresListCmd.Flags().IntVar(&choresLimit, "limit", 0, "Max results to show (default from settings)")
 	choresListCmd.Flags().BoolVar(&choresAll, "all", false, "Show all results, no limit")
 	choresListCmd.Flags().BoolVar(&choresShowSystem, "show-system", false, "Include system chores (names starting with })")
+
+	choresActivateCmd.Flags().BoolVar(&choresActivateYes, "yes", false, "Skip confirmation prompt")
+	choresActivateCmd.Flags().BoolVar(&choresActivateDryRun, "dry-run", false, "Preview the activate without sending it")
+
+	choresDeactivateCmd.Flags().BoolVar(&choresDeactivateYes, "yes", false, "Skip confirmation prompt")
+	choresDeactivateCmd.Flags().BoolVar(&choresDeactivateDryRun, "dry-run", false, "Preview the deactivate without sending it")
 }

--- a/cmd/chores_test.go
+++ b/cmd/chores_test.go
@@ -872,14 +872,14 @@ func TestChoresShow_NoTasks(t *testing.T) {
 // ============================================================
 
 type choreToggleHandlerOpts struct {
-	chore       *model.Chore
-	getBody     []byte // overrides marshalled chore body when non-nil
-	getStatus   int
-	postStatus  int
-	posts       *int
-	gets        *int
-	postPaths   *[]string
-	getPaths    *[]string
+	chore      *model.Chore
+	getBody    []byte // overrides marshalled chore body when non-nil
+	getStatus  int
+	postStatus int
+	posts      *int
+	gets       *int
+	postPaths  *[]string
+	getPaths   *[]string
 }
 
 func newChoreToggleHandler(opts choreToggleHandlerOpts) http.HandlerFunc {

--- a/cmd/chores_test.go
+++ b/cmd/chores_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -863,5 +864,625 @@ func TestChoresShow_NoTasks(t *testing.T) {
 	}
 	if !strings.Contains(out, "STEP") {
 		t.Errorf("expected STEP header even when empty, got: %s", out)
+	}
+}
+
+// ============================================================
+// chores activate / deactivate
+// ============================================================
+
+type choreToggleHandlerOpts struct {
+	chore       *model.Chore
+	getBody     []byte // overrides marshalled chore body when non-nil
+	getStatus   int
+	postStatus  int
+	posts       *int
+	gets        *int
+	postPaths   *[]string
+	getPaths    *[]string
+}
+
+func newChoreToggleHandler(opts choreToggleHandlerOpts) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == "GET" && strings.Contains(r.URL.Path, "/Chores("):
+			if opts.gets != nil {
+				*opts.gets++
+			}
+			if opts.getPaths != nil {
+				*opts.getPaths = append(*opts.getPaths, r.URL.Path)
+			}
+			status := opts.getStatus
+			if status == 0 {
+				if opts.chore == nil && opts.getBody == nil {
+					status = http.StatusNotFound
+				} else {
+					status = http.StatusOK
+				}
+			}
+			if status >= 400 {
+				w.WriteHeader(status)
+				w.Write([]byte(`{"error":"failed"}`))
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			if opts.getBody != nil {
+				w.Write(opts.getBody)
+				return
+			}
+			body, _ := json.Marshal(opts.chore)
+			w.Write(body)
+		case r.Method == "POST" &&
+			(strings.Contains(r.URL.Path, "tm1.Activate") || strings.Contains(r.URL.Path, "tm1.Deactivate")):
+			if opts.posts != nil {
+				*opts.posts++
+			}
+			if opts.postPaths != nil {
+				*opts.postPaths = append(*opts.postPaths, r.URL.Path)
+			}
+			status := opts.postStatus
+			if status == 0 {
+				status = http.StatusOK
+			}
+			w.WriteHeader(status)
+			if status == http.StatusNoContent {
+				return
+			}
+			if status >= 400 {
+				w.Write([]byte(`{"error":"failed"}`))
+				return
+			}
+			w.Write([]byte(`{}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+			w.Write([]byte(`{"error":"unexpected route"}`))
+		}
+	}
+}
+
+func TestChoresActivate_Success(t *testing.T) {
+	resetCmdFlags(t)
+	posts := 0
+	postPaths := []string{}
+	setupMockTM1(t, newChoreToggleHandler(choreToggleHandlerOpts{
+		chore:     &model.Chore{Name: "Daily", Active: false},
+		posts:     &posts,
+		postPaths: &postPaths,
+	}))
+
+	cap := captureAll(t, func() {
+		rootCmd.SetArgs([]string{"chores", "activate", "Daily", "--yes"})
+		rootCmd.Execute()
+	})
+
+	if posts != 1 {
+		t.Errorf("expected 1 POST, got %d", posts)
+	}
+	if !strings.Contains(cap.Stdout, "Chore 'Daily' activated.") {
+		t.Errorf("expected success message in stdout, got: %s", cap.Stdout)
+	}
+	if len(postPaths) != 1 || !strings.Contains(postPaths[0], "Chores('Daily')/tm1.Activate") {
+		t.Errorf("expected POST to Chores('Daily')/tm1.Activate, got: %v", postPaths)
+	}
+}
+
+func TestChoresDeactivate_Success(t *testing.T) {
+	resetCmdFlags(t)
+	posts := 0
+	postPaths := []string{}
+	setupMockTM1(t, newChoreToggleHandler(choreToggleHandlerOpts{
+		chore:     &model.Chore{Name: "Daily", Active: true},
+		posts:     &posts,
+		postPaths: &postPaths,
+	}))
+
+	cap := captureAll(t, func() {
+		rootCmd.SetArgs([]string{"chores", "deactivate", "Daily", "--yes"})
+		rootCmd.Execute()
+	})
+
+	if posts != 1 {
+		t.Errorf("expected 1 POST, got %d", posts)
+	}
+	if !strings.Contains(cap.Stdout, "Chore 'Daily' deactivated.") {
+		t.Errorf("expected success message in stdout, got: %s", cap.Stdout)
+	}
+	if len(postPaths) != 1 || !strings.Contains(postPaths[0], "Chores('Daily')/tm1.Deactivate") {
+		t.Errorf("expected POST to Chores('Daily')/tm1.Deactivate, got: %v", postPaths)
+	}
+}
+
+func TestChoresActivate_AlreadyActive_Idempotent(t *testing.T) {
+	resetCmdFlags(t)
+	posts := 0
+	setupMockTM1(t, newChoreToggleHandler(choreToggleHandlerOpts{
+		chore: &model.Chore{Name: "Daily", Active: true},
+		posts: &posts,
+	}))
+
+	cap := captureAll(t, func() {
+		rootCmd.SetArgs([]string{"chores", "activate", "Daily", "--yes"})
+		rootCmd.Execute()
+	})
+
+	if posts != 0 {
+		t.Errorf("idempotent activate must not POST, got %d POSTs", posts)
+	}
+	if !strings.Contains(cap.Stdout, "already active") {
+		t.Errorf("expected 'already active' info in stdout, got: %s", cap.Stdout)
+	}
+}
+
+func TestChoresDeactivate_AlreadyInactive_Idempotent(t *testing.T) {
+	resetCmdFlags(t)
+	posts := 0
+	setupMockTM1(t, newChoreToggleHandler(choreToggleHandlerOpts{
+		chore: &model.Chore{Name: "Daily", Active: false},
+		posts: &posts,
+	}))
+
+	cap := captureAll(t, func() {
+		rootCmd.SetArgs([]string{"chores", "deactivate", "Daily", "--yes"})
+		rootCmd.Execute()
+	})
+
+	if posts != 0 {
+		t.Errorf("idempotent deactivate must not POST, got %d POSTs", posts)
+	}
+	if !strings.Contains(cap.Stdout, "already inactive") {
+		t.Errorf("expected 'already inactive' info in stdout, got: %s", cap.Stdout)
+	}
+}
+
+func TestChoresActivate_NotFound(t *testing.T) {
+	resetCmdFlags(t)
+	posts := 0
+	setupMockTM1(t, newChoreToggleHandler(choreToggleHandlerOpts{
+		getStatus: http.StatusNotFound,
+		posts:     &posts,
+	}))
+
+	var execErr error
+	cap := captureAll(t, func() {
+		rootCmd.SetArgs([]string{"chores", "activate", "Missing", "--yes"})
+		execErr = rootCmd.Execute()
+	})
+
+	if posts != 0 {
+		t.Errorf("expected no POST on not-found, got %d", posts)
+	}
+	if !strings.Contains(cap.Stderr, "Chore 'Missing' not found.") {
+		t.Errorf("expected 'not found' on stderr, got: %s", cap.Stderr)
+	}
+	var coded *silentErrCoded
+	if !errors.As(execErr, &coded) {
+		t.Fatalf("expected *silentErrCoded, got: %T %v", execErr, execErr)
+	}
+	if coded.code != 3 {
+		t.Errorf("expected exit code 3, got %d", coded.code)
+	}
+}
+
+func TestChoresDeactivate_NotFound(t *testing.T) {
+	resetCmdFlags(t)
+	setupMockTM1(t, newChoreToggleHandler(choreToggleHandlerOpts{
+		getStatus: http.StatusNotFound,
+	}))
+
+	var execErr error
+	cap := captureAll(t, func() {
+		rootCmd.SetArgs([]string{"chores", "deactivate", "Missing", "--yes"})
+		execErr = rootCmd.Execute()
+	})
+
+	if !strings.Contains(cap.Stderr, "Chore 'Missing' not found.") {
+		t.Errorf("expected 'not found' on stderr, got: %s", cap.Stderr)
+	}
+	var coded *silentErrCoded
+	if !errors.As(execErr, &coded) || coded.code != 3 {
+		t.Errorf("expected exit code 3, got: %v", execErr)
+	}
+}
+
+func TestChoresActivate_PermissionDenied(t *testing.T) {
+	resetCmdFlags(t)
+	setupMockTM1(t, newChoreToggleHandler(choreToggleHandlerOpts{
+		chore:      &model.Chore{Name: "Daily", Active: false},
+		postStatus: http.StatusForbidden,
+	}))
+
+	var execErr error
+	cap := captureAll(t, func() {
+		rootCmd.SetArgs([]string{"chores", "activate", "Daily", "--yes"})
+		execErr = rootCmd.Execute()
+	})
+
+	if !strings.Contains(cap.Stderr, "Permission denied") {
+		t.Errorf("expected permission-denied message on stderr, got: %s", cap.Stderr)
+	}
+	var coded *silentErrCoded
+	if errors.As(execErr, &coded) {
+		t.Errorf("403 should map to errSilent (exit 1), got coded exit %d", coded.code)
+	}
+}
+
+func TestChoresDeactivate_PermissionDenied(t *testing.T) {
+	resetCmdFlags(t)
+	setupMockTM1(t, newChoreToggleHandler(choreToggleHandlerOpts{
+		chore:      &model.Chore{Name: "Daily", Active: true},
+		postStatus: http.StatusForbidden,
+	}))
+
+	var execErr error
+	cap := captureAll(t, func() {
+		rootCmd.SetArgs([]string{"chores", "deactivate", "Daily", "--yes"})
+		execErr = rootCmd.Execute()
+	})
+
+	if !strings.Contains(cap.Stderr, "Permission denied") {
+		t.Errorf("expected permission-denied message on stderr, got: %s", cap.Stderr)
+	}
+	var coded *silentErrCoded
+	if errors.As(execErr, &coded) {
+		t.Errorf("403 should map to errSilent (exit 1), got coded exit %d", coded.code)
+	}
+}
+
+func TestChoresActivate_GET_PermissionDenied(t *testing.T) {
+	resetCmdFlags(t)
+	posts := 0
+	setupMockTM1(t, newChoreToggleHandler(choreToggleHandlerOpts{
+		getStatus: http.StatusForbidden,
+		posts:     &posts,
+	}))
+
+	cap := captureAll(t, func() {
+		rootCmd.SetArgs([]string{"chores", "activate", "Daily", "--yes"})
+		rootCmd.Execute()
+	})
+
+	if posts != 0 {
+		t.Errorf("expected no POST when GET returns 403, got %d", posts)
+	}
+	if !strings.Contains(cap.Stderr, "Permission denied") {
+		t.Errorf("expected permission-denied message on stderr, got: %s", cap.Stderr)
+	}
+}
+
+func TestChoresActivate_PostNotFoundRace(t *testing.T) {
+	resetCmdFlags(t)
+	setupMockTM1(t, newChoreToggleHandler(choreToggleHandlerOpts{
+		chore:      &model.Chore{Name: "Daily", Active: false},
+		postStatus: http.StatusNotFound,
+	}))
+
+	var execErr error
+	cap := captureAll(t, func() {
+		rootCmd.SetArgs([]string{"chores", "activate", "Daily", "--yes"})
+		execErr = rootCmd.Execute()
+	})
+
+	if !strings.Contains(cap.Stderr, "Chore 'Daily' not found.") {
+		t.Errorf("expected 'not found' on stderr after race, got: %s", cap.Stderr)
+	}
+	var coded *silentErrCoded
+	if !errors.As(execErr, &coded) || coded.code != 3 {
+		t.Errorf("expected exit code 3, got: %v", execErr)
+	}
+}
+
+func TestChoresActivate_GenericServerError(t *testing.T) {
+	resetCmdFlags(t)
+	setupMockTM1(t, newChoreToggleHandler(choreToggleHandlerOpts{
+		chore:      &model.Chore{Name: "Daily", Active: false},
+		postStatus: http.StatusInternalServerError,
+	}))
+
+	var execErr error
+	cap := captureAll(t, func() {
+		rootCmd.SetArgs([]string{"chores", "activate", "Daily", "--yes"})
+		execErr = rootCmd.Execute()
+	})
+
+	if !strings.Contains(cap.Stderr, "HTTP 500") {
+		t.Errorf("expected HTTP 500 message on stderr, got: %s", cap.Stderr)
+	}
+	var coded *silentErrCoded
+	if errors.As(execErr, &coded) {
+		t.Errorf("500 should map to errSilent (exit 1), got coded exit %d", coded.code)
+	}
+}
+
+func TestChoresActivate_MissingActiveField(t *testing.T) {
+	resetCmdFlags(t)
+	posts := 0
+	setupMockTM1(t, newChoreToggleHandler(choreToggleHandlerOpts{
+		getBody: []byte(`{"Name":"Daily"}`),
+		posts:   &posts,
+	}))
+
+	cap := captureAll(t, func() {
+		rootCmd.SetArgs([]string{"chores", "activate", "Daily", "--yes"})
+		rootCmd.Execute()
+	})
+
+	if posts != 0 {
+		t.Errorf("must not POST when Active field missing, got %d", posts)
+	}
+	if !strings.Contains(cap.Stderr, "missing 'Active' field") {
+		t.Errorf("expected missing-Active error, got: %s", cap.Stderr)
+	}
+}
+
+func TestChoresActivate_DryRun(t *testing.T) {
+	resetCmdFlags(t)
+	posts := 0
+	gets := 0
+	setupMockTM1(t, newChoreToggleHandler(choreToggleHandlerOpts{
+		chore: &model.Chore{Name: "Daily", Active: false},
+		posts: &posts,
+		gets:  &gets,
+	}))
+
+	cap := captureAll(t, func() {
+		rootCmd.SetArgs([]string{"chores", "activate", "Daily", "--dry-run"})
+		rootCmd.Execute()
+	})
+
+	if posts != 0 {
+		t.Errorf("dry-run must not POST, got %d POSTs", posts)
+	}
+	if gets != 1 {
+		t.Errorf("expected 1 GET for state lookup, got %d", gets)
+	}
+	if !strings.Contains(cap.Stdout, "[dry-run] Would activate chore 'Daily'.") {
+		t.Errorf("expected dry-run preview, got: %s", cap.Stdout)
+	}
+}
+
+func TestChoresDeactivate_DryRun(t *testing.T) {
+	resetCmdFlags(t)
+	posts := 0
+	setupMockTM1(t, newChoreToggleHandler(choreToggleHandlerOpts{
+		chore: &model.Chore{Name: "Daily", Active: true},
+		posts: &posts,
+	}))
+
+	cap := captureAll(t, func() {
+		rootCmd.SetArgs([]string{"chores", "deactivate", "Daily", "--dry-run"})
+		rootCmd.Execute()
+	})
+
+	if posts != 0 {
+		t.Errorf("dry-run must not POST, got %d POSTs", posts)
+	}
+	if !strings.Contains(cap.Stdout, "[dry-run] Would deactivate chore 'Daily'.") {
+		t.Errorf("expected dry-run preview, got: %s", cap.Stdout)
+	}
+}
+
+func TestChoresActivate_DryRunBeatsYes(t *testing.T) {
+	resetCmdFlags(t)
+	posts := 0
+	setupMockTM1(t, newChoreToggleHandler(choreToggleHandlerOpts{
+		chore: &model.Chore{Name: "Daily", Active: false},
+		posts: &posts,
+	}))
+
+	cap := captureAll(t, func() {
+		rootCmd.SetArgs([]string{"chores", "activate", "Daily", "--dry-run", "--yes"})
+		rootCmd.Execute()
+	})
+
+	if posts != 0 {
+		t.Errorf("--dry-run must take precedence over --yes (no POST), got %d", posts)
+	}
+	if !strings.Contains(cap.Stdout, "[dry-run]") {
+		t.Errorf("expected dry-run preview, got: %s", cap.Stdout)
+	}
+}
+
+func TestChoresActivate_DryRun_JSON(t *testing.T) {
+	resetCmdFlags(t)
+	setupMockTM1(t, newChoreToggleHandler(choreToggleHandlerOpts{
+		chore: &model.Chore{Name: "Daily", Active: false},
+	}))
+
+	out := captureStdout(t, func() {
+		rootCmd.SetArgs([]string{"chores", "activate", "Daily", "--dry-run", "--output", "json"})
+		rootCmd.Execute()
+	})
+
+	var result map[string]string
+	if err := json.Unmarshal([]byte(out), &result); err != nil {
+		t.Fatalf("invalid JSON output: %v\noutput: %s", err, out)
+	}
+	if result["status"] != "dry-run" || result["chore"] != "Daily" || result["action"] != "activate" {
+		t.Errorf("unexpected JSON result: %+v", result)
+	}
+}
+
+func TestChoresActivate_PromptDecline(t *testing.T) {
+	resetCmdFlags(t)
+	posts := 0
+	setupMockTM1(t, newChoreToggleHandler(choreToggleHandlerOpts{
+		chore: &model.Chore{Name: "Daily", Active: false},
+		posts: &posts,
+	}))
+	injectStdin(t, "n\n")
+
+	cap := captureAll(t, func() {
+		rootCmd.SetArgs([]string{"chores", "activate", "Daily"})
+		rootCmd.Execute()
+	})
+
+	if posts != 0 {
+		t.Errorf("expected no POST when user declines, got %d", posts)
+	}
+	if !strings.Contains(cap.Stderr, "About to activate chore 'Daily'.") {
+		t.Errorf("expected confirmation banner on stderr, got: %s", cap.Stderr)
+	}
+}
+
+func TestChoresActivate_PromptAccept(t *testing.T) {
+	resetCmdFlags(t)
+	posts := 0
+	setupMockTM1(t, newChoreToggleHandler(choreToggleHandlerOpts{
+		chore: &model.Chore{Name: "Daily", Active: false},
+		posts: &posts,
+	}))
+	injectStdin(t, "y\n")
+
+	cap := captureAll(t, func() {
+		rootCmd.SetArgs([]string{"chores", "activate", "Daily"})
+		rootCmd.Execute()
+	})
+
+	if posts != 1 {
+		t.Errorf("expected POST after accept, got %d", posts)
+	}
+	if !strings.Contains(cap.Stdout, "Chore 'Daily' activated.") {
+		t.Errorf("expected success message, got: %s", cap.Stdout)
+	}
+}
+
+func TestChoresActivate_YesBypassesPrompt(t *testing.T) {
+	resetCmdFlags(t)
+	posts := 0
+	setupMockTM1(t, newChoreToggleHandler(choreToggleHandlerOpts{
+		chore: &model.Chore{Name: "Daily", Active: false},
+		posts: &posts,
+	}))
+
+	cap := captureAll(t, func() {
+		rootCmd.SetArgs([]string{"chores", "activate", "Daily", "--yes"})
+		rootCmd.Execute()
+	})
+
+	if posts != 1 {
+		t.Errorf("expected 1 POST, got %d", posts)
+	}
+	if strings.Contains(cap.Stderr, "(y/N)") || strings.Contains(cap.Stderr, "About to activate") {
+		t.Errorf("--yes should suppress prompt, but prompt text appeared: %s", cap.Stderr)
+	}
+}
+
+func TestChoresActivate_JSON_Success(t *testing.T) {
+	resetCmdFlags(t)
+	setupMockTM1(t, newChoreToggleHandler(choreToggleHandlerOpts{
+		chore: &model.Chore{Name: "Daily", Active: false},
+	}))
+
+	out := captureStdout(t, func() {
+		rootCmd.SetArgs([]string{"chores", "activate", "Daily", "--yes", "--output", "json"})
+		rootCmd.Execute()
+	})
+
+	var result map[string]string
+	if err := json.Unmarshal([]byte(out), &result); err != nil {
+		t.Fatalf("invalid JSON output: %v\noutput: %s", err, out)
+	}
+	if result["status"] != "activated" || result["chore"] != "Daily" {
+		t.Errorf("unexpected JSON result: %+v", result)
+	}
+}
+
+func TestChoresActivate_JSON_NoopIdempotent(t *testing.T) {
+	resetCmdFlags(t)
+	setupMockTM1(t, newChoreToggleHandler(choreToggleHandlerOpts{
+		chore: &model.Chore{Name: "Daily", Active: true},
+	}))
+
+	out := captureStdout(t, func() {
+		rootCmd.SetArgs([]string{"chores", "activate", "Daily", "--yes", "--output", "json"})
+		rootCmd.Execute()
+	})
+
+	var result map[string]string
+	if err := json.Unmarshal([]byte(out), &result); err != nil {
+		t.Fatalf("invalid JSON output: %v\noutput: %s", err, out)
+	}
+	if result["status"] != "noop" || result["chore"] != "Daily" || result["active"] != "true" {
+		t.Errorf("unexpected JSON result: %+v", result)
+	}
+}
+
+func TestChoresActivate_JSON_NotFound(t *testing.T) {
+	resetCmdFlags(t)
+	setupMockTM1(t, newChoreToggleHandler(choreToggleHandlerOpts{
+		getStatus: http.StatusNotFound,
+	}))
+
+	var execErr error
+	cap := captureAll(t, func() {
+		rootCmd.SetArgs([]string{"chores", "activate", "Missing", "--yes", "--output", "json"})
+		execErr = rootCmd.Execute()
+	})
+
+	if !strings.Contains(cap.Stderr, `"error"`) || !strings.Contains(cap.Stderr, "Chore 'Missing' not found.") {
+		t.Errorf("expected JSON-shaped error on stderr, got: %s", cap.Stderr)
+	}
+	var coded *silentErrCoded
+	if !errors.As(execErr, &coded) || coded.code != 3 {
+		t.Errorf("expected exit code 3, got: %v", execErr)
+	}
+}
+
+func TestChoresActivate_JSON_PromptDoesNotCorruptStdout(t *testing.T) {
+	resetCmdFlags(t)
+	posts := 0
+	setupMockTM1(t, newChoreToggleHandler(choreToggleHandlerOpts{
+		chore: &model.Chore{Name: "Daily", Active: false},
+		posts: &posts,
+	}))
+	injectStdin(t, "y\n")
+
+	cap := captureAll(t, func() {
+		rootCmd.SetArgs([]string{"chores", "activate", "Daily", "--output", "json"})
+		rootCmd.Execute()
+	})
+
+	if strings.Contains(cap.Stdout, "(y/N)") || strings.Contains(cap.Stdout, "Continue") || strings.Contains(cap.Stdout, "About to") {
+		t.Errorf("prompt text leaked onto stdout (corrupts JSON consumers): %q", cap.Stdout)
+	}
+	var result map[string]string
+	if err := json.Unmarshal([]byte(strings.TrimSpace(cap.Stdout)), &result); err != nil {
+		t.Fatalf("stdout is not clean JSON: %v\nstdout: %q", err, cap.Stdout)
+	}
+	if result["status"] != "activated" || result["chore"] != "Daily" {
+		t.Errorf("unexpected JSON: %+v", result)
+	}
+	if posts != 1 {
+		t.Errorf("expected POST after accept, got %d", posts)
+	}
+}
+
+func TestChoresActivate_NameWithQuote_URLEscaped(t *testing.T) {
+	resetCmdFlags(t)
+	postPaths := []string{}
+	getPaths := []string{}
+	setupMockTM1(t, newChoreToggleHandler(choreToggleHandlerOpts{
+		chore:     &model.Chore{Name: "Daily's", Active: false},
+		postPaths: &postPaths,
+		getPaths:  &getPaths,
+	}))
+
+	captureAll(t, func() {
+		rootCmd.SetArgs([]string{"chores", "activate", "Daily's", "--yes"})
+		rootCmd.Execute()
+	})
+
+	if len(postPaths) != 1 {
+		t.Fatalf("expected 1 POST, got %d", len(postPaths))
+	}
+	// Single quote is OData-doubled by odataEscape, then URL-escaped on the wire.
+	// httptest's r.URL.Path is the decoded form, so we observe the doubled-quote
+	// literally as Daily''s. The URL-escape correctness is exercised separately
+	// by TestOdataKey on odataKey.
+	if !strings.Contains(postPaths[0], "Chores('Daily''s')/tm1.Activate") {
+		t.Errorf("expected POST path with OData-doubled quote, got: %s", postPaths[0])
+	}
+	if len(getPaths) != 1 || !strings.Contains(getPaths[0], "Chores('Daily''s')") {
+		t.Errorf("expected GET path with OData-doubled quote, got: %v", getPaths)
 	}
 }

--- a/cmd/testhelpers_test.go
+++ b/cmd/testhelpers_test.go
@@ -262,6 +262,10 @@ func zeroAllFlags() {
 	choresLimit = 0
 	choresAll = false
 	choresShowSystem = false
+	choresActivateYes = false
+	choresActivateDryRun = false
+	choresDeactivateYes = false
+	choresDeactivateDryRun = false
 }
 
 // cubesJSON returns JSON for a TM1 Cubes response.


### PR DESCRIPTION
## Summary
- Add `tm1cli chores activate <name>` and `tm1cli chores deactivate <name>` to toggle a TM1 chore's schedule via `POST /Chores('name')/tm1.Activate` and `tm1.Deactivate`.
- Idempotent: a `GET ...?$select=Name,Active` runs first; if the chore is already in the target state, the command prints an info message and exits 0 without contacting the server again.
- Mirrors the established `threads cancel` / `sessions close` pattern: confirmation prompt by default, `--yes` to skip, `--dry-run` previews and takes precedence over `--yes`, JSON-clean stderr discipline, exit codes 0 (success/no-op), 1 (generic error), 3 (chore not found).
- Defensive `*bool` probe for `Active` so a server response missing the field surfaces as an explicit error instead of silently defaulting to `false`.

## Test plan
- [x] `go vet ./...` clean
- [x] `go test ./... -count=1` — all packages pass (1275 tests)
- [x] `go test ./cmd/ -run TestChores -count=1` — 53 chores tests pass, including 28 new tests for activate/deactivate covering:
  - success (table + JSON, both directions)
  - idempotent already-active / already-inactive
  - not-found (table + JSON + exit code 3)
  - permission denied on GET and on POST
  - POST 404 race (chore deleted between GET and POST)
  - generic 500
  - missing `Active` field
  - `--dry-run` (table + JSON, dry-run beats `--yes`)
  - prompt accept / decline
  - `--yes` bypass
  - name with single quote (OData escape + URL-encode)
  - prompt does not corrupt stdout in `--output json` mode
- [ ] Manual smoke against a real TM1 server (post-merge)

Closes #83