### PR TITLE
feat(#84): chores run — execute a chore immediately

### DIFF
--- a/cmd/chores.go
+++ b/cmd/chores.go
@@ -673,7 +673,7 @@ func runChoresRun(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	endpoint := fmt.Sprintf("Chores('%s')/tm1.Execute", url.PathEscape(choreName))
+	endpoint := choreEndpoint(choreName, "tm1.Execute")
 
 	if choreRunAsync {
 		return runChoreAsync(cl, choreName, endpoint, jsonMode)
@@ -702,7 +702,7 @@ func runChoreAsync(cl *client.Client, choreName, endpoint string, jsonMode bool)
 }
 
 func runChoreSync(cl *client.Client, choreName, endpoint string, jsonMode bool) error {
-	cl.SetTimeout(choreRunTimeout) // MUST run before Post — bounds the wait.
+	cl.SetTimeout(choreRunTimeout) // MUST run before Post.
 
 	start := time.Now()
 	_, err := cl.Post(endpoint, map[string]interface{}{})
@@ -733,6 +733,10 @@ func handleChoreRunError(err error, choreName, timeout string, jsonMode bool) er
 		output.PrintError(fmt.Sprintf("Chore '%s' not found.", choreName), jsonMode)
 		return errExit(3)
 	}
+	if strings.HasPrefix(err.Error(), "HTTP 403") {
+		output.PrintError("Permission denied. Running chores requires admin privileges.", jsonMode)
+		return errSilent
+	}
 	if errors.Is(err, client.ErrTimeout) {
 		msg := fmt.Sprintf("Chore '%s' did not complete within %s.", choreName, timeout)
 		if jsonMode {
@@ -755,9 +759,8 @@ func handleChoreRunError(err error, choreName, timeout string, jsonMode bool) er
 }
 
 func printChoreTasksPreflight(cl *client.Client, choreName string) error {
-	endpoint := fmt.Sprintf(
-		"Chores('%s')?$expand=Tasks($expand=Process($select=Name))",
-		url.PathEscape(choreName))
+	endpoint := choreEndpoint(choreName, "") +
+		"?$select=Name&$expand=Tasks($expand=Process($select=Name))"
 	data, err := cl.Get(endpoint)
 	if err != nil {
 		return err

--- a/cmd/chores.go
+++ b/cmd/chores.go
@@ -632,6 +632,11 @@ REST API: POST /Chores('name')/tm1.Execute
 By default, the command waits for the chore to complete (up to --timeout).
 Use --async to return immediately with the server-side thread ID.
 
+With --verbose, the chore's task list is printed to stderr before the run.
+TM1's tm1.Execute does not stream per-task results, so step-level failure
+detail comes from the server's error message on failure (typically HTTP
+5xx) rather than from a structured per-task status.
+
 Exit codes:
   0  chore executed successfully (sync) or async accepted
   1  generic error (auth, network, server, task failure)

--- a/cmd/chores.go
+++ b/cmd/chores.go
@@ -654,17 +654,17 @@ Exit codes:
 func runChoresRun(cmd *cobra.Command, args []string) error {
 	choreName := args[0]
 
+	if !choreRunAsync && choreRunTimeout <= 0 {
+		emitChoreError(choreName, "error", "", "--timeout must be greater than zero.", isJSONOutput(nil))
+		return errSilent
+	}
+
 	cfg, err := loadConfig()
 	if err != nil {
 		emitChoreError(choreName, "error", "", err.Error(), isJSONOutput(nil))
 		return errSilent
 	}
 	jsonMode := isJSONOutput(cfg)
-
-	if !choreRunAsync && choreRunTimeout <= 0 {
-		emitChoreError(choreName, "error", "", "--timeout must be greater than zero.", jsonMode)
-		return errSilent
-	}
 
 	cl, err := createClient(cfg)
 	if err != nil {

--- a/cmd/chores.go
+++ b/cmd/chores.go
@@ -735,32 +735,38 @@ func runChoreSync(cl *client.Client, choreName, endpoint string, jsonMode bool) 
 
 func handleChoreRunError(err error, choreName, timeout string, jsonMode bool) error {
 	if errors.Is(err, client.ErrNotFound) {
-		output.PrintError(fmt.Sprintf("Chore '%s' not found.", choreName), jsonMode)
+		emitChoreError(choreName, "not_found", "",
+			fmt.Sprintf("Chore '%s' not found.", choreName), jsonMode)
 		return errExit(3)
 	}
 	if strings.HasPrefix(err.Error(), "HTTP 403") {
-		output.PrintError("Permission denied. Running chores requires admin privileges.", jsonMode)
+		emitChoreError(choreName, "forbidden", "",
+			"Permission denied. Running chores requires admin privileges.", jsonMode)
 		return errSilent
 	}
 	if errors.Is(err, client.ErrTimeout) {
-		msg := fmt.Sprintf("Chore '%s' did not complete within %s.", choreName, timeout)
-		if jsonMode {
-			output.PrintJSON(model.ChoreRunResult{
-				Chore: choreName, Status: "timeout", Timeout: timeout, Message: msg,
-			})
-		} else {
-			output.PrintError(msg, false)
-		}
+		emitChoreError(choreName, "timeout", timeout,
+			fmt.Sprintf("Chore '%s' did not complete within %s.", choreName, timeout), jsonMode)
 		return errExit(4)
 	}
+	emitChoreError(choreName, "error", "", err.Error(), jsonMode)
+	return errSilent
+}
+
+// emitChoreError unifies the error-output shape so JSON mode always emits a
+// single ChoreRunResult on stdout (matching the success path) and text mode
+// always emits a human-readable line on stderr.
+func emitChoreError(choreName, status, timeout, message string, jsonMode bool) {
 	if jsonMode {
 		output.PrintJSON(model.ChoreRunResult{
-			Chore: choreName, Status: "error", Message: err.Error(),
+			Chore:   choreName,
+			Status:  status,
+			Timeout: timeout,
+			Message: message,
 		})
-	} else {
-		output.PrintError(err.Error(), false)
+		return
 	}
-	return errSilent
+	output.PrintError(message, false)
 }
 
 func printChoreTasksPreflight(cl *client.Client, choreName string) error {

--- a/cmd/chores.go
+++ b/cmd/chores.go
@@ -10,6 +10,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 	"tm1cli/internal/client"
 	"tm1cli/internal/model"
 	"tm1cli/internal/output"
@@ -28,6 +29,13 @@ var (
 	choresActivateDryRun   bool
 	choresDeactivateYes    bool
 	choresDeactivateDryRun bool
+)
+
+const defaultChoreTimeout = 30 * time.Minute
+
+var (
+	choreRunAsync   bool
+	choreRunTimeout time.Duration
 )
 
 var choresCmd = &cobra.Command{
@@ -613,12 +621,169 @@ func handleChoreToggleError(err error, name string, jsonMode bool) error {
 	return errSilent
 }
 
+var choresRunCmd = &cobra.Command{
+	Use:          "run <name>",
+	Short:        "Execute a chore immediately",
+	SilenceUsage: true,
+	Long: `Execute a chore on the TM1 server.
+
+REST API: POST /Chores('name')/tm1.Execute
+
+By default, the command waits for the chore to complete (up to --timeout).
+Use --async to return immediately with the server-side thread ID.
+
+Exit codes:
+  0  chore executed successfully (sync) or async accepted
+  1  generic error (auth, network, server, task failure)
+  3  chore not found
+  4  wait exceeded --timeout`,
+	Example: `  tm1cli chores run "Nightly Load"
+  tm1cli chores run "Nightly Load" --async
+  tm1cli chores run "Nightly Load" --timeout 1h
+  tm1cli chores run "Nightly Load" --verbose
+  tm1cli chores run "Nightly Load" --output json`,
+	Args: cobra.ExactArgs(1),
+	RunE: runChoresRun,
+}
+
+func runChoresRun(cmd *cobra.Command, args []string) error {
+	choreName := args[0]
+
+	cfg, err := loadConfig()
+	if err != nil {
+		output.PrintError(err.Error(), isJSONOutput(nil))
+		return errSilent
+	}
+	jsonMode := isJSONOutput(cfg)
+
+	if !choreRunAsync && choreRunTimeout <= 0 {
+		output.PrintError("--timeout must be greater than zero.", jsonMode)
+		return errSilent
+	}
+
+	cl, err := createClient(cfg)
+	if err != nil {
+		output.PrintError(err.Error(), jsonMode)
+		return errSilent
+	}
+
+	if flagVerbose {
+		if err := printChoreTasksPreflight(cl, choreName); err != nil {
+			fmt.Fprintf(os.Stderr, "[warn] cannot fetch chore tasks: %s\n", err)
+		}
+	}
+
+	endpoint := fmt.Sprintf("Chores('%s')/tm1.Execute", url.PathEscape(choreName))
+
+	if choreRunAsync {
+		return runChoreAsync(cl, choreName, endpoint, jsonMode)
+	}
+	return runChoreSync(cl, choreName, endpoint, jsonMode)
+}
+
+func runChoreAsync(cl *client.Client, choreName, endpoint string, jsonMode bool) error {
+	threadID, err := cl.PostAsync(endpoint, map[string]interface{}{})
+	if err != nil {
+		return handleChoreRunError(err, choreName, "", jsonMode)
+	}
+	result := model.ChoreRunResult{
+		Chore:    choreName,
+		Status:   "started",
+		ThreadID: threadID,
+		Message:  fmt.Sprintf("Chore '%s' started asynchronously.", choreName),
+	}
+	if jsonMode {
+		output.PrintJSON(result)
+	} else {
+		fmt.Printf("Chore '%s' started asynchronously.\n", choreName)
+		fmt.Printf("  Thread ID: %s\n", threadID)
+	}
+	return nil
+}
+
+func runChoreSync(cl *client.Client, choreName, endpoint string, jsonMode bool) error {
+	cl.SetTimeout(choreRunTimeout) // MUST run before Post — bounds the wait.
+
+	start := time.Now()
+	_, err := cl.Post(endpoint, map[string]interface{}{})
+	elapsed := time.Since(start)
+
+	if err != nil {
+		return handleChoreRunError(err, choreName, choreRunTimeout.String(), jsonMode)
+	}
+
+	result := model.ChoreRunResult{
+		Chore:      choreName,
+		Status:     "completed",
+		DurationMs: elapsed.Milliseconds(),
+		Message:    fmt.Sprintf("Chore '%s' executed successfully.", choreName),
+	}
+	if jsonMode {
+		output.PrintJSON(result)
+	} else {
+		fmt.Printf("Chore '%s' executed successfully.\n", choreName)
+		fmt.Printf("  Status:   Completed\n")
+		fmt.Printf("  Duration: %.1fs\n", elapsed.Seconds())
+	}
+	return nil
+}
+
+func handleChoreRunError(err error, choreName, timeout string, jsonMode bool) error {
+	if errors.Is(err, client.ErrNotFound) {
+		output.PrintError(fmt.Sprintf("Chore '%s' not found.", choreName), jsonMode)
+		return errExit(3)
+	}
+	if errors.Is(err, client.ErrTimeout) {
+		msg := fmt.Sprintf("Chore '%s' did not complete within %s.", choreName, timeout)
+		if jsonMode {
+			output.PrintJSON(model.ChoreRunResult{
+				Chore: choreName, Status: "timeout", Timeout: timeout, Message: msg,
+			})
+		} else {
+			output.PrintError(msg, false)
+		}
+		return errExit(4)
+	}
+	if jsonMode {
+		output.PrintJSON(model.ChoreRunResult{
+			Chore: choreName, Status: "error", Message: err.Error(),
+		})
+	} else {
+		output.PrintError(err.Error(), false)
+	}
+	return errSilent
+}
+
+func printChoreTasksPreflight(cl *client.Client, choreName string) error {
+	endpoint := fmt.Sprintf(
+		"Chores('%s')?$expand=Tasks($expand=Process($select=Name))",
+		url.PathEscape(choreName))
+	data, err := cl.Get(endpoint)
+	if err != nil {
+		return err
+	}
+	var chore model.ChoreWithTasks
+	if jsonErr := json.Unmarshal(data, &chore); jsonErr != nil {
+		return fmt.Errorf("cannot parse chore: %w", jsonErr)
+	}
+	fmt.Fprintf(os.Stderr, "Chore '%s' has %d task(s):\n", chore.Name, len(chore.Tasks))
+	for i, t := range chore.Tasks {
+		step := t.Step
+		if step == 0 {
+			step = i + 1
+		}
+		fmt.Fprintf(os.Stderr, "  [%d] %s\n", step, t.Process.Name)
+	}
+	return nil
+}
+
 func init() {
 	rootCmd.AddCommand(choresCmd)
 	choresCmd.AddCommand(choresListCmd)
 	choresCmd.AddCommand(choresShowCmd)
 	choresCmd.AddCommand(choresActivateCmd)
 	choresCmd.AddCommand(choresDeactivateCmd)
+	choresCmd.AddCommand(choresRunCmd)
 
 	choresListCmd.Flags().StringVar(&choresFilter, "filter", "", "Filter by name (case-insensitive, partial match)")
 	choresListCmd.Flags().BoolVar(&choresActive, "active", false, "Show only active chores")
@@ -632,4 +797,9 @@ func init() {
 
 	choresDeactivateCmd.Flags().BoolVar(&choresDeactivateYes, "yes", false, "Skip confirmation prompt")
 	choresDeactivateCmd.Flags().BoolVar(&choresDeactivateDryRun, "dry-run", false, "Preview the deactivate without sending it")
+
+	choresRunCmd.Flags().BoolVar(&choreRunAsync, "async", false,
+		"Return immediately with the server-side thread ID; do not wait")
+	choresRunCmd.Flags().DurationVar(&choreRunTimeout, "timeout", defaultChoreTimeout,
+		"Maximum time to wait for the chore to complete (sync mode only)")
 }

--- a/cmd/chores.go
+++ b/cmd/chores.go
@@ -656,19 +656,19 @@ func runChoresRun(cmd *cobra.Command, args []string) error {
 
 	cfg, err := loadConfig()
 	if err != nil {
-		output.PrintError(err.Error(), isJSONOutput(nil))
+		emitChoreError(choreName, "error", "", err.Error(), isJSONOutput(nil))
 		return errSilent
 	}
 	jsonMode := isJSONOutput(cfg)
 
 	if !choreRunAsync && choreRunTimeout <= 0 {
-		output.PrintError("--timeout must be greater than zero.", jsonMode)
+		emitChoreError(choreName, "error", "", "--timeout must be greater than zero.", jsonMode)
 		return errSilent
 	}
 
 	cl, err := createClient(cfg)
 	if err != nil {
-		output.PrintError(err.Error(), jsonMode)
+		emitChoreError(choreName, "error", "", err.Error(), jsonMode)
 		return errSilent
 	}
 

--- a/cmd/chores_test.go
+++ b/cmd/chores_test.go
@@ -1658,6 +1658,75 @@ func TestRunChoresRun_TaskFailure_JSON(t *testing.T) {
 	}
 }
 
+func TestRunChoresRun_NotFound_JSON(t *testing.T) {
+	resetCmdFlags(t)
+	flagOutput = "json"
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		w.Write([]byte(`Not found`))
+	})
+
+	var err error
+	cap := captureAll(t, func() {
+		err = runChoresRun(choresRunCmd, []string{"Nightly"})
+	})
+
+	if exitCodeForError(err) != 3 {
+		t.Errorf("exit code = %d, want 3", exitCodeForError(err))
+	}
+	var result model.ChoreRunResult
+	if jsonErr := json.Unmarshal([]byte(cap.Stdout), &result); jsonErr != nil {
+		t.Fatalf("invalid JSON output: %v\nstdout: %s", jsonErr, cap.Stdout)
+	}
+	if result.Status != "not_found" {
+		t.Errorf("Status = %q, want %q", result.Status, "not_found")
+	}
+	if result.Chore != "Nightly" {
+		t.Errorf("Chore = %q, want %q", result.Chore, "Nightly")
+	}
+	if !strings.Contains(result.Message, "not found") {
+		t.Errorf("Message = %q, want it to mention 'not found'", result.Message)
+	}
+	if cap.Stderr != "" {
+		t.Errorf("stderr should be empty in JSON mode, got: %q", cap.Stderr)
+	}
+}
+
+func TestRunChoresRun_Timeout_JSON(t *testing.T) {
+	resetCmdFlags(t)
+	flagOutput = "json"
+	choreRunTimeout = 50 * time.Millisecond
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(500 * time.Millisecond)
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	var err error
+	cap := captureAll(t, func() {
+		err = runChoresRun(choresRunCmd, []string{"Nightly"})
+	})
+
+	if exitCodeForError(err) != 4 {
+		t.Errorf("exit code = %d, want 4", exitCodeForError(err))
+	}
+	var result model.ChoreRunResult
+	if jsonErr := json.Unmarshal([]byte(cap.Stdout), &result); jsonErr != nil {
+		t.Fatalf("invalid JSON output: %v\nstdout: %s", jsonErr, cap.Stdout)
+	}
+	if result.Status != "timeout" {
+		t.Errorf("Status = %q, want %q", result.Status, "timeout")
+	}
+	if result.Timeout != choreRunTimeout.String() {
+		t.Errorf("Timeout = %q, want %q", result.Timeout, choreRunTimeout.String())
+	}
+	if !strings.Contains(result.Message, "did not complete within") {
+		t.Errorf("Message = %q, want it to mention 'did not complete within'", result.Message)
+	}
+	if cap.Stderr != "" {
+		t.Errorf("stderr should be empty in JSON mode, got: %q", cap.Stderr)
+	}
+}
+
 func TestRunChoresRun_JSONSuccess(t *testing.T) {
 	resetCmdFlags(t)
 	flagOutput = "json"

--- a/cmd/chores_test.go
+++ b/cmd/chores_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+	"time"
 	"tm1cli/internal/model"
 )
 
@@ -1485,4 +1486,420 @@ func TestChoresActivate_NameWithQuote_URLEscaped(t *testing.T) {
 	if len(getPaths) != 1 || !strings.Contains(getPaths[0], "Chores('Daily''s')") {
 		t.Errorf("expected GET path with OData-doubled quote, got: %v", getPaths)
 	}
+}
+
+// ============================================================
+// chores run
+// ============================================================
+
+func TestRunChoresRun_Success(t *testing.T) {
+	resetCmdFlags(t)
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	var err error
+	cap := captureAll(t, func() {
+		err = runChoresRun(choresRunCmd, []string{"Nightly"})
+	})
+
+	if err != nil {
+		t.Fatalf("expected nil error, got: %v", err)
+	}
+	if !strings.Contains(cap.Stdout, "executed successfully") {
+		t.Errorf("stdout missing 'executed successfully': %s", cap.Stdout)
+	}
+	if !strings.Contains(cap.Stdout, "Completed") {
+		t.Errorf("stdout missing 'Completed': %s", cap.Stdout)
+	}
+}
+
+func TestRunChoresRun_Async(t *testing.T) {
+	resetCmdFlags(t)
+	choreRunAsync = true
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Location", "Threads('314')")
+		w.WriteHeader(http.StatusAccepted)
+	})
+
+	var err error
+	cap := captureAll(t, func() {
+		err = runChoresRun(choresRunCmd, []string{"Nightly"})
+	})
+
+	if err != nil {
+		t.Fatalf("expected nil error, got: %v", err)
+	}
+	if !strings.Contains(cap.Stdout, "started asynchronously") {
+		t.Errorf("stdout missing 'started asynchronously': %s", cap.Stdout)
+	}
+	if !strings.Contains(cap.Stdout, "314") {
+		t.Errorf("stdout missing thread id '314': %s", cap.Stdout)
+	}
+}
+
+func TestRunChoresRun_Async_JSON(t *testing.T) {
+	resetCmdFlags(t)
+	choreRunAsync = true
+	flagOutput = "json"
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Location", "Threads('314')")
+		w.WriteHeader(http.StatusAccepted)
+	})
+
+	var err error
+	cap := captureAll(t, func() {
+		err = runChoresRun(choresRunCmd, []string{"Nightly"})
+	})
+
+	if err != nil {
+		t.Fatalf("expected nil error, got: %v", err)
+	}
+	var result model.ChoreRunResult
+	if jsonErr := json.Unmarshal([]byte(cap.Stdout), &result); jsonErr != nil {
+		t.Fatalf("invalid JSON output: %v\nstdout: %s", jsonErr, cap.Stdout)
+	}
+	if result.Status != "started" {
+		t.Errorf("Status = %q, want %q", result.Status, "started")
+	}
+	if result.ThreadID != "314" {
+		t.Errorf("ThreadID = %q, want %q", result.ThreadID, "314")
+	}
+}
+
+func TestRunChoresRun_NotFound(t *testing.T) {
+	resetCmdFlags(t)
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		w.Write([]byte(`{"error":"not found"}`))
+	})
+
+	var err error
+	cap := captureAll(t, func() {
+		err = runChoresRun(choresRunCmd, []string{"Missing"})
+	})
+
+	if exitCodeForError(err) != 3 {
+		t.Errorf("exit code = %d, want 3 (err: %v)", exitCodeForError(err), err)
+	}
+	if !strings.Contains(cap.Stderr, "Chore 'Missing' not found.") {
+		t.Errorf("stderr missing 'not found' message: %s", cap.Stderr)
+	}
+}
+
+func TestRunChoresRun_Timeout(t *testing.T) {
+	resetCmdFlags(t)
+	choreRunTimeout = 50 * time.Millisecond
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(500 * time.Millisecond)
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	var err error
+	cap := captureAll(t, func() {
+		err = runChoresRun(choresRunCmd, []string{"SlowChore"})
+	})
+
+	if exitCodeForError(err) != 4 {
+		t.Errorf("exit code = %d, want 4 (err: %v)", exitCodeForError(err), err)
+	}
+	if !strings.Contains(cap.Stderr, "did not complete within") {
+		t.Errorf("stderr missing timeout message: %s", cap.Stderr)
+	}
+}
+
+func TestRunChoresRun_TaskFailure(t *testing.T) {
+	resetCmdFlags(t)
+	failMsg := "Chore 'Nightly' failed at step 2: Process 'Bad' returned an error"
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte(failMsg))
+	})
+
+	var err error
+	cap := captureAll(t, func() {
+		err = runChoresRun(choresRunCmd, []string{"Nightly"})
+	})
+
+	if exitCodeForError(err) != 1 {
+		t.Errorf("exit code = %d, want 1", exitCodeForError(err))
+	}
+	if !strings.Contains(cap.Stderr, "failed at step 2") {
+		t.Errorf("stderr missing failure message: %s", cap.Stderr)
+	}
+}
+
+func TestRunChoresRun_TaskFailure_JSON(t *testing.T) {
+	resetCmdFlags(t)
+	flagOutput = "json"
+	failMsg := "Chore 'Nightly' failed at step 2: Process 'Bad' returned an error"
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte(failMsg))
+	})
+
+	var err error
+	cap := captureAll(t, func() {
+		err = runChoresRun(choresRunCmd, []string{"Nightly"})
+	})
+
+	if exitCodeForError(err) != 1 {
+		t.Errorf("exit code = %d, want 1", exitCodeForError(err))
+	}
+	var result model.ChoreRunResult
+	if jsonErr := json.Unmarshal([]byte(cap.Stdout), &result); jsonErr != nil {
+		t.Fatalf("invalid JSON output: %v\nstdout: %s", jsonErr, cap.Stdout)
+	}
+	if result.Status != "error" {
+		t.Errorf("Status = %q, want %q", result.Status, "error")
+	}
+	if !strings.Contains(result.Message, "failed at step 2") {
+		t.Errorf("Message does not contain server text: %q", result.Message)
+	}
+}
+
+func TestRunChoresRun_JSONSuccess(t *testing.T) {
+	resetCmdFlags(t)
+	flagOutput = "json"
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	var err error
+	cap := captureAll(t, func() {
+		err = runChoresRun(choresRunCmd, []string{"Nightly"})
+	})
+
+	if err != nil {
+		t.Fatalf("expected nil error, got: %v", err)
+	}
+	var result model.ChoreRunResult
+	if jsonErr := json.Unmarshal([]byte(cap.Stdout), &result); jsonErr != nil {
+		t.Fatalf("invalid JSON output: %v\nstdout: %s", jsonErr, cap.Stdout)
+	}
+	if result.Status != "completed" {
+		t.Errorf("Status = %q, want %q", result.Status, "completed")
+	}
+	if result.Chore != "Nightly" {
+		t.Errorf("Chore = %q, want %q", result.Chore, "Nightly")
+	}
+	// DurationMs must be present (no omitempty); verify the raw JSON contains the key.
+	if !strings.Contains(cap.Stdout, `"duration_ms"`) {
+		t.Errorf("JSON output missing 'duration_ms' field: %s", cap.Stdout)
+	}
+	if result.DurationMs < 0 {
+		t.Errorf("DurationMs = %d, want >= 0", result.DurationMs)
+	}
+}
+
+func TestRunChoresRun_VerbosePreflightListsTasks(t *testing.T) {
+	resetCmdFlags(t)
+	flagVerbose = true
+	tasksBody := `{"Name":"Nightly","Tasks":[{"Step":1,"Process":{"Name":"LoadData"}},{"Step":2,"Process":{"Name":"RunReport"}}]}`
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "GET" {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(tasksBody))
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	var err error
+	cap := captureAll(t, func() {
+		err = runChoresRun(choresRunCmd, []string{"Nightly"})
+	})
+
+	if err != nil {
+		t.Fatalf("expected nil error, got: %v", err)
+	}
+	if !strings.Contains(cap.Stderr, "Chore 'Nightly' has 2 task(s):") {
+		t.Errorf("stderr missing task list header: %s", cap.Stderr)
+	}
+	if !strings.Contains(cap.Stderr, "[1] LoadData") {
+		t.Errorf("stderr missing '[1] LoadData': %s", cap.Stderr)
+	}
+	if !strings.Contains(cap.Stderr, "[2] RunReport") {
+		t.Errorf("stderr missing '[2] RunReport': %s", cap.Stderr)
+	}
+	if !strings.Contains(cap.Stdout, "executed successfully") {
+		t.Errorf("stdout missing 'executed successfully': %s", cap.Stdout)
+	}
+}
+
+func TestRunChoresRun_VerbosePreflightFailureIsNonFatal(t *testing.T) {
+	resetCmdFlags(t)
+	flagVerbose = true
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "GET" {
+			w.WriteHeader(http.StatusInternalServerError)
+			w.Write([]byte(`{"error":"server error"}`))
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	var err error
+	cap := captureAll(t, func() {
+		err = runChoresRun(choresRunCmd, []string{"Nightly"})
+	})
+
+	if err != nil {
+		t.Fatalf("expected nil error (preflight failure is non-fatal), got: %v", err)
+	}
+	if !strings.Contains(cap.Stderr, "[warn] cannot fetch chore tasks") {
+		t.Errorf("stderr missing warn message: %s", cap.Stderr)
+	}
+	if !strings.Contains(cap.Stdout, "executed successfully") {
+		t.Errorf("stdout missing 'executed successfully': %s", cap.Stdout)
+	}
+}
+
+func TestRunChoresRun_URLEncoding(t *testing.T) {
+	cases := []struct {
+		name         string
+		wantPathPart string
+	}{
+		{"Night Load", "Chores('Night%20Load')"},
+		{"A/B", "Chores('A%2FB')"},
+		{"A'B", "Chores('A%27B')"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			resetCmdFlags(t)
+			var gotPath string
+			setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+				gotPath = r.URL.EscapedPath()
+				w.WriteHeader(http.StatusNoContent)
+			})
+
+			captureAll(t, func() {
+				_ = runChoresRun(choresRunCmd, []string{tc.name})
+			})
+
+			if !strings.Contains(gotPath, tc.wantPathPart) {
+				t.Errorf("EscapedPath = %q, want it to contain %q", gotPath, tc.wantPathPart)
+			}
+		})
+	}
+}
+
+func TestRunChoresRun_AsyncIgnoresTimeoutFlag(t *testing.T) {
+	resetCmdFlags(t)
+	choreRunAsync = true
+	choreRunTimeout = 1 * time.Millisecond
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(50 * time.Millisecond)
+		w.Header().Set("Location", "Threads('99')")
+		w.WriteHeader(http.StatusAccepted)
+	})
+
+	var err error
+	captureAll(t, func() {
+		err = runChoresRun(choresRunCmd, []string{"Nightly"})
+	})
+
+	if err != nil {
+		t.Errorf("expected nil error (async skips SetTimeout), got: %v", err)
+	}
+}
+
+func TestRunChoresRun_TimeoutZero(t *testing.T) {
+	resetCmdFlags(t)
+	choreRunTimeout = 0
+
+	var err error
+	cap := captureAll(t, func() {
+		err = runChoresRun(choresRunCmd, []string{"Nightly"})
+	})
+
+	if exitCodeForError(err) != 1 {
+		t.Errorf("exit code = %d, want 1 (err: %v)", exitCodeForError(err), err)
+	}
+	if !strings.Contains(cap.Stderr, "--timeout must be greater than zero.") {
+		t.Errorf("stderr missing timeout-zero error: %s", cap.Stderr)
+	}
+}
+
+func TestRunChoresRun_AsyncServerIgnoredPrefer(t *testing.T) {
+	resetCmdFlags(t)
+	choreRunAsync = true
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	var err error
+	cap := captureAll(t, func() {
+		err = runChoresRun(choresRunCmd, []string{"Nightly"})
+	})
+
+	if exitCodeForError(err) != 1 {
+		t.Errorf("exit code = %d, want 1 (err: %v)", exitCodeForError(err), err)
+	}
+	if !strings.Contains(cap.Stderr, "async response missing Location") {
+		t.Errorf("stderr missing async-no-location message: %s", cap.Stderr)
+	}
+}
+
+func TestRunChoresRun_ExitCodes(t *testing.T) {
+	t.Run("404 -> exit 3", func(t *testing.T) {
+		resetCmdFlags(t)
+		setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+			w.Write([]byte(`not found`))
+		})
+		var err error
+		captureAll(t, func() {
+			err = runChoresRun(choresRunCmd, []string{"Nightly"})
+		})
+		if got := exitCodeForError(err); got != 3 {
+			t.Errorf("exit code = %d, want 3 (err: %v)", got, err)
+		}
+	})
+
+	t.Run("sleep > timeout -> exit 4", func(t *testing.T) {
+		resetCmdFlags(t)
+		choreRunTimeout = 50 * time.Millisecond
+		setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+			time.Sleep(500 * time.Millisecond)
+			w.WriteHeader(http.StatusNoContent)
+		})
+		var err error
+		captureAll(t, func() {
+			err = runChoresRun(choresRunCmd, []string{"Nightly"})
+		})
+		if got := exitCodeForError(err); got != 4 {
+			t.Errorf("exit code = %d, want 4 (err: %v)", got, err)
+		}
+	})
+
+	t.Run("500 -> exit 1", func(t *testing.T) {
+		resetCmdFlags(t)
+		setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+			w.Write([]byte(`server error`))
+		})
+		var err error
+		captureAll(t, func() {
+			err = runChoresRun(choresRunCmd, []string{"Nightly"})
+		})
+		if got := exitCodeForError(err); got != 1 {
+			t.Errorf("exit code = %d, want 1 (err: %v)", got, err)
+		}
+	})
+
+	t.Run("async missing Location -> exit 1", func(t *testing.T) {
+		resetCmdFlags(t)
+		choreRunAsync = true
+		setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNoContent)
+		})
+		var err error
+		captureAll(t, func() {
+			err = runChoresRun(choresRunCmd, []string{"Nightly"})
+		})
+		if got := exitCodeForError(err); got != 1 {
+			t.Errorf("exit code = %d, want 1 (err: %v)", got, err)
+		}
+	})
 }

--- a/cmd/chores_test.go
+++ b/cmd/chores_test.go
@@ -1890,6 +1890,37 @@ func TestRunChoresRun_TimeoutZero(t *testing.T) {
 	}
 }
 
+func TestRunChoresRun_TimeoutZero_JSON(t *testing.T) {
+	resetCmdFlags(t)
+	flagOutput = "json"
+	choreRunTimeout = 0
+
+	var err error
+	cap := captureAll(t, func() {
+		err = runChoresRun(choresRunCmd, []string{"Nightly"})
+	})
+
+	if exitCodeForError(err) != 1 {
+		t.Errorf("exit code = %d, want 1", exitCodeForError(err))
+	}
+	var result model.ChoreRunResult
+	if jsonErr := json.Unmarshal([]byte(cap.Stdout), &result); jsonErr != nil {
+		t.Fatalf("invalid JSON output: %v\nstdout: %s", jsonErr, cap.Stdout)
+	}
+	if result.Status != "error" {
+		t.Errorf("Status = %q, want %q", result.Status, "error")
+	}
+	if result.Chore != "Nightly" {
+		t.Errorf("Chore = %q, want %q", result.Chore, "Nightly")
+	}
+	if !strings.Contains(result.Message, "--timeout must be greater than zero.") {
+		t.Errorf("Message = %q, want timeout-zero text", result.Message)
+	}
+	if cap.Stderr != "" {
+		t.Errorf("stderr should be empty in JSON mode, got: %q", cap.Stderr)
+	}
+}
+
 func TestRunChoresRun_AsyncServerIgnoredPrefer(t *testing.T) {
 	resetCmdFlags(t)
 	choreRunAsync = true

--- a/cmd/chores_test.go
+++ b/cmd/chores_test.go
@@ -1762,7 +1762,7 @@ func TestRunChoresRun_URLEncoding(t *testing.T) {
 	}{
 		{"Night Load", "Chores('Night%20Load')"},
 		{"A/B", "Chores('A%2FB')"},
-		{"A'B", "Chores('A%27B')"},
+		{"A'B", "Chores('A%27%27B')"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/cmd/testhelpers_test.go
+++ b/cmd/testhelpers_test.go
@@ -266,6 +266,8 @@ func zeroAllFlags() {
 	choresActivateDryRun = false
 	choresDeactivateYes = false
 	choresDeactivateDryRun = false
+	choreRunAsync = false
+	choreRunTimeout = defaultChoreTimeout
 }
 
 // cubesJSON returns JSON for a TM1 Cubes response.

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -23,6 +23,11 @@ var ErrNotFound = errors.New("not found")
 // ErrTimeout is wrapped into timeout errors so callers can dispatch with errors.Is.
 var ErrTimeout = errors.New("timeout")
 
+// ErrAsyncNoLocation is returned when an async POST succeeds but the server
+// did not include a parseable "Threads('<id>')" Location header — i.e. it
+// likely ignored the Prefer: respond-async preference.
+var ErrAsyncNoLocation = errors.New("async response missing Location header")
+
 const defaultTimeout = 30 * time.Second
 
 type Client struct {
@@ -107,7 +112,7 @@ func (c *Client) setHeaders(req *http.Request) {
 	c.setAuth(req)
 }
 
-func (c *Client) do(req *http.Request) ([]byte, int, error) {
+func (c *Client) do(req *http.Request) (http.Header, []byte, int, error) {
 	c.setHeaders(req)
 
 	start := time.Now()
@@ -117,7 +122,7 @@ func (c *Client) do(req *http.Request) ([]byte, int, error) {
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
-		return nil, 0, c.wrapError(err)
+		return nil, nil, 0, c.wrapError(err)
 	}
 	defer resp.Body.Close()
 
@@ -128,14 +133,14 @@ func (c *Client) do(req *http.Request) ([]byte, int, error) {
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, resp.StatusCode, fmt.Errorf("cannot read response: %w", err)
+		return resp.Header, nil, resp.StatusCode, fmt.Errorf("cannot read response: %w", err)
 	}
 
 	if resp.StatusCode >= 400 {
-		return body, resp.StatusCode, c.httpError(resp.StatusCode, body, req.URL.Path)
+		return resp.Header, body, resp.StatusCode, c.httpError(resp.StatusCode, body, req.URL.Path)
 	}
 
-	return body, resp.StatusCode, nil
+	return resp.Header, body, resp.StatusCode, nil
 }
 
 func (c *Client) Get(endpoint string) ([]byte, error) {
@@ -144,7 +149,7 @@ func (c *Client) Get(endpoint string) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("cannot create request: %w", err)
 	}
-	body, _, err := c.do(req)
+	_, body, _, err := c.do(req)
 	return body, err
 }
 
@@ -162,7 +167,7 @@ func (c *Client) doWithPayload(method, endpoint string, payload interface{}) ([]
 	if err != nil {
 		return nil, fmt.Errorf("cannot create request: %w", err)
 	}
-	body, _, err := c.do(req)
+	_, body, _, err := c.do(req)
 	return body, err
 }
 
@@ -174,13 +179,65 @@ func (c *Client) Patch(endpoint string, payload interface{}) ([]byte, error) {
 	return c.doWithPayload("PATCH", endpoint, payload)
 }
 
+// PostAsync sends a POST with Prefer: respond-async. TM1 responds 202 Accepted
+// with Location: Threads('<id>'); the parsed numeric thread id is returned.
+// If the server omits or malforms the Location header (including the case
+// where it ignored the async preference and ran synchronously), the call
+// returns ErrAsyncNoLocation. HTTP errors >= 400 propagate from the
+// underlying do() path (ErrNotFound, ErrTimeout, etc.).
+func (c *Client) PostAsync(endpoint string, payload interface{}) (string, error) {
+	fullURL := c.baseURL + "/" + strings.TrimLeft(endpoint, "/")
+	var bodyReader io.Reader
+	if payload != nil {
+		data, err := json.Marshal(payload)
+		if err != nil {
+			return "", fmt.Errorf("cannot marshal request body: %w", err)
+		}
+		bodyReader = bytes.NewReader(data)
+	}
+	req, err := http.NewRequest("POST", fullURL, bodyReader)
+	if err != nil {
+		return "", fmt.Errorf("cannot create request: %w", err)
+	}
+	req.Header.Set("Prefer", "respond-async")
+
+	headers, _, _, err := c.do(req)
+	if err != nil {
+		return "", err
+	}
+	id, ok := parseThreadIDFromLocation(headers.Get("Location"))
+	if !ok {
+		return "", ErrAsyncNoLocation
+	}
+	return id, nil
+}
+
+// parseThreadIDFromLocation extracts the thread id from a TM1 async Location
+// header. Accepts "Threads('1234')" alone or as a suffix of an absolute URL.
+// Returns ("", false) when missing, empty-id, malformed, or wrong entity.
+func parseThreadIDFromLocation(loc string) (string, bool) {
+	if loc == "" {
+		return "", false
+	}
+	i := strings.LastIndex(loc, "Threads('")
+	if i < 0 {
+		return "", false
+	}
+	rest := loc[i+len("Threads('"):]
+	j := strings.Index(rest, "'")
+	if j <= 0 {
+		return "", false
+	}
+	return rest[:j], true
+}
+
 func (c *Client) Delete(endpoint string) error {
 	url := c.baseURL + "/" + strings.TrimLeft(endpoint, "/")
 	req, err := http.NewRequest("DELETE", url, nil)
 	if err != nil {
 		return fmt.Errorf("cannot create request: %w", err)
 	}
-	_, _, err = c.do(req)
+	_, _, _, err = c.do(req)
 	return err
 }
 

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -754,3 +754,70 @@ func TestHTTPErrorBodyTruncation(t *testing.T) {
 		t.Errorf("error body should be truncated to 200 chars, but contains %d x's", strings.Count(errStr, "x"))
 	}
 }
+
+func TestParseThreadIDFromLocation(t *testing.T) {
+	tests := []struct {
+		input  string
+		wantID string
+		wantOK bool
+	}{
+		{"Threads('1234')", "1234", true},
+		{"https://host/api/v1/Threads('77')", "77", true},
+		{"https://host/api/v1/Threads('77')?api-version=1", "77", true},
+		{"", "", false},
+		{"Threads('')", "", false},
+		{"Threads('1234", "", false},
+		{"Sessions('77')", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			gotID, gotOK := parseThreadIDFromLocation(tt.input)
+			if gotOK != tt.wantOK {
+				t.Errorf("ok = %v, want %v", gotOK, tt.wantOK)
+			}
+			if gotID != tt.wantID {
+				t.Errorf("id = %q, want %q", gotID, tt.wantID)
+			}
+		})
+	}
+}
+
+func TestPostAsync_SendsPreferHeader_ParsesLocation(t *testing.T) {
+	var capturedPrefer string
+	ts := newTestServer(func(w http.ResponseWriter, r *http.Request) {
+		capturedPrefer = r.Header.Get("Prefer")
+		w.Header().Set("Location", "Threads('77')")
+		w.WriteHeader(http.StatusAccepted)
+	})
+	defer ts.Close()
+
+	c := newTestClient(t, ts.URL)
+	id, err := c.PostAsync("Chores('Demo')/tm1.Execute", map[string]interface{}{})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if id != "77" {
+		t.Errorf("id = %q, want %q", id, "77")
+	}
+	if capturedPrefer != "respond-async" {
+		t.Errorf("Prefer header = %q, want %q", capturedPrefer, "respond-async")
+	}
+}
+
+func TestPostAsync_NoLocation_ReturnsErrAsyncNoLocation(t *testing.T) {
+	ts := newTestServer(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+	defer ts.Close()
+
+	c := newTestClient(t, ts.URL)
+	id, err := c.PostAsync("Chores('Demo')/tm1.Execute", map[string]interface{}{})
+
+	if !errors.Is(err, ErrAsyncNoLocation) {
+		t.Errorf("errors.Is(err, ErrAsyncNoLocation) = false, want true (err = %v)", err)
+	}
+	if id != "" {
+		t.Errorf("id = %q, want empty string", id)
+	}
+}

--- a/internal/model/chore.go
+++ b/internal/model/chore.go
@@ -36,7 +36,6 @@ type ChoreWithTasks struct {
 
 // ChoreRunResult is the JSON payload emitted by `chores run`.
 // Status values: "completed", "error", "timeout", "started".
-// DurationMs has no omitempty so it is always present on sync success.
 type ChoreRunResult struct {
 	Chore      string `json:"chore"`
 	Status     string `json:"status"`

--- a/internal/model/chore.go
+++ b/internal/model/chore.go
@@ -35,7 +35,7 @@ type ChoreWithTasks struct {
 }
 
 // ChoreRunResult is the JSON payload emitted by `chores run`.
-// Status values: "completed", "error", "timeout", "started".
+// Status values: "completed", "started", "error", "timeout", "not_found", "forbidden".
 type ChoreRunResult struct {
 	Chore      string `json:"chore"`
 	Status     string `json:"status"`

--- a/internal/model/chore.go
+++ b/internal/model/chore.go
@@ -1,12 +1,12 @@
 package model
 
 type Chore struct {
-	Name           string      `json:"Name"`
-	Active         bool        `json:"Active"`
-	StartTime      string      `json:"StartTime"`
-	DSTSensitive   bool        `json:"DSTSensitive"`
-	Frequency      string      `json:"Frequency"`
-	Tasks          []ChoreTask `json:"Tasks,omitempty"`
+	Name         string      `json:"Name"`
+	Active       bool        `json:"Active"`
+	StartTime    string      `json:"StartTime"`
+	DSTSensitive bool        `json:"DSTSensitive"`
+	Frequency    string      `json:"Frequency"`
+	Tasks        []ChoreTask `json:"Tasks,omitempty"`
 }
 
 type ChoreResponse struct {
@@ -14,7 +14,7 @@ type ChoreResponse struct {
 }
 
 type ChoreTask struct {
-	Step       int              `json:"Step"`
+	Step       int              `json:"Step,omitempty"`
 	Process    ChoreTaskProcess `json:"Process"`
 	Parameters []ChoreTaskParam `json:"Parameters"`
 }
@@ -26,4 +26,22 @@ type ChoreTaskProcess struct {
 type ChoreTaskParam struct {
 	Name  string      `json:"Name"`
 	Value interface{} `json:"Value"`
+}
+
+// ChoreWithTasks is the projection used by --verbose preflight.
+type ChoreWithTasks struct {
+	Name  string      `json:"Name"`
+	Tasks []ChoreTask `json:"Tasks"`
+}
+
+// ChoreRunResult is the JSON payload emitted by `chores run`.
+// Status values: "completed", "error", "timeout", "started".
+// DurationMs has no omitempty so it is always present on sync success.
+type ChoreRunResult struct {
+	Chore      string `json:"chore"`
+	Status     string `json:"status"`
+	DurationMs int64  `json:"duration_ms"`
+	ThreadID   string `json:"thread_id,omitempty"`
+	Timeout    string `json:"timeout,omitempty"`
+	Message    string `json:"message,omitempty"`
 }


### PR DESCRIPTION
## Summary
- Add `tm1cli chores run <name>` — POST `/Chores('name')/tm1.Execute`, waits by default and respects `--timeout` (default 30m); `--async` returns immediately with the server-side thread ID via `Prefer: respond-async` + `Location` header.
- Extend `internal/client/Client` with `PostAsync` + `ErrAsyncNoLocation` sentinel; widen the internal `do()` return to expose response headers.
- Exit codes propagate failure: `0` ok / async accepted · `1` generic (incl. task failure, missing async Location) · `3` chore not found · `4` wait exceeded `--timeout` · admin-required `HTTP 403` is mapped to a friendlier error.
- `--verbose` prints the chore's preflight task list to stderr; tightened OData projection to `$select=Name&$expand=Tasks($expand=Process($select=Name))` so unused chore properties stay off the wire.

Closes #84

## Acceptance criterion note (`--verbose`)
Issue #84 reads "Output: per-task status when `--verbose`". TM1's `tm1.Execute` is opaque — a sync run returns 204 with no per-task results, and the executing thread has exited from `/Threads` by the time the response lands. This PR interprets that criterion as **preflight task list to stderr, plus the server's error message (which typically names the failing step) propagated on 5xx**. The `chores run --help` Long now spells this out explicitly so the limitation is part of the contract rather than implied.

## Test plan
- [x] `go build ./...`
- [x] `go test ./...` — 1307 tests pass across 6 packages
- [x] New unit tests in `internal/client/client_test.go`:
  - `TestParseThreadIDFromLocation` (7-case table: relative / absolute / trailing query / malformed / empty / wrong entity)
  - `TestPostAsync_SendsPreferHeader_ParsesLocation`
  - `TestPostAsync_NoLocation_ReturnsErrAsyncNoLocation`
- [x] New integration tests in `cmd/chores_test.go` cover all four acceptance scenarios plus the edge cases the plan called out:
  - sync success (204) — text + JSON variants
  - async (202 + Location) — text + JSON variants
  - 404 → exit 3
  - timeout (handler sleeps past `--timeout`) → exit 4
  - 500 task failure → exit 1, error body propagated
  - `--verbose` preflight lists tasks; preflight 500 is non-fatal (`[warn]` to stderr, run continues)
  - URL encoding via `r.URL.EscapedPath()` — `Night Load`, `A/B`, `A'B` (OData-doubled `%27%27`)
  - `--async` ignores `--timeout`; `--timeout 0` rejected up front
  - async-with-no-Location surfaces `ErrAsyncNoLocation`
  - explicit `exitCodeForError` table asserting 3 / 4 / 1
- [ ] Smoke-test against a live TM1 instance before merging (not gated in CI)

## Commits
- `adad940` feat(#84): add chores run subcommand with sync/async execution
- `3282be1` refactor(#84): use choreEndpoint + tighten preflight projection
- `3616597` docs(#84): clarify --verbose scope for chores run