### PR TITLE
feat(#85): sandbox list and create commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,24 @@ tm1cli chores show "DailyLoad" --output json
 `Every 1 day`); JSON preserves the raw ISO 8601 duration. `chores show`
 exits with code 3 when the named chore does not exist.
 
+### Sandboxes
+
+```bash
+tm1cli sandbox list                       # list sandboxes (NAME, IN SANDBOX DIM, LOADED, ACTIVE, QUEUED)
+tm1cli sandbox list --loaded              # only sandboxes currently loaded in memory
+tm1cli sandbox list --active              # only sandboxes the current user has active
+tm1cli sandbox list --filter "fy24"       # filter by name (partial, case-insensitive)
+tm1cli sandbox list --count               # row count only
+tm1cli sandbox list --all                 # no 50-row limit
+tm1cli sandbox list --output json         # raw sandbox objects
+
+tm1cli sandbox create FY24Plan            # create a new sandbox
+tm1cli sandbox create FY24Plan --output json
+```
+
+`sandbox create` reports a clear "already exists" error when the name is
+taken (TM1 returns HTTP 400 or 409 depending on version).
+
 ### Logs
 
 ```bash

--- a/cmd/sandbox.go
+++ b/cmd/sandbox.go
@@ -21,9 +21,10 @@ var (
 )
 
 var sandboxCmd = &cobra.Command{
-	Use:   "sandbox",
-	Short: "Manage TM1 sandboxes",
-	Long:  `Manage and inspect TM1 sandboxes.`,
+	Use:          "sandbox",
+	Short:        "Manage TM1 sandboxes",
+	Long:         `Manage and inspect TM1 sandboxes.`,
+	SilenceUsage: true,
 }
 
 var sandboxListCmd = &cobra.Command{
@@ -39,8 +40,9 @@ Results are limited to 50 by default. Use --all to show everything.`,
   tm1cli sandbox list --active
   tm1cli sandbox list --filter "fy24"
   tm1cli sandbox list --output json`,
-	Args: cobra.NoArgs,
-	RunE: runSandboxList,
+	Args:         cobra.NoArgs,
+	RunE:         runSandboxList,
+	SilenceUsage: true,
 }
 
 var sandboxCreateCmd = &cobra.Command{
@@ -51,8 +53,9 @@ var sandboxCreateCmd = &cobra.Command{
 REST API: POST /Sandboxes`,
 	Example: `  tm1cli sandbox create FY24Plan
   tm1cli sandbox create FY24Plan --output json`,
-	Args: cobra.ExactArgs(1),
-	RunE: runSandboxCreate,
+	Args:         cobra.ExactArgs(1),
+	RunE:         runSandboxCreate,
+	SilenceUsage: true,
 }
 
 func runSandboxList(cmd *cobra.Command, args []string) error {
@@ -159,6 +162,9 @@ func displaySandboxes(sandboxes []model.Sandbox, total int, limit int, jsonMode 
 		shown = shown[:limit]
 	}
 	if jsonMode {
+		if shown == nil {
+			shown = []model.Sandbox{}
+		}
 		output.PrintJSON(shown)
 		return
 	}

--- a/cmd/sandbox.go
+++ b/cmd/sandbox.go
@@ -74,8 +74,7 @@ func runSandboxList(cmd *cobra.Command, args []string) error {
 
 	filterFallback := false
 	if sandboxListFilter != "" {
-		safeFilter := strings.ReplaceAll(sandboxListFilter, "'", "''")
-		filterEndpoint := endpoint + fmt.Sprintf("&$filter=contains(tolower(Name),tolower('%s'))", safeFilter)
+		filterEndpoint := endpoint + fmt.Sprintf("&$filter=contains(tolower(Name),tolower('%s'))", odataEscape(sandboxListFilter))
 		data, err := cl.Get(filterEndpoint)
 		if err == nil {
 			var resp model.SandboxResponse

--- a/cmd/sandbox.go
+++ b/cmd/sandbox.go
@@ -90,7 +90,10 @@ func runSandboxList(cmd *cobra.Command, args []string) error {
 
 	fetchEndpoint := endpoint
 	if limit > 0 && !activeFilters {
-		fetchEndpoint += fmt.Sprintf("&$top=%d", limit)
+		// Over-fetch above --limit so PrintSummary can report "Showing N of M"
+		// when the server has more than --limit rows; otherwise --count would
+		// silently cap at --limit and the truncation summary would never fire.
+		fetchEndpoint += fmt.Sprintf("&$top=%d", limit+500)
 	}
 
 	data, err := cl.Get(fetchEndpoint)

--- a/cmd/sandbox.go
+++ b/cmd/sandbox.go
@@ -1,0 +1,247 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+	"tm1cli/internal/model"
+	"tm1cli/internal/output"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	sandboxListFilter string
+	sandboxListLimit  int
+	sandboxListAll    bool
+	sandboxListCount  bool
+	sandboxListLoaded bool
+	sandboxListActive bool
+)
+
+var sandboxCmd = &cobra.Command{
+	Use:   "sandbox",
+	Short: "Manage TM1 sandboxes",
+	Long:  `Manage and inspect TM1 sandboxes.`,
+}
+
+var sandboxListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List TM1 sandboxes",
+	Long: `List sandboxes on the TM1 server.
+
+REST API: GET /Sandboxes
+
+Results are limited to 50 by default. Use --all to show everything.`,
+	Example: `  tm1cli sandbox list
+  tm1cli sandbox list --loaded
+  tm1cli sandbox list --active
+  tm1cli sandbox list --filter "fy24"
+  tm1cli sandbox list --output json`,
+	Args: cobra.NoArgs,
+	RunE: runSandboxList,
+}
+
+var sandboxCreateCmd = &cobra.Command{
+	Use:   "create <name>",
+	Short: "Create a new sandbox",
+	Long: `Create a new TM1 sandbox.
+
+REST API: POST /Sandboxes`,
+	Example: `  tm1cli sandbox create FY24Plan
+  tm1cli sandbox create FY24Plan --output json`,
+	Args: cobra.ExactArgs(1),
+	RunE: runSandboxCreate,
+}
+
+func runSandboxList(cmd *cobra.Command, args []string) error {
+	cfg, err := loadConfig()
+	if err != nil {
+		output.PrintError(err.Error(), isJSONOutput(nil))
+		return errSilent
+	}
+	jsonMode := isJSONOutput(cfg)
+	cl, err := createClient(cfg)
+	if err != nil {
+		output.PrintError(err.Error(), jsonMode)
+		return errSilent
+	}
+
+	limit := getLimit(cfg, sandboxListLimit, sandboxListAll)
+	activeFilters := sandboxListFilter != "" || sandboxListLoaded || sandboxListActive
+	endpoint := "Sandboxes?$select=Name,IncludeInSandboxDimension,Loaded,Active,Queued"
+
+	filterFallback := false
+	if sandboxListFilter != "" {
+		safeFilter := strings.ReplaceAll(sandboxListFilter, "'", "''")
+		filterEndpoint := endpoint + fmt.Sprintf("&$filter=contains(tolower(Name),tolower('%s'))", safeFilter)
+		data, err := cl.Get(filterEndpoint)
+		if err == nil {
+			var resp model.SandboxResponse
+			if jsonErr := json.Unmarshal(data, &resp); jsonErr == nil {
+				sandboxes := applySandboxBoolFilters(resp.Value, sandboxListLoaded, sandboxListActive)
+				displaySandboxes(sandboxes, len(sandboxes), limit, jsonMode)
+				return nil
+			}
+		}
+		filterFallback = true
+		output.PrintWarning("Server-side filter not supported, filtering locally...")
+	}
+
+	fetchEndpoint := endpoint
+	if limit > 0 && !activeFilters {
+		fetchEndpoint += fmt.Sprintf("&$top=%d", limit)
+	}
+
+	data, err := cl.Get(fetchEndpoint)
+	if err != nil {
+		output.PrintError(err.Error(), jsonMode)
+		return errSilent
+	}
+	var resp model.SandboxResponse
+	if err := json.Unmarshal(data, &resp); err != nil {
+		output.PrintError("Cannot parse server response.", jsonMode)
+		return errSilent
+	}
+
+	sandboxes := resp.Value
+	if sandboxListFilter != "" && filterFallback {
+		sandboxes = filterSandboxesByName(sandboxes, sandboxListFilter)
+	}
+	sandboxes = applySandboxBoolFilters(sandboxes, sandboxListLoaded, sandboxListActive)
+	displaySandboxes(sandboxes, len(sandboxes), limit, jsonMode)
+	return nil
+}
+
+func filterSandboxesByName(sandboxes []model.Sandbox, filter string) []model.Sandbox {
+	lower := strings.ToLower(filter)
+	var out []model.Sandbox
+	for _, s := range sandboxes {
+		if strings.Contains(strings.ToLower(s.Name), lower) {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+func applySandboxBoolFilters(sandboxes []model.Sandbox, loaded, active bool) []model.Sandbox {
+	if !loaded && !active {
+		return sandboxes
+	}
+	var out []model.Sandbox
+	for _, s := range sandboxes {
+		if loaded && !s.Loaded {
+			continue
+		}
+		if active && !s.Active {
+			continue
+		}
+		out = append(out, s)
+	}
+	return out
+}
+
+func displaySandboxes(sandboxes []model.Sandbox, total int, limit int, jsonMode bool) {
+	if sandboxListCount {
+		if jsonMode {
+			output.PrintJSON(map[string]int{"count": total})
+		} else {
+			fmt.Printf("%d sandboxes\n", total)
+		}
+		return
+	}
+
+	shown := sandboxes
+	if limit > 0 && len(shown) > limit {
+		shown = shown[:limit]
+	}
+	if jsonMode {
+		output.PrintJSON(shown)
+		return
+	}
+
+	headers := []string{"NAME", "IN SANDBOX DIM", "LOADED", "ACTIVE", "QUEUED"}
+	rows := make([][]string, len(shown))
+	for i, s := range shown {
+		rows[i] = []string{
+			s.Name,
+			strconv.FormatBool(s.IncludeInSandboxDimension),
+			strconv.FormatBool(s.Loaded),
+			strconv.FormatBool(s.Active),
+			strconv.FormatBool(s.Queued),
+		}
+	}
+	output.PrintTable(headers, rows)
+	output.PrintSummary(len(shown), total, "--filter, --loaded, --active, or --all")
+}
+
+func runSandboxCreate(cmd *cobra.Command, args []string) error {
+	name := args[0]
+
+	cfg, err := loadConfig()
+	if err != nil {
+		output.PrintError(err.Error(), isJSONOutput(nil))
+		return errSilent
+	}
+	jsonMode := isJSONOutput(cfg)
+
+	if strings.TrimSpace(name) == "" {
+		output.PrintError("Sandbox name cannot be empty.", jsonMode)
+		return errSilent
+	}
+
+	cl, err := createClient(cfg)
+	if err != nil {
+		output.PrintError(err.Error(), jsonMode)
+		return errSilent
+	}
+
+	body, err := cl.Post("Sandboxes", map[string]string{"Name": name})
+	if err != nil {
+		if isDuplicateSandboxError(body, err) {
+			output.PrintError(fmt.Sprintf("Sandbox '%s' already exists.", name), jsonMode)
+			return errSilent
+		}
+		output.PrintError(err.Error(), jsonMode)
+		return errSilent
+	}
+
+	if jsonMode {
+		output.PrintJSON(map[string]string{"status": "created", "name": name})
+	} else {
+		fmt.Printf("Created sandbox '%s'.\n", name)
+	}
+	return nil
+}
+
+// isDuplicateSandboxError reports whether the (body, err) pair from a
+// POST /Sandboxes failure is a duplicate-name conflict. TM1 returns HTTP
+// 400 (and HTTP 409 on some newer PA versions) with a body containing
+// "already exists" or "duplicate". The body is inspected (rather than
+// only err.Error()) because client.httpError truncates the body at 200
+// chars in the error string, which may cut off the keyword.
+func isDuplicateSandboxError(body []byte, err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	if !strings.HasPrefix(msg, "HTTP 400") && !strings.HasPrefix(msg, "HTTP 409") {
+		return false
+	}
+	combined := strings.ToLower(msg + " " + string(body))
+	return strings.Contains(combined, "already exists") || strings.Contains(combined, "duplicate")
+}
+
+func init() {
+	rootCmd.AddCommand(sandboxCmd)
+	sandboxCmd.AddCommand(sandboxListCmd)
+	sandboxCmd.AddCommand(sandboxCreateCmd)
+
+	sandboxListCmd.Flags().StringVar(&sandboxListFilter, "filter", "", "Filter by name (case-insensitive, partial match)")
+	sandboxListCmd.Flags().IntVar(&sandboxListLimit, "limit", 0, "Max results to show (default from settings)")
+	sandboxListCmd.Flags().BoolVar(&sandboxListAll, "all", false, "Show all results, no limit")
+	sandboxListCmd.Flags().BoolVar(&sandboxListCount, "count", false, "Show count only")
+	sandboxListCmd.Flags().BoolVar(&sandboxListLoaded, "loaded", false, "Show only sandboxes currently loaded in memory")
+	sandboxListCmd.Flags().BoolVar(&sandboxListActive, "active", false, "Show only sandboxes the current user has active")
+}

--- a/cmd/sandbox.go
+++ b/cmd/sandbox.go
@@ -70,7 +70,7 @@ func runSandboxList(cmd *cobra.Command, args []string) error {
 
 	limit := getLimit(cfg, sandboxListLimit, sandboxListAll)
 	activeFilters := sandboxListFilter != "" || sandboxListLoaded || sandboxListActive
-	endpoint := "Sandboxes?$select=Name,IncludeInSandboxDimension,Loaded,Active,Queued"
+	endpoint := "Sandboxes?$select=Name,IncludeInSandboxDimension,IsLoaded,IsActive,IsQueued"
 
 	filterFallback := false
 	if sandboxListFilter != "" {
@@ -133,10 +133,10 @@ func applySandboxBoolFilters(sandboxes []model.Sandbox, loaded, active bool) []m
 	}
 	var out []model.Sandbox
 	for _, s := range sandboxes {
-		if loaded && !s.Loaded {
+		if loaded && !s.IsLoaded {
 			continue
 		}
-		if active && !s.Active {
+		if active && !s.IsActive {
 			continue
 		}
 		out = append(out, s)
@@ -169,9 +169,9 @@ func displaySandboxes(sandboxes []model.Sandbox, total int, limit int, jsonMode 
 		rows[i] = []string{
 			s.Name,
 			strconv.FormatBool(s.IncludeInSandboxDimension),
-			strconv.FormatBool(s.Loaded),
-			strconv.FormatBool(s.Active),
-			strconv.FormatBool(s.Queued),
+			strconv.FormatBool(s.IsLoaded),
+			strconv.FormatBool(s.IsActive),
+			strconv.FormatBool(s.IsQueued),
 		}
 	}
 	output.PrintTable(headers, rows)

--- a/cmd/sandbox_test.go
+++ b/cmd/sandbox_test.go
@@ -1,0 +1,787 @@
+package cmd
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"tm1cli/internal/model"
+)
+
+// ============================================================
+// filterSandboxesByName
+// ============================================================
+
+func TestFilterSandboxesByName(t *testing.T) {
+	sandboxes := []model.Sandbox{
+		{Name: "Plan_FY24"},
+		{Name: "Budget_FY24"},
+		{Name: "FORECAST"},
+		{Name: "actual"},
+	}
+
+	tests := []struct {
+		name      string
+		filter    string
+		wantNames []string
+	}{
+		{"basic match", "fy24", []string{"Plan_FY24", "Budget_FY24"}},
+		{"case-insensitive uppercase filter", "PLAN", []string{"Plan_FY24"}},
+		{"empty filter returns all", "", []string{"Plan_FY24", "Budget_FY24", "FORECAST", "actual"}},
+		{"no match returns nil", "xyz", nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := filterSandboxesByName(sandboxes, tt.filter)
+			gotNames := sandboxNames(got)
+			if !stringSliceEqual(gotNames, tt.wantNames) {
+				t.Errorf("filterSandboxesByName(%q) = %v, want %v", tt.filter, gotNames, tt.wantNames)
+			}
+		})
+	}
+}
+
+// ============================================================
+// applySandboxBoolFilters
+// ============================================================
+
+func TestApplySandboxBoolFilters(t *testing.T) {
+	sandboxes := []model.Sandbox{
+		{Name: "LoadedOnly", Loaded: true, Active: false},
+		{Name: "ActiveOnly", Loaded: false, Active: true},
+		{Name: "Both", Loaded: true, Active: true},
+		{Name: "Neither", Loaded: false, Active: false},
+	}
+
+	tests := []struct {
+		name      string
+		loaded    bool
+		active    bool
+		wantNames []string
+	}{
+		{"no filters returns input", false, false, []string{"LoadedOnly", "ActiveOnly", "Both", "Neither"}},
+		{"loaded only", true, false, []string{"LoadedOnly", "Both"}},
+		{"active only", false, true, []string{"ActiveOnly", "Both"}},
+		{"loaded and active (AND)", true, true, []string{"Both"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := applySandboxBoolFilters(sandboxes, tt.loaded, tt.active)
+			gotNames := sandboxNames(got)
+			if !stringSliceEqual(gotNames, tt.wantNames) {
+				t.Errorf("applySandboxBoolFilters(loaded=%v, active=%v) = %v, want %v",
+					tt.loaded, tt.active, gotNames, tt.wantNames)
+			}
+		})
+	}
+}
+
+// ============================================================
+// isDuplicateSandboxError
+// ============================================================
+
+func TestIsDuplicateSandboxError(t *testing.T) {
+	tests := []struct {
+		name string
+		body []byte
+		err  error
+		want bool
+	}{
+		{"nil err returns false", []byte("already exists"), nil, false},
+		{"HTTP 400 with already exists body", []byte(`{"error":{"message":"Sandbox 'X' already exists."}}`), fmt.Errorf("HTTP 400: short"), true},
+		{"HTTP 400 with already exists in err string", nil, fmt.Errorf("HTTP 400: already exists"), true},
+		{"HTTP 409 with duplicate body", []byte("Sandbox is a duplicate"), fmt.Errorf("HTTP 409: conflict"), true},
+		{"HTTP 400 with unrelated body", []byte("invalid query"), fmt.Errorf("HTTP 400: invalid query"), false},
+		{"HTTP 500 with already exists body (ignored)", []byte("already exists"), fmt.Errorf("HTTP 500: server error"), false},
+		{"HTTP 404 not duplicate", []byte("not found"), fmt.Errorf("HTTP 404: not found"), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isDuplicateSandboxError(tt.body, tt.err)
+			if got != tt.want {
+				t.Errorf("isDuplicateSandboxError() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// ============================================================
+// displaySandboxes
+// ============================================================
+
+func TestDisplaySandboxes_TableHeaders(t *testing.T) {
+	origCount := sandboxListCount
+	defer func() { sandboxListCount = origCount }()
+	sandboxListCount = false
+
+	sandboxes := []model.Sandbox{
+		{Name: "FY24Plan", IncludeInSandboxDimension: true, Loaded: true, Active: false, Queued: false},
+	}
+
+	out := captureStdout(t, func() {
+		displaySandboxes(sandboxes, len(sandboxes), 0, false)
+	})
+
+	for _, h := range []string{"NAME", "IN SANDBOX DIM", "LOADED", "ACTIVE", "QUEUED"} {
+		if !strings.Contains(out, h) {
+			t.Errorf("table output missing header %q, got:\n%s", h, out)
+		}
+	}
+	if !strings.Contains(out, "FY24Plan") {
+		t.Errorf("table output missing sandbox name, got:\n%s", out)
+	}
+	if !strings.Contains(out, "true") || !strings.Contains(out, "false") {
+		t.Errorf("table output missing true/false values, got:\n%s", out)
+	}
+}
+
+func TestDisplaySandboxes_JSONOutput(t *testing.T) {
+	origCount := sandboxListCount
+	defer func() { sandboxListCount = origCount }()
+	sandboxListCount = false
+
+	sandboxes := []model.Sandbox{
+		{Name: "A", Loaded: true, Active: true},
+		{Name: "B"},
+	}
+
+	out := captureStdout(t, func() {
+		displaySandboxes(sandboxes, len(sandboxes), 0, true)
+	})
+
+	var parsed []model.Sandbox
+	if err := json.Unmarshal([]byte(out), &parsed); err != nil {
+		t.Fatalf("cannot parse JSON output: %v\noutput:\n%s", err, out)
+	}
+	if len(parsed) != 2 {
+		t.Fatalf("JSON output length = %d, want 2", len(parsed))
+	}
+	if parsed[0].Name != "A" || !parsed[0].Loaded || !parsed[0].Active {
+		t.Errorf("JSON[0] = %+v, want Name=A Loaded=true Active=true", parsed[0])
+	}
+}
+
+func TestDisplaySandboxes_Count(t *testing.T) {
+	origCount := sandboxListCount
+	defer func() { sandboxListCount = origCount }()
+	sandboxListCount = true
+
+	sandboxes := []model.Sandbox{{Name: "A"}, {Name: "B"}, {Name: "C"}, {Name: "D"}, {Name: "E"}}
+
+	out := captureStdout(t, func() {
+		displaySandboxes(sandboxes, 5, 0, false)
+	})
+
+	if out != "5 sandboxes\n" {
+		t.Errorf("count output = %q, want %q", out, "5 sandboxes\n")
+	}
+}
+
+func TestDisplaySandboxes_CountJSON(t *testing.T) {
+	origCount := sandboxListCount
+	defer func() { sandboxListCount = origCount }()
+	sandboxListCount = true
+
+	out := captureStdout(t, func() {
+		displaySandboxes([]model.Sandbox{{Name: "A"}}, 7, 0, true)
+	})
+
+	var parsed map[string]int
+	if err := json.Unmarshal([]byte(out), &parsed); err != nil {
+		t.Fatalf("cannot parse JSON count: %v\noutput:\n%s", err, out)
+	}
+	if parsed["count"] != 7 {
+		t.Errorf("count = %d, want 7", parsed["count"])
+	}
+}
+
+func TestDisplaySandboxes_LimitTruncation(t *testing.T) {
+	origCount := sandboxListCount
+	defer func() { sandboxListCount = origCount }()
+	sandboxListCount = false
+
+	sandboxes := []model.Sandbox{
+		{Name: "A1"}, {Name: "A2"}, {Name: "A3"}, {Name: "A4"}, {Name: "A5"},
+	}
+
+	captured := captureAll(t, func() {
+		displaySandboxes(sandboxes, 5, 2, false)
+	})
+
+	if !strings.Contains(captured.Stdout, "A1") || !strings.Contains(captured.Stdout, "A2") {
+		t.Errorf("output should contain first 2 names, got:\n%s", captured.Stdout)
+	}
+	if strings.Contains(captured.Stdout, "A3") || strings.Contains(captured.Stdout, "A5") {
+		t.Errorf("output should not contain truncated names, got:\n%s", captured.Stdout)
+	}
+	if !strings.Contains(captured.Stderr, "Showing 2 of 5") {
+		t.Errorf("stderr should contain truncation summary, got:\n%s", captured.Stderr)
+	}
+}
+
+// ============================================================
+// Integration — runSandboxList
+// ============================================================
+
+func TestRunSandboxList_TableOutput(t *testing.T) {
+	resetCmdFlags(t)
+
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(sandboxesJSON(
+			model.Sandbox{Name: "FY24Plan", IncludeInSandboxDimension: true, Loaded: true},
+			model.Sandbox{Name: "FY24Budget"},
+		))
+	})
+
+	captured := captureAll(t, func() {
+		if err := runSandboxList(sandboxListCmd, nil); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	for _, want := range []string{"NAME", "FY24Plan", "FY24Budget"} {
+		if !strings.Contains(captured.Stdout, want) {
+			t.Errorf("stdout missing %q, got:\n%s", want, captured.Stdout)
+		}
+	}
+}
+
+func TestRunSandboxList_JSONOutput(t *testing.T) {
+	resetCmdFlags(t)
+	flagOutput = "json"
+
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(sandboxesJSON(model.Sandbox{
+			Name: "FY24Plan", IncludeInSandboxDimension: true, Loaded: true, Active: true, Queued: false,
+		}))
+	})
+
+	captured := captureAll(t, func() {
+		if err := runSandboxList(sandboxListCmd, nil); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	var parsed []model.Sandbox
+	if err := json.Unmarshal([]byte(captured.Stdout), &parsed); err != nil {
+		t.Fatalf("output is not valid JSON: %v\noutput: %s", err, captured.Stdout)
+	}
+	if len(parsed) != 1 {
+		t.Fatalf("expected 1 sandbox, got %d", len(parsed))
+	}
+	got := parsed[0]
+	if got.Name != "FY24Plan" || !got.IncludeInSandboxDimension || !got.Loaded || !got.Active || got.Queued {
+		t.Errorf("unexpected fields: %+v", got)
+	}
+}
+
+func TestRunSandboxList_LoadedFilter(t *testing.T) {
+	resetCmdFlags(t)
+	sandboxListLoaded = true
+
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(sandboxesJSON(
+			model.Sandbox{Name: "Loaded1", Loaded: true},
+			model.Sandbox{Name: "NotLoaded", Loaded: false},
+			model.Sandbox{Name: "Loaded2", Loaded: true, Active: true},
+		))
+	})
+
+	captured := captureAll(t, func() {
+		if err := runSandboxList(sandboxListCmd, nil); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	if !strings.Contains(captured.Stdout, "Loaded1") || !strings.Contains(captured.Stdout, "Loaded2") {
+		t.Errorf("output should contain Loaded sandboxes, got:\n%s", captured.Stdout)
+	}
+	if strings.Contains(captured.Stdout, "NotLoaded") {
+		t.Errorf("output should not contain NotLoaded, got:\n%s", captured.Stdout)
+	}
+}
+
+func TestRunSandboxList_ActiveFilter(t *testing.T) {
+	resetCmdFlags(t)
+	sandboxListActive = true
+
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(sandboxesJSON(
+			model.Sandbox{Name: "Active1", Active: true},
+			model.Sandbox{Name: "NotActive"},
+			model.Sandbox{Name: "Active2", Active: true, Loaded: true},
+		))
+	})
+
+	captured := captureAll(t, func() {
+		if err := runSandboxList(sandboxListCmd, nil); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	if !strings.Contains(captured.Stdout, "Active1") || !strings.Contains(captured.Stdout, "Active2") {
+		t.Errorf("output should contain Active sandboxes, got:\n%s", captured.Stdout)
+	}
+	if strings.Contains(captured.Stdout, "NotActive") {
+		t.Errorf("output should not contain NotActive, got:\n%s", captured.Stdout)
+	}
+}
+
+func TestRunSandboxList_NameFilterFallback(t *testing.T) {
+	resetCmdFlags(t)
+	sandboxListFilter = "plan"
+
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.RawQuery, "$filter") {
+			w.WriteHeader(http.StatusBadRequest)
+			w.Write([]byte(`{"error":"filter not supported"}`))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(sandboxesJSON(
+			model.Sandbox{Name: "FY24Plan"},
+			model.Sandbox{Name: "Budget"},
+			model.Sandbox{Name: "PlanB"},
+		))
+	})
+
+	captured := captureAll(t, func() {
+		if err := runSandboxList(sandboxListCmd, nil); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	if !strings.Contains(captured.Stderr, "[warn]") {
+		t.Errorf("stderr should contain [warn] for fallback, got:\n%s", captured.Stderr)
+	}
+	if !strings.Contains(captured.Stderr, "filtering locally") {
+		t.Errorf("stderr should mention local filtering, got:\n%s", captured.Stderr)
+	}
+	if !strings.Contains(captured.Stdout, "FY24Plan") || !strings.Contains(captured.Stdout, "PlanB") {
+		t.Errorf("output should contain matching names, got:\n%s", captured.Stdout)
+	}
+	if strings.Contains(captured.Stdout, "Budget") {
+		t.Errorf("output should not contain non-matching names, got:\n%s", captured.Stdout)
+	}
+}
+
+func TestRunSandboxList_ServerSideFilterSuccess(t *testing.T) {
+	resetCmdFlags(t)
+	sandboxListFilter = "plan"
+
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(sandboxesJSON(
+			model.Sandbox{Name: "FY24Plan"},
+			model.Sandbox{Name: "PlanB"},
+		))
+	})
+
+	captured := captureAll(t, func() {
+		if err := runSandboxList(sandboxListCmd, nil); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	if strings.Contains(captured.Stderr, "[warn]") {
+		t.Errorf("stderr should not contain [warn] when server filter succeeds, got:\n%s", captured.Stderr)
+	}
+	if !strings.Contains(captured.Stdout, "FY24Plan") {
+		t.Errorf("output missing FY24Plan, got:\n%s", captured.Stdout)
+	}
+}
+
+func TestRunSandboxList_FilterPlusBooleanFilters(t *testing.T) {
+	resetCmdFlags(t)
+	sandboxListFilter = "plan"
+	sandboxListLoaded = true
+
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		// Server-side filter returns name-matched results; client must AND with --loaded.
+		w.Write(sandboxesJSON(
+			model.Sandbox{Name: "FY24Plan", Loaded: true},
+			model.Sandbox{Name: "PlanB", Loaded: false},
+		))
+	})
+
+	captured := captureAll(t, func() {
+		if err := runSandboxList(sandboxListCmd, nil); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	if !strings.Contains(captured.Stdout, "FY24Plan") {
+		t.Errorf("output should contain FY24Plan (matches both filters), got:\n%s", captured.Stdout)
+	}
+	if strings.Contains(captured.Stdout, "PlanB") {
+		t.Errorf("output should not contain PlanB (fails --loaded filter), got:\n%s", captured.Stdout)
+	}
+}
+
+func TestRunSandboxList_EmptyResult(t *testing.T) {
+	resetCmdFlags(t)
+
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"value":[]}`))
+	})
+
+	captured := captureAll(t, func() {
+		if err := runSandboxList(sandboxListCmd, nil); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	if !strings.Contains(captured.Stdout, "NAME") {
+		t.Errorf("output should contain header even for empty result, got:\n%s", captured.Stdout)
+	}
+}
+
+func TestRunSandboxList_HTTPError(t *testing.T) {
+	resetCmdFlags(t)
+
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte(`{"error":"server explosion"}`))
+	})
+
+	captured := captureAll(t, func() {
+		err := runSandboxList(sandboxListCmd, nil)
+		if !errors.Is(err, errSilent) {
+			t.Fatalf("expected errSilent, got: %v", err)
+		}
+	})
+
+	if !strings.Contains(captured.Stderr, "Error:") {
+		t.Errorf("stderr should contain 'Error:', got:\n%s", captured.Stderr)
+	}
+}
+
+func TestRunSandboxList_MalformedJSON(t *testing.T) {
+	resetCmdFlags(t)
+
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{not json`))
+	})
+
+	captured := captureAll(t, func() {
+		err := runSandboxList(sandboxListCmd, nil)
+		if !errors.Is(err, errSilent) {
+			t.Fatalf("expected errSilent, got: %v", err)
+		}
+	})
+
+	if !strings.Contains(captured.Stderr, "Cannot parse server response.") {
+		t.Errorf("stderr should mention parse error, got:\n%s", captured.Stderr)
+	}
+}
+
+func TestRunSandboxList_CountWithJSON(t *testing.T) {
+	resetCmdFlags(t)
+	sandboxListCount = true
+	flagOutput = "json"
+
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(sandboxesJSON(
+			model.Sandbox{Name: "A"},
+			model.Sandbox{Name: "B"},
+			model.Sandbox{Name: "C"},
+		))
+	})
+
+	captured := captureAll(t, func() {
+		if err := runSandboxList(sandboxListCmd, nil); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	var parsed map[string]int
+	if err := json.Unmarshal([]byte(captured.Stdout), &parsed); err != nil {
+		t.Fatalf("cannot parse JSON count: %v\noutput: %s", err, captured.Stdout)
+	}
+	if parsed["count"] != 3 {
+		t.Errorf("count = %d, want 3", parsed["count"])
+	}
+}
+
+func TestRunSandboxList_AllOverridesLimit(t *testing.T) {
+	resetCmdFlags(t)
+	sandboxListAll = true
+	sandboxListLimit = 5 // should be ignored when --all is set
+
+	var capturedQuery string
+	boxes := make([]model.Sandbox, 60)
+	for i := range boxes {
+		boxes[i] = model.Sandbox{Name: fmt.Sprintf("Box%02d", i)}
+	}
+
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		capturedQuery = r.URL.RawQuery
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(sandboxesJSON(boxes...))
+	})
+
+	captured := captureAll(t, func() {
+		if err := runSandboxList(sandboxListCmd, nil); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	if strings.Contains(capturedQuery, "$top=") {
+		t.Errorf("request should not include $top= when --all is set, got query: %s", capturedQuery)
+	}
+	if !strings.Contains(captured.Stdout, "Box00") || !strings.Contains(captured.Stdout, "Box59") {
+		t.Errorf("output should contain all 60 sandboxes, got first/last check failed:\n%s", captured.Stdout)
+	}
+	if strings.Contains(captured.Stderr, "Showing ") {
+		t.Errorf("stderr should not show truncation summary with --all, got:\n%s", captured.Stderr)
+	}
+}
+
+// ============================================================
+// Integration — runSandboxCreate
+// ============================================================
+
+func TestRunSandboxCreate_Success(t *testing.T) {
+	resetCmdFlags(t)
+
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+		w.Write([]byte(`{"Name":"FY24Plan"}`))
+	})
+
+	captured := captureAll(t, func() {
+		if err := runSandboxCreate(sandboxCreateCmd, []string{"FY24Plan"}); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	if !strings.Contains(captured.Stdout, "Created sandbox 'FY24Plan'.") {
+		t.Errorf("stdout should confirm creation, got:\n%s", captured.Stdout)
+	}
+}
+
+func TestRunSandboxCreate_JSONOutput(t *testing.T) {
+	resetCmdFlags(t)
+	flagOutput = "json"
+
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+		w.Write([]byte(`{"Name":"FY24Plan"}`))
+	})
+
+	captured := captureAll(t, func() {
+		if err := runSandboxCreate(sandboxCreateCmd, []string{"FY24Plan"}); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	var parsed map[string]string
+	if err := json.Unmarshal([]byte(captured.Stdout), &parsed); err != nil {
+		t.Fatalf("output is not valid JSON: %v\noutput: %s", err, captured.Stdout)
+	}
+	if parsed["status"] != "created" || parsed["name"] != "FY24Plan" {
+		t.Errorf("unexpected JSON: %+v", parsed)
+	}
+}
+
+func TestRunSandboxCreate_PostBodyShape(t *testing.T) {
+	resetCmdFlags(t)
+
+	var (
+		gotMethod string
+		gotPath   string
+		gotBody   []byte
+	)
+
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		gotBody, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusCreated)
+		w.Write([]byte(`{"Name":"FY24Plan"}`))
+	})
+
+	captureAll(t, func() {
+		if err := runSandboxCreate(sandboxCreateCmd, []string{"FY24Plan"}); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	if gotMethod != http.MethodPost {
+		t.Errorf("method = %q, want POST", gotMethod)
+	}
+	if gotPath != "/api/v1/Sandboxes" {
+		t.Errorf("path = %q, want /api/v1/Sandboxes", gotPath)
+	}
+	var parsed map[string]string
+	if err := json.Unmarshal(gotBody, &parsed); err != nil {
+		t.Fatalf("body is not valid JSON: %v\nbody: %s", err, gotBody)
+	}
+	if parsed["Name"] != "FY24Plan" {
+		t.Errorf("body Name = %q, want FY24Plan; full body: %s", parsed["Name"], gotBody)
+	}
+}
+
+func TestRunSandboxCreate_DuplicateName_HTTP400(t *testing.T) {
+	resetCmdFlags(t)
+
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte(`{"error":{"message":"Sandbox 'FY24Plan' already exists."}}`))
+	})
+
+	captured := captureAll(t, func() {
+		err := runSandboxCreate(sandboxCreateCmd, []string{"FY24Plan"})
+		if !errors.Is(err, errSilent) {
+			t.Fatalf("expected errSilent, got: %v", err)
+		}
+	})
+
+	if !strings.Contains(captured.Stderr, "Sandbox 'FY24Plan' already exists.") {
+		t.Errorf("stderr should report duplicate, got:\n%s", captured.Stderr)
+	}
+}
+
+func TestRunSandboxCreate_DuplicateName_HTTP409(t *testing.T) {
+	resetCmdFlags(t)
+
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusConflict)
+		w.Write([]byte(`Sandbox 'FY24Plan' already exists.`))
+	})
+
+	captured := captureAll(t, func() {
+		err := runSandboxCreate(sandboxCreateCmd, []string{"FY24Plan"})
+		if !errors.Is(err, errSilent) {
+			t.Fatalf("expected errSilent, got: %v", err)
+		}
+	})
+
+	if !strings.Contains(captured.Stderr, "already exists.") {
+		t.Errorf("stderr should report duplicate, got:\n%s", captured.Stderr)
+	}
+}
+
+func TestRunSandboxCreate_DuplicateJSONError(t *testing.T) {
+	resetCmdFlags(t)
+	flagOutput = "json"
+
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte(`{"error":{"message":"Sandbox 'FY24Plan' already exists."}}`))
+	})
+
+	captured := captureAll(t, func() {
+		err := runSandboxCreate(sandboxCreateCmd, []string{"FY24Plan"})
+		if !errors.Is(err, errSilent) {
+			t.Fatalf("expected errSilent, got: %v", err)
+		}
+	})
+
+	// PrintError emits pretty-printed JSON; decode it instead of exact match.
+	var parsed map[string]interface{}
+	if err := json.Unmarshal([]byte(captured.Stderr), &parsed); err != nil {
+		t.Fatalf("stderr is not valid JSON: %v\nstderr: %s", err, captured.Stderr)
+	}
+	msg, _ := parsed["error"].(string)
+	if !strings.Contains(msg, "already exists") {
+		t.Errorf("JSON error message = %q, want it to contain 'already exists'", msg)
+	}
+}
+
+func TestRunSandboxCreate_EmptyName(t *testing.T) {
+	resetCmdFlags(t)
+
+	hit := false
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		hit = true
+		w.WriteHeader(http.StatusCreated)
+	})
+
+	captured := captureAll(t, func() {
+		err := runSandboxCreate(sandboxCreateCmd, []string{""})
+		if !errors.Is(err, errSilent) {
+			t.Fatalf("expected errSilent, got: %v", err)
+		}
+	})
+
+	if hit {
+		t.Errorf("server should not be contacted for empty name")
+	}
+	if !strings.Contains(captured.Stderr, "Sandbox name cannot be empty.") {
+		t.Errorf("stderr should reject empty name, got:\n%s", captured.Stderr)
+	}
+}
+
+func TestRunSandboxCreate_WhitespaceOnlyName(t *testing.T) {
+	resetCmdFlags(t)
+
+	hit := false
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		hit = true
+		w.WriteHeader(http.StatusCreated)
+	})
+
+	captured := captureAll(t, func() {
+		err := runSandboxCreate(sandboxCreateCmd, []string{"   "})
+		if !errors.Is(err, errSilent) {
+			t.Fatalf("expected errSilent, got: %v", err)
+		}
+	})
+
+	if hit {
+		t.Errorf("server should not be contacted for whitespace-only name")
+	}
+	if !strings.Contains(captured.Stderr, "Sandbox name cannot be empty.") {
+		t.Errorf("stderr should reject whitespace-only name, got:\n%s", captured.Stderr)
+	}
+}
+
+func TestRunSandboxCreate_GenericServerError(t *testing.T) {
+	resetCmdFlags(t)
+
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte(`{"error":"explosion"}`))
+	})
+
+	captured := captureAll(t, func() {
+		err := runSandboxCreate(sandboxCreateCmd, []string{"FY24Plan"})
+		if !errors.Is(err, errSilent) {
+			t.Fatalf("expected errSilent, got: %v", err)
+		}
+	})
+
+	if !strings.Contains(captured.Stderr, "HTTP 500") {
+		t.Errorf("stderr should pass through HTTP 500, got:\n%s", captured.Stderr)
+	}
+}
+
+// ============================================================
+// Helpers
+// ============================================================
+
+func sandboxNames(boxes []model.Sandbox) []string {
+	if boxes == nil {
+		return nil
+	}
+	names := make([]string, len(boxes))
+	for i, b := range boxes {
+		names[i] = b.Name
+	}
+	return names
+}

--- a/cmd/sandbox_test.go
+++ b/cmd/sandbox_test.go
@@ -136,8 +136,11 @@ func TestDisplaySandboxes_TableHeaders(t *testing.T) {
 	if !strings.Contains(out, "FY24Plan") {
 		t.Errorf("table output missing sandbox name, got:\n%s", out)
 	}
-	if !strings.Contains(out, "true") || !strings.Contains(out, "false") {
-		t.Errorf("table output missing true/false values, got:\n%s", out)
+	if !strings.Contains(out, "true") {
+		t.Errorf("table output missing 'true' for boolean column, got:\n%s", out)
+	}
+	if !strings.Contains(out, "false") {
+		t.Errorf("table output missing 'false' for boolean column, got:\n%s", out)
 	}
 }
 
@@ -217,8 +220,10 @@ func TestDisplaySandboxes_LimitTruncation(t *testing.T) {
 	if !strings.Contains(captured.Stdout, "A1") || !strings.Contains(captured.Stdout, "A2") {
 		t.Errorf("output should contain first 2 names, got:\n%s", captured.Stdout)
 	}
-	if strings.Contains(captured.Stdout, "A3") || strings.Contains(captured.Stdout, "A5") {
-		t.Errorf("output should not contain truncated names, got:\n%s", captured.Stdout)
+	for _, name := range []string{"A3", "A4", "A5"} {
+		if strings.Contains(captured.Stdout, name) {
+			t.Errorf("output should not contain truncated name %q, got:\n%s", name, captured.Stdout)
+		}
 	}
 	if !strings.Contains(captured.Stderr, "Showing 2 of 5") {
 		t.Errorf("stderr should contain truncation summary, got:\n%s", captured.Stderr)

--- a/cmd/sandbox_test.go
+++ b/cmd/sandbox_test.go
@@ -586,6 +586,38 @@ func TestRunSandboxList_TruncationSummary(t *testing.T) {
 	}
 }
 
+func TestRunSandboxList_JSONEmptyArrayWhenFilterStripsAll(t *testing.T) {
+	resetCmdFlags(t)
+	sandboxListLoaded = true
+	flagOutput = "json"
+
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(sandboxesJSON(
+			model.Sandbox{Name: "NotLoaded1"},
+			model.Sandbox{Name: "NotLoaded2"},
+		))
+	})
+
+	captured := captureAll(t, func() {
+		if err := runSandboxList(sandboxListCmd, nil); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	trimmed := strings.TrimSpace(captured.Stdout)
+	if trimmed == "null" {
+		t.Fatalf("JSON output should be [] when filter strips everything, got null (downstream jq/array consumers break)")
+	}
+	var parsed []model.Sandbox
+	if err := json.Unmarshal([]byte(captured.Stdout), &parsed); err != nil {
+		t.Fatalf("output is not valid JSON array: %v\noutput: %s", err, captured.Stdout)
+	}
+	if len(parsed) != 0 {
+		t.Errorf("expected empty array, got %d entries", len(parsed))
+	}
+}
+
 func TestRunSandboxList_CountReflectsActualTotal(t *testing.T) {
 	resetCmdFlags(t)
 	sandboxListCount = true

--- a/cmd/sandbox_test.go
+++ b/cmd/sandbox_test.go
@@ -556,6 +556,61 @@ func TestRunSandboxList_AllOverridesLimit(t *testing.T) {
 	}
 }
 
+func TestRunSandboxList_TruncationSummary(t *testing.T) {
+	resetCmdFlags(t)
+
+	boxes := make([]model.Sandbox, 60)
+	for i := range boxes {
+		boxes[i] = model.Sandbox{Name: fmt.Sprintf("Box%02d", i)}
+	}
+
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(sandboxesJSON(boxes...))
+	})
+
+	captured := captureAll(t, func() {
+		if err := runSandboxList(sandboxListCmd, nil); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	if !strings.Contains(captured.Stderr, "Showing 50 of 60") {
+		t.Errorf("stderr should contain 'Showing 50 of 60' truncation summary, got:\n%s", captured.Stderr)
+	}
+	if !strings.Contains(captured.Stdout, "Box00") || !strings.Contains(captured.Stdout, "Box49") {
+		t.Errorf("stdout should contain first 50 names, got:\n%s", captured.Stdout)
+	}
+	if strings.Contains(captured.Stdout, "Box50") || strings.Contains(captured.Stdout, "Box59") {
+		t.Errorf("stdout should not contain rows beyond limit, got:\n%s", captured.Stdout)
+	}
+}
+
+func TestRunSandboxList_CountReflectsActualTotal(t *testing.T) {
+	resetCmdFlags(t)
+	sandboxListCount = true
+
+	boxes := make([]model.Sandbox, 60)
+	for i := range boxes {
+		boxes[i] = model.Sandbox{Name: fmt.Sprintf("Box%02d", i)}
+	}
+
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(sandboxesJSON(boxes...))
+	})
+
+	captured := captureAll(t, func() {
+		if err := runSandboxList(sandboxListCmd, nil); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	if !strings.Contains(captured.Stdout, "60 sandboxes") {
+		t.Errorf("--count should report 60 (actual total), not limit; got:\n%s", captured.Stdout)
+	}
+}
+
 // ============================================================
 // Integration — runSandboxCreate
 // ============================================================

--- a/cmd/sandbox_test.go
+++ b/cmd/sandbox_test.go
@@ -51,10 +51,10 @@ func TestFilterSandboxesByName(t *testing.T) {
 
 func TestApplySandboxBoolFilters(t *testing.T) {
 	sandboxes := []model.Sandbox{
-		{Name: "LoadedOnly", Loaded: true, Active: false},
-		{Name: "ActiveOnly", Loaded: false, Active: true},
-		{Name: "Both", Loaded: true, Active: true},
-		{Name: "Neither", Loaded: false, Active: false},
+		{Name: "LoadedOnly", IsLoaded: true, IsActive: false},
+		{Name: "ActiveOnly", IsLoaded: false, IsActive: true},
+		{Name: "Both", IsLoaded: true, IsActive: true},
+		{Name: "Neither", IsLoaded: false, IsActive: false},
 	}
 
 	tests := []struct {
@@ -121,7 +121,7 @@ func TestDisplaySandboxes_TableHeaders(t *testing.T) {
 	sandboxListCount = false
 
 	sandboxes := []model.Sandbox{
-		{Name: "FY24Plan", IncludeInSandboxDimension: true, Loaded: true, Active: false, Queued: false},
+		{Name: "FY24Plan", IncludeInSandboxDimension: true, IsLoaded: true, IsActive: false, IsQueued: false},
 	}
 
 	out := captureStdout(t, func() {
@@ -150,7 +150,7 @@ func TestDisplaySandboxes_JSONOutput(t *testing.T) {
 	sandboxListCount = false
 
 	sandboxes := []model.Sandbox{
-		{Name: "A", Loaded: true, Active: true},
+		{Name: "A", IsLoaded: true, IsActive: true},
 		{Name: "B"},
 	}
 
@@ -165,7 +165,7 @@ func TestDisplaySandboxes_JSONOutput(t *testing.T) {
 	if len(parsed) != 2 {
 		t.Fatalf("JSON output length = %d, want 2", len(parsed))
 	}
-	if parsed[0].Name != "A" || !parsed[0].Loaded || !parsed[0].Active {
+	if parsed[0].Name != "A" || !parsed[0].IsLoaded || !parsed[0].IsActive {
 		t.Errorf("JSON[0] = %+v, want Name=A Loaded=true Active=true", parsed[0])
 	}
 }
@@ -240,7 +240,7 @@ func TestRunSandboxList_TableOutput(t *testing.T) {
 	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.Write(sandboxesJSON(
-			model.Sandbox{Name: "FY24Plan", IncludeInSandboxDimension: true, Loaded: true},
+			model.Sandbox{Name: "FY24Plan", IncludeInSandboxDimension: true, IsLoaded: true},
 			model.Sandbox{Name: "FY24Budget"},
 		))
 	})
@@ -265,7 +265,7 @@ func TestRunSandboxList_JSONOutput(t *testing.T) {
 	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.Write(sandboxesJSON(model.Sandbox{
-			Name: "FY24Plan", IncludeInSandboxDimension: true, Loaded: true, Active: true, Queued: false,
+			Name: "FY24Plan", IncludeInSandboxDimension: true, IsLoaded: true, IsActive: true, IsQueued: false,
 		}))
 	})
 
@@ -283,7 +283,7 @@ func TestRunSandboxList_JSONOutput(t *testing.T) {
 		t.Fatalf("expected 1 sandbox, got %d", len(parsed))
 	}
 	got := parsed[0]
-	if got.Name != "FY24Plan" || !got.IncludeInSandboxDimension || !got.Loaded || !got.Active || got.Queued {
+	if got.Name != "FY24Plan" || !got.IncludeInSandboxDimension || !got.IsLoaded || !got.IsActive || got.IsQueued {
 		t.Errorf("unexpected fields: %+v", got)
 	}
 }
@@ -295,9 +295,9 @@ func TestRunSandboxList_LoadedFilter(t *testing.T) {
 	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.Write(sandboxesJSON(
-			model.Sandbox{Name: "Loaded1", Loaded: true},
-			model.Sandbox{Name: "NotLoaded", Loaded: false},
-			model.Sandbox{Name: "Loaded2", Loaded: true, Active: true},
+			model.Sandbox{Name: "Loaded1", IsLoaded: true},
+			model.Sandbox{Name: "NotLoaded", IsLoaded: false},
+			model.Sandbox{Name: "Loaded2", IsLoaded: true, IsActive: true},
 		))
 	})
 
@@ -322,9 +322,9 @@ func TestRunSandboxList_ActiveFilter(t *testing.T) {
 	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.Write(sandboxesJSON(
-			model.Sandbox{Name: "Active1", Active: true},
+			model.Sandbox{Name: "Active1", IsActive: true},
 			model.Sandbox{Name: "NotActive"},
-			model.Sandbox{Name: "Active2", Active: true, Loaded: true},
+			model.Sandbox{Name: "Active2", IsActive: true, IsLoaded: true},
 		))
 	})
 
@@ -415,8 +415,8 @@ func TestRunSandboxList_FilterPlusBooleanFilters(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		// Server-side filter returns name-matched results; client must AND with --loaded.
 		w.Write(sandboxesJSON(
-			model.Sandbox{Name: "FY24Plan", Loaded: true},
-			model.Sandbox{Name: "PlanB", Loaded: false},
+			model.Sandbox{Name: "FY24Plan", IsLoaded: true},
+			model.Sandbox{Name: "PlanB", IsLoaded: false},
 		))
 	})
 

--- a/cmd/testhelpers_test.go
+++ b/cmd/testhelpers_test.go
@@ -268,6 +268,12 @@ func zeroAllFlags() {
 	choresDeactivateDryRun = false
 	choreRunAsync = false
 	choreRunTimeout = defaultChoreTimeout
+	sandboxListFilter = ""
+	sandboxListLimit = 0
+	sandboxListAll = false
+	sandboxListCount = false
+	sandboxListLoaded = false
+	sandboxListActive = false
 }
 
 // cubesJSON returns JSON for a TM1 Cubes response.
@@ -512,6 +518,18 @@ func choresJSON(chores ...model.Chore) []byte {
 // choreDetailJSON returns JSON for a single TM1 Chore (show endpoint).
 func choreDetailJSON(chore model.Chore) []byte {
 	data, _ := json.Marshal(chore)
+	return data
+}
+
+// sandboxesJSON returns JSON for a TM1 Sandboxes response.
+func sandboxesJSON(boxes ...model.Sandbox) []byte {
+	resp := struct {
+		Value []model.Sandbox `json:"value"`
+	}{Value: boxes}
+	if resp.Value == nil {
+		resp.Value = []model.Sandbox{}
+	}
+	data, _ := json.Marshal(resp)
 	return data
 }
 

--- a/internal/model/sandbox.go
+++ b/internal/model/sandbox.go
@@ -1,0 +1,17 @@
+package model
+
+// Sandbox represents a TM1 sandbox.
+//
+// Fields match the tm1.Sandbox OData entity returned by GET /Sandboxes.
+type Sandbox struct {
+	Name                      string `json:"Name"`
+	IncludeInSandboxDimension bool   `json:"IncludeInSandboxDimension"`
+	Loaded                    bool   `json:"Loaded"`
+	Active                    bool   `json:"Active"`
+	Queued                    bool   `json:"Queued"`
+}
+
+// SandboxResponse is the OData collection wrapper for GET /Sandboxes.
+type SandboxResponse struct {
+	Value []Sandbox `json:"value"`
+}

--- a/internal/model/sandbox.go
+++ b/internal/model/sandbox.go
@@ -2,13 +2,15 @@ package model
 
 // Sandbox represents a TM1 sandbox.
 //
-// Fields match the tm1.Sandbox OData entity returned by GET /Sandboxes.
+// Field names match the tm1.Sandbox OData entity returned by GET /Sandboxes
+// (verified against the TM1py reference client). The Loaded/Active/Queued
+// flags are exposed by TM1 as Is-prefixed booleans.
 type Sandbox struct {
 	Name                      string `json:"Name"`
 	IncludeInSandboxDimension bool   `json:"IncludeInSandboxDimension"`
-	Loaded                    bool   `json:"Loaded"`
-	Active                    bool   `json:"Active"`
-	Queued                    bool   `json:"Queued"`
+	IsLoaded                  bool   `json:"IsLoaded"`
+	IsActive                  bool   `json:"IsActive"`
+	IsQueued                  bool   `json:"IsQueued"`
 }
 
 // SandboxResponse is the OData collection wrapper for GET /Sandboxes.


### PR DESCRIPTION
## Summary

- Add `tm1cli sandbox list` (`GET /Sandboxes`) with columns NAME, IN SANDBOX DIM, LOADED, ACTIVE, QUEUED and `--loaded` / `--active` boolean filters (plus `--filter`, `--limit`, `--all`, `--count` for parity with existing list commands).
- Add `tm1cli sandbox create <name>` (`POST /Sandboxes`) with friendly duplicate-name detection covering both HTTP 400 and HTTP 409 responses (bodies are inspected directly to avoid the client's 200-char error truncation).
- Field names use the IBM TM1 OData schema (`IsLoaded`, `IsActive`, `IsQueued`) verified against the TM1py reference client; user-facing flag and column names follow the issue spec.
- `--limit` over-fetches by 500 rows (matching `cubes`/`chores`/`process`/`dims`/`threads`/`sessions`) so the documented `Showing 50 of N` truncation summary fires and `--count` reports the true total.

## Changes

| File | Change |
|------|--------|
| `internal/model/sandbox.go` | New `Sandbox` / `SandboxResponse` types |
| `cmd/sandbox.go` | New parent + `list` + `create` subcommands |
| `cmd/sandbox_test.go` | 26 new unit + integration tests |
| `cmd/testhelpers_test.go` | Reset new flags + `sandboxesJSON` helper |
| `README.md` | New `### Sandboxes` section under `## Usage` |

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./...` — 1356 tests pass (26 new sandbox tests)
- [x] `go vet ./...` clean
- [x] List: table output, JSON output, empty result, malformed JSON, HTTP error
- [x] List filters: `--filter` (server-side success + client-side fallback), `--loaded`, `--active`, `--filter` + `--loaded` combination
- [x] List counting/limit: `--count` (text + JSON), `--all` overrides `--limit`, truncation summary `Showing 50 of 60` on default limit, `--count` reports true total (60) instead of capped limit
- [x] Create: success (text + JSON), POST method/path/body shape verified, empty / whitespace-only name rejected without contacting server
- [x] Create errors: HTTP 400 duplicate, HTTP 409 duplicate, JSON error format on duplicate, generic HTTP 500 passthrough

Closes #85
