### PR TITLE
fix(#85): skip $top on sandbox list --count to report real total

### DIFF
--- a/cmd/sandbox.go
+++ b/cmd/sandbox.go
@@ -92,10 +92,11 @@ func runSandboxList(cmd *cobra.Command, args []string) error {
 	}
 
 	fetchEndpoint := endpoint
-	if limit > 0 && !activeFilters {
+	if limit > 0 && !activeFilters && !sandboxListCount {
 		// Over-fetch above --limit so PrintSummary can report "Showing N of M"
-		// when the server has more than --limit rows; otherwise --count would
-		// silently cap at --limit and the truncation summary would never fire.
+		// when the server has more than --limit rows; otherwise the truncation
+		// summary would never fire. Skip $top entirely when --count is set so
+		// the displayed total is the real server total, not the over-fetch cap.
 		fetchEndpoint += fmt.Sprintf("&$top=%d", limit+500)
 	}
 

--- a/cmd/sandbox_test.go
+++ b/cmd/sandbox_test.go
@@ -643,6 +643,40 @@ func TestRunSandboxList_CountReflectsActualTotal(t *testing.T) {
 	}
 }
 
+// Regression: when --count is set and the server has more than limit+500
+// rows, the result must still reflect the real total. Earlier code sent
+// $top=limit+500 unconditionally, silently capping the displayed count at
+// the over-fetch cap (e.g. 550) instead of the actual server total.
+func TestRunSandboxList_CountAboveOverFetchCap(t *testing.T) {
+	resetCmdFlags(t)
+	sandboxListCount = true
+
+	boxes := make([]model.Sandbox, 600)
+	for i := range boxes {
+		boxes[i] = model.Sandbox{Name: fmt.Sprintf("Box%03d", i)}
+	}
+
+	var capturedQuery string
+	setupMockTM1(t, func(w http.ResponseWriter, r *http.Request) {
+		capturedQuery = r.URL.RawQuery
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(sandboxesJSON(boxes...))
+	})
+
+	captured := captureAll(t, func() {
+		if err := runSandboxList(sandboxListCmd, nil); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	if strings.Contains(capturedQuery, "$top=") {
+		t.Errorf("request must not include $top= when --count is set, got query: %s", capturedQuery)
+	}
+	if !strings.Contains(captured.Stdout, "600 sandboxes") {
+		t.Errorf("--count must report 600 (actual total), not the over-fetch cap; got:\n%s", captured.Stdout)
+	}
+}
+
 // ============================================================
 // Integration — runSandboxCreate
 // ============================================================


### PR DESCRIPTION
## Summary
- Follow-up fix to PR #126 (sandbox list/create). When `--count` was set, the request always sent `\$top=limit+500`, silently capping the displayed total at the over-fetch cap (default 550). On servers with more sandboxes, `tm1cli sandbox list --count` returned incorrect data.
- Adds a guard so `\$top` is skipped when `--count` is set; the displayed total now reflects the real server total.
- Adds a regression test with 600 mock sandboxes that asserts both (a) the request URL omits `\$top=` and (b) the output reports `600 sandboxes`.

## Discovery
Caught in a cold external `/review` pass on the merged sandbox feature.

## Test plan
- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./...` — 1,358 tests pass across all packages
- [x] `go test ./cmd/... -run Sandbox -count=1` — 48 sandbox tests pass (47 prior + 1 new regression)
- [ ] Smoke-check against a live TM1 server with >550 sandboxes (optional — covered by the new mock test)

## Scope
- `cmd/sandbox.go`: one-line guard + updated comment explaining the rationale.
- `cmd/sandbox_test.go`: new `TestRunSandboxList_CountAboveOverFetchCap`.

No public API changes. No new dependencies. Strictly additive: the test set grew by 1.