### PR TITLE
feat(#86): sandbox merge / delete commands

### DIFF
--- a/cmd/sandbox.go
+++ b/cmd/sandbox.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"net/url"
 	"os"
 	"strconv"
 	"strings"
@@ -32,14 +31,6 @@ var (
 	sandboxDeleteYes    bool
 	sandboxDeleteDryRun bool
 )
-
-// sandboxKey encodes a sandbox name for use as an OData URL key:
-// OData single-quote-doubling, then URL path-escape. Use only for URL
-// paths. For JSON odata.bind values, apply odataEscape directly — the
-// path-escape would corrupt the binding reference.
-func sandboxKey(name string) string {
-	return url.PathEscape(odataEscape(name))
-}
 
 var sandboxCmd = &cobra.Command{
 	Use:          "sandbox",
@@ -382,7 +373,7 @@ func runSandboxMerge(cmd *cobra.Command, args []string) error {
 		"CleanAfter":        sandboxMergeClean,
 	}
 
-	endpoint := fmt.Sprintf("Sandboxes('%s')/tm1.Merge", sandboxKey(name))
+	endpoint := fmt.Sprintf("Sandboxes('%s')/tm1.Merge", odataKey(name))
 	body, postErr := cl.Post(endpoint, payload)
 	if postErr != nil {
 		return handleSandboxMergeError(postErr, body, name, jsonMode)
@@ -442,7 +433,7 @@ func runSandboxDelete(cmd *cobra.Command, args []string) error {
 		return errSilent
 	}
 
-	endpoint := fmt.Sprintf("Sandboxes('%s')", sandboxKey(name))
+	endpoint := fmt.Sprintf("Sandboxes('%s')", odataKey(name))
 	if delErr := cl.Delete(endpoint); delErr != nil {
 		return handleSandboxDeleteError(delErr, name, jsonMode)
 	}

--- a/cmd/sandbox.go
+++ b/cmd/sandbox.go
@@ -316,8 +316,18 @@ func runSandboxMerge(cmd *cobra.Command, args []string) error {
 	}
 	jsonMode := isJSONOutput(cfg)
 
-	if strings.TrimSpace(name) == "" {
+	name = strings.TrimSpace(name)
+	if name == "" {
 		output.PrintError("Sandbox name cannot be empty.", jsonMode)
+		return errSilent
+	}
+
+	// If --target was explicitly set but resolves to empty/whitespace
+	// (e.g. `--target "$TARGET"` in a script with TARGET unset), fail
+	// fast rather than silently routing to the destructive base-merge
+	// path. An unset --target legitimately means "merge to base".
+	if cmd.Flags().Changed("target") && strings.TrimSpace(sandboxMergeTarget) == "" {
+		output.PrintError("--target was set but is empty. Omit --target to merge into the base sandbox, or pass a non-empty target name.", jsonMode)
 		return errSilent
 	}
 

--- a/cmd/sandbox.go
+++ b/cmd/sandbox.go
@@ -367,29 +367,59 @@ func runSandboxMerge(cmd *cobra.Command, args []string) error {
 		return errSilent
 	}
 
-	payload := map[string]interface{}{
-		"Source@odata.bind": fmt.Sprintf("Sandboxes('%s')", odataEscape(name)),
-		"Target@odata.bind": fmt.Sprintf("Sandboxes('%s')", odataEscape(target)),
-		"CleanAfter":        sandboxMergeClean,
-	}
-
-	endpoint := fmt.Sprintf("Sandboxes('%s')/tm1.Merge", odataKey(name))
-	body, postErr := cl.Post(endpoint, payload)
-	if postErr != nil {
-		return handleSandboxMergeError(postErr, body, name, jsonMode)
+	cleaned := false
+	if target == "" {
+		// Merge to base routes through TM1's dedicated tm1.Publish action,
+		// which does not require a Target binding. (tm1.Merge with an
+		// empty-string Target — e.g. Sandboxes('') — is not portable
+		// across TM1 versions because an empty OData key is invalid.)
+		// tm1.Publish has no CleanAfter parameter, so the --clean
+		// semantics are implemented as an explicit DELETE on the source
+		// after a successful Publish.
+		endpoint := fmt.Sprintf("Sandboxes('%s')/tm1.Publish", odataKey(name))
+		body, postErr := cl.Post(endpoint, map[string]interface{}{})
+		if postErr != nil {
+			return handleSandboxMergeError(postErr, body, name, jsonMode)
+		}
+		if sandboxMergeClean {
+			if delErr := cl.Delete(fmt.Sprintf("Sandboxes('%s')", odataKey(name))); delErr != nil {
+				// Publish already succeeded — surface the cleanup failure
+				// as a warning rather than failing the whole operation.
+				output.PrintWarning(fmt.Sprintf("Sandbox '%s' published to base but cleanup DELETE failed: %s", name, delErr.Error()))
+			} else {
+				cleaned = true
+			}
+		}
+	} else {
+		payload := map[string]interface{}{
+			"Source@odata.bind": fmt.Sprintf("Sandboxes('%s')", odataEscape(name)),
+			"Target@odata.bind": fmt.Sprintf("Sandboxes('%s')", odataEscape(target)),
+			"CleanAfter":        sandboxMergeClean,
+		}
+		endpoint := fmt.Sprintf("Sandboxes('%s')/tm1.Merge", odataKey(name))
+		body, postErr := cl.Post(endpoint, payload)
+		if postErr != nil {
+			return handleSandboxMergeError(postErr, body, name, jsonMode)
+		}
+		cleaned = sandboxMergeClean
 	}
 
 	if jsonMode {
 		output.PrintJSON(map[string]interface{}{
-			"status": "merged",
-			"source": name,
-			"target": target,
-			"clean":  sandboxMergeClean,
+			"status":  "merged",
+			"source":  name,
+			"target":  target,
+			"clean":   sandboxMergeClean,
+			"cleaned": cleaned,
 		})
 	} else {
 		cleanPart := ""
 		if sandboxMergeClean {
-			cleanPart = " (source cleaned)"
+			if cleaned {
+				cleanPart = " (source cleaned)"
+			} else {
+				cleanPart = " (source cleanup failed)"
+			}
 		}
 		fmt.Printf("Merged sandbox '%s' into %s%s.\n", name, targetLabel, cleanPart)
 	}

--- a/cmd/sandbox.go
+++ b/cmd/sandbox.go
@@ -391,8 +391,11 @@ func runSandboxMerge(cmd *cobra.Command, args []string) error {
 			}
 		}
 	} else {
+		// tm1.Merge is bound to the source via the URL path
+		// (Sandboxes('source')/tm1.Merge), so Source@odata.bind is
+		// redundant in the body. Send only the Target binding and
+		// CleanAfter — some TM1 versions reject the extra Source field.
 		payload := map[string]interface{}{
-			"Source@odata.bind": fmt.Sprintf("Sandboxes('%s')", odataEscape(name)),
 			"Target@odata.bind": fmt.Sprintf("Sandboxes('%s')", odataEscape(target)),
 			"CleanAfter":        sandboxMergeClean,
 		}

--- a/cmd/sandbox.go
+++ b/cmd/sandbox.go
@@ -1,10 +1,15 @@
 package cmd
 
 import (
+	"bufio"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"net/url"
+	"os"
 	"strconv"
 	"strings"
+	"tm1cli/internal/client"
 	"tm1cli/internal/model"
 	"tm1cli/internal/output"
 
@@ -18,7 +23,23 @@ var (
 	sandboxListCount  bool
 	sandboxListLoaded bool
 	sandboxListActive bool
+
+	sandboxMergeYes    bool
+	sandboxMergeClean  bool
+	sandboxMergeTarget string
+	sandboxMergeDryRun bool
+
+	sandboxDeleteYes    bool
+	sandboxDeleteDryRun bool
 )
+
+// sandboxKey encodes a sandbox name for use as an OData URL key:
+// OData single-quote-doubling, then URL path-escape. Use only for URL
+// paths. For JSON odata.bind values, apply odataEscape directly — the
+// path-escape would corrupt the binding reference.
+func sandboxKey(name string) string {
+	return url.PathEscape(odataEscape(name))
+}
 
 var sandboxCmd = &cobra.Command{
 	Use:          "sandbox",
@@ -55,6 +76,58 @@ REST API: POST /Sandboxes`,
   tm1cli sandbox create FY24Plan --output json`,
 	Args:         cobra.ExactArgs(1),
 	RunE:         runSandboxCreate,
+	SilenceUsage: true,
+}
+
+var sandboxMergeCmd = &cobra.Command{
+	Use:   "merge <name>",
+	Short: "Merge a sandbox into the base (or another sandbox)",
+	Long: `Merge a TM1 sandbox into the base sandbox, or into another named sandbox via --target.
+
+REST API: POST /Sandboxes('name')/tm1.Merge
+
+WARNING: merge applies the source sandbox's pending writes to the target.
+Once merged, the target reflects the combined state. Use --clean to drop
+the source sandbox after a successful merge.
+
+The command prompts for confirmation by default. Use --yes to skip the
+prompt for scripting. --dry-run takes precedence over --yes.
+
+Exit codes:
+  0  merge completed
+  1  generic error (auth, network, server, conflict, sandbox loaded by another user)
+  3  sandbox not found`,
+	Example: `  tm1cli sandbox merge FY24Plan
+  tm1cli sandbox merge FY24Plan --yes
+  tm1cli sandbox merge FY24Plan --target FY24Forecast
+  tm1cli sandbox merge FY24Plan --clean --yes
+  tm1cli sandbox merge FY24Plan --dry-run`,
+	Args:         cobra.ExactArgs(1),
+	RunE:         runSandboxMerge,
+	SilenceUsage: true,
+}
+
+var sandboxDeleteCmd = &cobra.Command{
+	Use:   "delete <name>",
+	Short: "Delete a TM1 sandbox",
+	Long: `Delete a TM1 sandbox by name.
+
+REST API: DELETE /Sandboxes('name')
+
+WARNING: deletion is permanent. Any unmerged writes in the sandbox are lost.
+
+The command prompts for confirmation by default. Use --yes to skip the
+prompt for scripting. --dry-run takes precedence over --yes.
+
+Exit codes:
+  0  sandbox deleted
+  1  generic error (auth, network, server, sandbox loaded by another user)
+  3  sandbox not found`,
+	Example: `  tm1cli sandbox delete FY24Plan
+  tm1cli sandbox delete FY24Plan --yes
+  tm1cli sandbox delete FY24Plan --dry-run --output json`,
+	Args:         cobra.ExactArgs(1),
+	RunE:         runSandboxDelete,
 	SilenceUsage: true,
 }
 
@@ -242,10 +315,230 @@ func isDuplicateSandboxError(body []byte, err error) bool {
 	return strings.Contains(combined, "already exists") || strings.Contains(combined, "duplicate")
 }
 
+func runSandboxMerge(cmd *cobra.Command, args []string) error {
+	name := args[0]
+
+	cfg, err := loadConfig()
+	if err != nil {
+		output.PrintError(err.Error(), isJSONOutput(nil))
+		return errSilent
+	}
+	jsonMode := isJSONOutput(cfg)
+
+	if strings.TrimSpace(name) == "" {
+		output.PrintError("Sandbox name cannot be empty.", jsonMode)
+		return errSilent
+	}
+
+	target := strings.TrimSpace(sandboxMergeTarget)
+	if target == name {
+		output.PrintError("--target cannot equal the source sandbox name.", jsonMode)
+		return errSilent
+	}
+
+	targetLabel := "base"
+	if target != "" {
+		targetLabel = fmt.Sprintf("sandbox '%s'", target)
+	}
+
+	if sandboxMergeDryRun {
+		if jsonMode {
+			output.PrintJSON(map[string]interface{}{
+				"status": "dry-run",
+				"source": name,
+				"target": target,
+				"clean":  sandboxMergeClean,
+			})
+		} else {
+			cleanPart := ""
+			if sandboxMergeClean {
+				cleanPart = " and clean source after merge"
+			}
+			fmt.Printf("[dry-run] Would merge sandbox '%s' into %s%s.\n", name, targetLabel, cleanPart)
+		}
+		return nil
+	}
+
+	if !sandboxMergeYes {
+		cleanPart := ""
+		if sandboxMergeClean {
+			cleanPart = " (source will be cleaned after merge)"
+		}
+		fmt.Fprintf(os.Stderr, "About to merge sandbox '%s' into %s%s.\n", name, targetLabel, cleanPart)
+		if !promptYesNo(bufio.NewReader(os.Stdin), "Continue?") {
+			return nil
+		}
+	}
+
+	cl, err := createClient(cfg)
+	if err != nil {
+		output.PrintError(err.Error(), jsonMode)
+		return errSilent
+	}
+
+	payload := map[string]interface{}{
+		"Source@odata.bind": fmt.Sprintf("Sandboxes('%s')", odataEscape(name)),
+		"Target@odata.bind": fmt.Sprintf("Sandboxes('%s')", odataEscape(target)),
+		"CleanAfter":        sandboxMergeClean,
+	}
+
+	endpoint := fmt.Sprintf("Sandboxes('%s')/tm1.Merge", sandboxKey(name))
+	body, postErr := cl.Post(endpoint, payload)
+	if postErr != nil {
+		return handleSandboxMergeError(postErr, body, name, jsonMode)
+	}
+
+	if jsonMode {
+		output.PrintJSON(map[string]interface{}{
+			"status": "merged",
+			"source": name,
+			"target": target,
+			"clean":  sandboxMergeClean,
+		})
+	} else {
+		cleanPart := ""
+		if sandboxMergeClean {
+			cleanPart = " (source cleaned)"
+		}
+		fmt.Printf("Merged sandbox '%s' into %s%s.\n", name, targetLabel, cleanPart)
+	}
+	return nil
+}
+
+func runSandboxDelete(cmd *cobra.Command, args []string) error {
+	name := args[0]
+
+	cfg, err := loadConfig()
+	if err != nil {
+		output.PrintError(err.Error(), isJSONOutput(nil))
+		return errSilent
+	}
+	jsonMode := isJSONOutput(cfg)
+
+	if strings.TrimSpace(name) == "" {
+		output.PrintError("Sandbox name cannot be empty.", jsonMode)
+		return errSilent
+	}
+
+	if sandboxDeleteDryRun {
+		if jsonMode {
+			output.PrintJSON(map[string]string{"status": "dry-run", "name": name})
+		} else {
+			fmt.Printf("[dry-run] Would delete sandbox '%s'.\n", name)
+		}
+		return nil
+	}
+
+	if !sandboxDeleteYes {
+		fmt.Fprintf(os.Stderr, "About to permanently delete sandbox '%s'. Unmerged writes will be lost.\n", name)
+		if !promptYesNo(bufio.NewReader(os.Stdin), "Continue?") {
+			return nil
+		}
+	}
+
+	cl, err := createClient(cfg)
+	if err != nil {
+		output.PrintError(err.Error(), jsonMode)
+		return errSilent
+	}
+
+	endpoint := fmt.Sprintf("Sandboxes('%s')", sandboxKey(name))
+	if delErr := cl.Delete(endpoint); delErr != nil {
+		return handleSandboxDeleteError(delErr, name, jsonMode)
+	}
+
+	if jsonMode {
+		output.PrintJSON(map[string]string{"status": "deleted", "name": name})
+	} else {
+		fmt.Printf("Deleted sandbox '%s'.\n", name)
+	}
+	return nil
+}
+
+// handleSandboxMergeError funnels merge failures through one place. The
+// "loaded by another user" check runs before the merge-conflict check
+// because it's a more specific failure mode — TM1 may return a body
+// containing both keywords, and the lock-message is more actionable.
+func handleSandboxMergeError(err error, body []byte, name string, jsonMode bool) error {
+	if errors.Is(err, client.ErrNotFound) {
+		output.PrintError(fmt.Sprintf("Sandbox '%s' not found.", name), jsonMode)
+		return errExit(3)
+	}
+	if strings.HasPrefix(err.Error(), "HTTP 403") {
+		output.PrintError("Permission denied. Merging sandboxes requires admin or owner privileges.", jsonMode)
+		return errSilent
+	}
+	if isSandboxLockedError(body, err) {
+		output.PrintError(fmt.Sprintf("Sandbox '%s' is loaded by another user. Wait for it to be unloaded and retry.", name), jsonMode)
+		return errSilent
+	}
+	if isSandboxMergeConflictError(body, err) {
+		output.PrintError(fmt.Sprintf("Merge conflict on sandbox '%s'. Resolve conflicting changes and retry.", name), jsonMode)
+		return errSilent
+	}
+	output.PrintError(err.Error(), jsonMode)
+	return errSilent
+}
+
+func handleSandboxDeleteError(err error, name string, jsonMode bool) error {
+	if errors.Is(err, client.ErrNotFound) {
+		output.PrintError(fmt.Sprintf("Sandbox '%s' not found.", name), jsonMode)
+		return errExit(3)
+	}
+	if strings.HasPrefix(err.Error(), "HTTP 403") {
+		output.PrintError("Permission denied. Deleting a sandbox requires admin or owner privileges.", jsonMode)
+		return errSilent
+	}
+	if isSandboxLockedError(nil, err) {
+		output.PrintError(fmt.Sprintf("Sandbox '%s' is loaded by another user. Wait for it to be unloaded and retry.", name), jsonMode)
+		return errSilent
+	}
+	output.PrintError(err.Error(), jsonMode)
+	return errSilent
+}
+
+// isSandboxLockedError reports whether (body, err) indicates the sandbox
+// is loaded by another user. TM1 returns HTTP 400/409 with messages
+// like "Sandbox 'X' is loaded by user 'Y'", "currently loaded", or
+// "is in use". The body is inspected (not only err.Error()) because
+// client.httpError truncates at 200 chars, which can cut off the keyword.
+// body may be nil when only the error string is available (e.g. DELETE).
+func isSandboxLockedError(body []byte, err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	if !strings.HasPrefix(msg, "HTTP 400") && !strings.HasPrefix(msg, "HTTP 409") {
+		return false
+	}
+	combined := strings.ToLower(msg + " " + string(body))
+	return strings.Contains(combined, "loaded by") ||
+		strings.Contains(combined, "currently loaded") ||
+		strings.Contains(combined, "is in use")
+}
+
+// isSandboxMergeConflictError detects merge-conflict responses. The
+// keyword set is intentionally narrower than isSandboxLockedError so the
+// more-specific locked-by-user message takes precedence when both apply.
+func isSandboxMergeConflictError(body []byte, err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	if !strings.HasPrefix(msg, "HTTP 400") && !strings.HasPrefix(msg, "HTTP 409") {
+		return false
+	}
+	combined := strings.ToLower(msg + " " + string(body))
+	return strings.Contains(combined, "conflict") ||
+		strings.Contains(combined, "cannot be merged")
+}
+
 func init() {
 	rootCmd.AddCommand(sandboxCmd)
 	sandboxCmd.AddCommand(sandboxListCmd)
 	sandboxCmd.AddCommand(sandboxCreateCmd)
+	sandboxCmd.AddCommand(sandboxMergeCmd)
+	sandboxCmd.AddCommand(sandboxDeleteCmd)
 
 	sandboxListCmd.Flags().StringVar(&sandboxListFilter, "filter", "", "Filter by name (case-insensitive, partial match)")
 	sandboxListCmd.Flags().IntVar(&sandboxListLimit, "limit", 0, "Max results to show (default from settings)")
@@ -253,4 +546,12 @@ func init() {
 	sandboxListCmd.Flags().BoolVar(&sandboxListCount, "count", false, "Show count only")
 	sandboxListCmd.Flags().BoolVar(&sandboxListLoaded, "loaded", false, "Show only sandboxes currently loaded in memory")
 	sandboxListCmd.Flags().BoolVar(&sandboxListActive, "active", false, "Show only sandboxes the current user has active")
+
+	sandboxMergeCmd.Flags().BoolVar(&sandboxMergeYes, "yes", false, "Skip confirmation prompt")
+	sandboxMergeCmd.Flags().BoolVar(&sandboxMergeClean, "clean", false, "Delete the source sandbox after a successful merge")
+	sandboxMergeCmd.Flags().StringVar(&sandboxMergeTarget, "target", "", "Target sandbox name (default: base sandbox)")
+	sandboxMergeCmd.Flags().BoolVar(&sandboxMergeDryRun, "dry-run", false, "Preview the merge without contacting the server")
+
+	sandboxDeleteCmd.Flags().BoolVar(&sandboxDeleteYes, "yes", false, "Skip confirmation prompt")
+	sandboxDeleteCmd.Flags().BoolVar(&sandboxDeleteDryRun, "dry-run", false, "Preview the delete without contacting the server")
 }

--- a/cmd/sandbox_test.go
+++ b/cmd/sandbox_test.go
@@ -1164,6 +1164,24 @@ func TestRunSandboxMerge_NamedTargetCleanAfterTrue(t *testing.T) {
 	}
 }
 
+func TestRunSandboxMerge_ExplicitEmptyTargetRejected(t *testing.T) {
+	resetCmdFlags(t)
+	posts := 0
+	setupMockTM1(t, newMergeHandler(mergeHandlerOpts{posts: &posts}))
+
+	cap := captureAll(t, func() {
+		rootCmd.SetArgs([]string{"sandbox", "merge", "FY24Plan", "--yes", "--target", ""})
+		rootCmd.Execute()
+	})
+
+	if posts != 0 {
+		t.Errorf("expected zero POST when --target explicitly empty, got %d", posts)
+	}
+	if !strings.Contains(cap.Stderr, "--target was set but is empty") {
+		t.Errorf("stderr should reject explicit empty --target, got: %s", cap.Stderr)
+	}
+}
+
 func TestRunSandboxMerge_RejectsTargetEqualsSource(t *testing.T) {
 	resetCmdFlags(t)
 	sandboxMergeYes = true

--- a/cmd/sandbox_test.go
+++ b/cmd/sandbox_test.go
@@ -898,29 +898,6 @@ func TestRunSandboxCreate_GenericServerError(t *testing.T) {
 }
 
 // ============================================================
-// Unit — sandboxKey
-// ============================================================
-
-func TestSandboxKey(t *testing.T) {
-	tests := []struct {
-		name string
-		in   string
-		want string
-	}{
-		{"plain name unchanged", "FY24Plan", "FY24Plan"},
-		{"single quote doubled then path-escaped", "O'Brien", "O%27%27Brien"},
-		{"empty input returns empty", "", ""},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := sandboxKey(tt.in); got != tt.want {
-				t.Errorf("sandboxKey(%q) = %q, want %q", tt.in, got, tt.want)
-			}
-		})
-	}
-}
-
-// ============================================================
 // Unit — isSandboxLockedError
 // ============================================================
 

--- a/cmd/sandbox_test.go
+++ b/cmd/sandbox_test.go
@@ -963,13 +963,13 @@ func TestIsSandboxMergeConflictError(t *testing.T) {
 // and may issue a follow-up DELETE on the source for --clean — both are
 // captured by this handler.
 type mergeHandlerOpts struct {
-	status      int
-	body        string
-	posts       *int
-	postPaths   *[]string
-	postBodies  *[]map[string]interface{}
-	deletes     *int
-	deletePaths *[]string
+	status       int
+	body         string
+	posts        *int
+	postPaths    *[]string
+	postBodies   *[]map[string]interface{}
+	deletes      *int
+	deletePaths  *[]string
 	deleteStatus int // status returned for follow-up DELETE; 0 → 204
 }
 

--- a/cmd/sandbox_test.go
+++ b/cmd/sandbox_test.go
@@ -1116,7 +1116,8 @@ func TestRunSandboxMerge_PostsToNamedTarget(t *testing.T) {
 	sandboxMergeTarget = "FY24Forecast"
 
 	bodies := []map[string]interface{}{}
-	setupMockTM1(t, newMergeHandler(mergeHandlerOpts{postBodies: &bodies}))
+	paths := []string{}
+	setupMockTM1(t, newMergeHandler(mergeHandlerOpts{postBodies: &bodies, postPaths: &paths}))
 
 	captureAll(t, func() {
 		if err := runSandboxMerge(sandboxMergeCmd, []string{"FY24Plan"}); err != nil {
@@ -1124,8 +1125,15 @@ func TestRunSandboxMerge_PostsToNamedTarget(t *testing.T) {
 		}
 	})
 
+	if !strings.Contains(paths[0], "Sandboxes('FY24Plan')/tm1.Merge") {
+		t.Errorf("path = %q, want Sandboxes('FY24Plan')/tm1.Merge", paths[0])
+	}
 	if bodies[0]["Target@odata.bind"] != "Sandboxes('FY24Forecast')" {
 		t.Errorf("Target@odata.bind = %v, want Sandboxes('FY24Forecast')", bodies[0]["Target@odata.bind"])
+	}
+	// Source is bound via the URL path on tm1.Merge — must not also appear in the body.
+	if _, has := bodies[0]["Source@odata.bind"]; has {
+		t.Errorf("body should not include Source@odata.bind (action is bound to source via URL), got: %v", bodies[0])
 	}
 }
 

--- a/cmd/sandbox_test.go
+++ b/cmd/sandbox_test.go
@@ -898,6 +898,669 @@ func TestRunSandboxCreate_GenericServerError(t *testing.T) {
 }
 
 // ============================================================
+// Unit — sandboxKey
+// ============================================================
+
+func TestSandboxKey(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"plain name unchanged", "FY24Plan", "FY24Plan"},
+		{"single quote doubled then path-escaped", "O'Brien", "O%27%27Brien"},
+		{"empty input returns empty", "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := sandboxKey(tt.in); got != tt.want {
+				t.Errorf("sandboxKey(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+// ============================================================
+// Unit — isSandboxLockedError
+// ============================================================
+
+func TestIsSandboxLockedError(t *testing.T) {
+	tests := []struct {
+		name string
+		body []byte
+		err  error
+		want bool
+	}{
+		{"HTTP 400 with 'is loaded by user'", []byte(`{"error":"Sandbox 'X' is loaded by user 'Y'."}`), fmt.Errorf("HTTP 400: short"), true},
+		{"HTTP 409 with 'currently loaded'", []byte("Sandbox is currently loaded."), fmt.Errorf("HTTP 409: conflict"), true},
+		{"HTTP 400 with 'is in use'", []byte("Resource is in use."), fmt.Errorf("HTTP 400: bad request"), true},
+		{"keyword only in err string (truncated body)", nil, fmt.Errorf("HTTP 400: Sandbox is loaded by another user"), true},
+		{"HTTP 500 ignored even with keyword", []byte("loaded by"), fmt.Errorf("HTTP 500: server error"), false},
+		{"HTTP 404 ignored", []byte("loaded by"), fmt.Errorf("HTTP 404: not found"), false},
+		{"nil err returns false", []byte("loaded by"), nil, false},
+		{"case-insensitive uppercase", []byte("LOADED BY USER"), fmt.Errorf("HTTP 400: short"), true},
+		{"no keyword returns false", []byte("something else"), fmt.Errorf("HTTP 400: short"), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isSandboxLockedError(tt.body, tt.err); got != tt.want {
+				t.Errorf("isSandboxLockedError() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// ============================================================
+// Unit — isSandboxMergeConflictError
+// ============================================================
+
+func TestIsSandboxMergeConflictError(t *testing.T) {
+	tests := []struct {
+		name string
+		body []byte
+		err  error
+		want bool
+	}{
+		{"HTTP 409 with 'conflict'", []byte(`{"error":"merge conflict on sandbox X"}`), fmt.Errorf("HTTP 409: conflict"), true},
+		{"HTTP 400 with 'cannot be merged'", []byte("Sandbox cannot be merged."), fmt.Errorf("HTTP 400: short"), true},
+		{"HTTP 500 with keyword ignored", []byte("conflict"), fmt.Errorf("HTTP 500: explosion"), false},
+		{"nil err returns false", []byte("conflict"), nil, false},
+		{"no keyword returns false", []byte("unrelated"), fmt.Errorf("HTTP 400: short"), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isSandboxMergeConflictError(tt.body, tt.err); got != tt.want {
+				t.Errorf("isSandboxMergeConflictError() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// ============================================================
+// Integration — runSandboxMerge
+// ============================================================
+
+// mergeHandlerOpts captures the merge mock behaviour. status overrides
+// the default 200 OK; body overrides the default empty JSON.
+type mergeHandlerOpts struct {
+	status     int
+	body       string
+	posts      *int
+	postPaths  *[]string
+	postBodies *[]map[string]interface{}
+}
+
+func newMergeHandler(opts mergeHandlerOpts) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || !strings.Contains(r.URL.Path, "/tm1.Merge") {
+			w.WriteHeader(http.StatusNotFound)
+			w.Write([]byte(`{"error":"unexpected route"}`))
+			return
+		}
+		if opts.posts != nil {
+			*opts.posts++
+		}
+		if opts.postPaths != nil {
+			*opts.postPaths = append(*opts.postPaths, r.URL.Path)
+		}
+		if opts.postBodies != nil {
+			raw, _ := io.ReadAll(r.Body)
+			var parsed map[string]interface{}
+			_ = json.Unmarshal(raw, &parsed)
+			*opts.postBodies = append(*opts.postBodies, parsed)
+		}
+		status := opts.status
+		if status == 0 {
+			status = http.StatusOK
+		}
+		w.WriteHeader(status)
+		if opts.body != "" {
+			w.Write([]byte(opts.body))
+		} else {
+			w.Write([]byte(`{}`))
+		}
+	}
+}
+
+func TestRunSandboxMerge_PostsToBaseByDefault(t *testing.T) {
+	resetCmdFlags(t)
+	sandboxMergeYes = true
+
+	posts := 0
+	paths := []string{}
+	bodies := []map[string]interface{}{}
+	setupMockTM1(t, newMergeHandler(mergeHandlerOpts{posts: &posts, postPaths: &paths, postBodies: &bodies}))
+
+	captureAll(t, func() {
+		if err := runSandboxMerge(sandboxMergeCmd, []string{"FY24Plan"}); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	if posts != 1 {
+		t.Fatalf("expected 1 POST, got %d", posts)
+	}
+	if !strings.Contains(paths[0], "Sandboxes('FY24Plan')/tm1.Merge") {
+		t.Errorf("path = %q, want Sandboxes('FY24Plan')/tm1.Merge", paths[0])
+	}
+	if bodies[0]["Source@odata.bind"] != "Sandboxes('FY24Plan')" {
+		t.Errorf("Source@odata.bind = %v, want Sandboxes('FY24Plan')", bodies[0]["Source@odata.bind"])
+	}
+	if bodies[0]["Target@odata.bind"] != "Sandboxes('')" {
+		t.Errorf("Target@odata.bind = %v, want Sandboxes('') for base", bodies[0]["Target@odata.bind"])
+	}
+	if bodies[0]["CleanAfter"] != false {
+		t.Errorf("CleanAfter = %v, want false", bodies[0]["CleanAfter"])
+	}
+}
+
+func TestRunSandboxMerge_PostsToNamedTarget(t *testing.T) {
+	resetCmdFlags(t)
+	sandboxMergeYes = true
+	sandboxMergeTarget = "FY24Forecast"
+
+	bodies := []map[string]interface{}{}
+	setupMockTM1(t, newMergeHandler(mergeHandlerOpts{postBodies: &bodies}))
+
+	captureAll(t, func() {
+		if err := runSandboxMerge(sandboxMergeCmd, []string{"FY24Plan"}); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	if bodies[0]["Target@odata.bind"] != "Sandboxes('FY24Forecast')" {
+		t.Errorf("Target@odata.bind = %v, want Sandboxes('FY24Forecast')", bodies[0]["Target@odata.bind"])
+	}
+}
+
+func TestRunSandboxMerge_CleanAfterTrueWhenFlagSet(t *testing.T) {
+	resetCmdFlags(t)
+	sandboxMergeYes = true
+	sandboxMergeClean = true
+
+	bodies := []map[string]interface{}{}
+	setupMockTM1(t, newMergeHandler(mergeHandlerOpts{postBodies: &bodies}))
+
+	cap := captureAll(t, func() {
+		if err := runSandboxMerge(sandboxMergeCmd, []string{"FY24Plan"}); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	if bodies[0]["CleanAfter"] != true {
+		t.Errorf("CleanAfter = %v, want true", bodies[0]["CleanAfter"])
+	}
+	if !strings.Contains(cap.Stdout, "(source cleaned)") {
+		t.Errorf("stdout should mention source cleaned, got: %s", cap.Stdout)
+	}
+}
+
+func TestRunSandboxMerge_RejectsTargetEqualsSource(t *testing.T) {
+	resetCmdFlags(t)
+	sandboxMergeYes = true
+	sandboxMergeTarget = "FY24Plan"
+
+	posts := 0
+	setupMockTM1(t, newMergeHandler(mergeHandlerOpts{posts: &posts}))
+
+	cap := captureAll(t, func() {
+		err := runSandboxMerge(sandboxMergeCmd, []string{"FY24Plan"})
+		if !errors.Is(err, errSilent) {
+			t.Fatalf("expected errSilent, got: %v", err)
+		}
+	})
+
+	if posts != 0 {
+		t.Errorf("expected zero POST when --target equals source, got %d", posts)
+	}
+	if !strings.Contains(cap.Stderr, "--target cannot equal the source") {
+		t.Errorf("stderr should explain --target=source rejection, got: %s", cap.Stderr)
+	}
+}
+
+func TestRunSandboxMerge_PromptDeclineSkipsHTTP(t *testing.T) {
+	resetCmdFlags(t)
+	posts := 0
+	setupMockTM1(t, newMergeHandler(mergeHandlerOpts{posts: &posts}))
+	injectStdin(t, "n\n")
+
+	cap := captureAll(t, func() {
+		if err := runSandboxMerge(sandboxMergeCmd, []string{"FY24Plan"}); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	if posts != 0 {
+		t.Errorf("expected zero POST when user declines, got %d", posts)
+	}
+	if !strings.Contains(cap.Stderr, "About to merge sandbox 'FY24Plan'") {
+		t.Errorf("stderr should contain warning text, got: %s", cap.Stderr)
+	}
+}
+
+func TestRunSandboxMerge_PromptAcceptYProceeds(t *testing.T) {
+	resetCmdFlags(t)
+	posts := 0
+	setupMockTM1(t, newMergeHandler(mergeHandlerOpts{posts: &posts}))
+	injectStdin(t, "y\n")
+
+	captureAll(t, func() {
+		if err := runSandboxMerge(sandboxMergeCmd, []string{"FY24Plan"}); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	if posts != 1 {
+		t.Errorf("expected 1 POST after 'y', got %d", posts)
+	}
+}
+
+func TestRunSandboxMerge_PromptAcceptYesProceeds(t *testing.T) {
+	resetCmdFlags(t)
+	posts := 0
+	setupMockTM1(t, newMergeHandler(mergeHandlerOpts{posts: &posts}))
+	injectStdin(t, "yes\n")
+
+	captureAll(t, func() {
+		if err := runSandboxMerge(sandboxMergeCmd, []string{"FY24Plan"}); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	if posts != 1 {
+		t.Errorf("expected 1 POST after 'yes', got %d", posts)
+	}
+}
+
+func TestRunSandboxMerge_YesSuppressesPrompt(t *testing.T) {
+	resetCmdFlags(t)
+	sandboxMergeYes = true
+	setupMockTM1(t, newMergeHandler(mergeHandlerOpts{}))
+
+	cap := captureAll(t, func() {
+		if err := runSandboxMerge(sandboxMergeCmd, []string{"FY24Plan"}); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	if strings.Contains(cap.Stderr, "About to merge") {
+		t.Errorf("stderr should NOT contain prompt text when --yes set, got: %s", cap.Stderr)
+	}
+}
+
+func TestRunSandboxMerge_ClosedStdinSkipsHTTP(t *testing.T) {
+	resetCmdFlags(t)
+	posts := 0
+	setupMockTM1(t, newMergeHandler(mergeHandlerOpts{posts: &posts}))
+	injectStdin(t, "")
+
+	captureAll(t, func() {
+		if err := runSandboxMerge(sandboxMergeCmd, []string{"FY24Plan"}); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	if posts != 0 {
+		t.Errorf("expected zero POST on closed stdin, got %d", posts)
+	}
+}
+
+func TestRunSandboxMerge_DryRunSkipsHTTP(t *testing.T) {
+	resetCmdFlags(t)
+	sandboxMergeDryRun = true
+	posts := 0
+	setupMockTM1(t, newMergeHandler(mergeHandlerOpts{posts: &posts}))
+
+	cap := captureAll(t, func() {
+		if err := runSandboxMerge(sandboxMergeCmd, []string{"FY24Plan"}); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	if posts != 0 {
+		t.Errorf("expected zero POST in dry-run, got %d", posts)
+	}
+	if !strings.Contains(cap.Stdout, "[dry-run] Would merge sandbox 'FY24Plan' into base") {
+		t.Errorf("stdout should describe dry-run, got: %s", cap.Stdout)
+	}
+}
+
+func TestRunSandboxMerge_NotFoundExits3(t *testing.T) {
+	resetCmdFlags(t)
+	sandboxMergeYes = true
+	setupMockTM1(t, newMergeHandler(mergeHandlerOpts{status: http.StatusNotFound, body: `{"error":"not found"}`}))
+
+	cap := captureAll(t, func() {
+		err := runSandboxMerge(sandboxMergeCmd, []string{"FY24Plan"})
+		if exitCodeForError(err) != 3 {
+			t.Fatalf("expected exit code 3, got %d (err=%v)", exitCodeForError(err), err)
+		}
+	})
+
+	if !strings.Contains(cap.Stderr, "Sandbox 'FY24Plan' not found.") {
+		t.Errorf("stderr should report not found, got: %s", cap.Stderr)
+	}
+}
+
+func TestRunSandboxMerge_MergeConflictMessage(t *testing.T) {
+	resetCmdFlags(t)
+	sandboxMergeYes = true
+	setupMockTM1(t, newMergeHandler(mergeHandlerOpts{
+		status: http.StatusBadRequest,
+		body:   `{"error":{"message":"Sandbox cannot be merged due to conflict."}}`,
+	}))
+
+	cap := captureAll(t, func() {
+		err := runSandboxMerge(sandboxMergeCmd, []string{"FY24Plan"})
+		if !errors.Is(err, errSilent) {
+			t.Fatalf("expected errSilent, got: %v", err)
+		}
+	})
+
+	if !strings.Contains(cap.Stderr, "Merge conflict on sandbox 'FY24Plan'") {
+		t.Errorf("stderr should report merge conflict, got: %s", cap.Stderr)
+	}
+}
+
+func TestRunSandboxMerge_LockedByUserMessage(t *testing.T) {
+	resetCmdFlags(t)
+	sandboxMergeYes = true
+	setupMockTM1(t, newMergeHandler(mergeHandlerOpts{
+		status: http.StatusBadRequest,
+		body:   `{"error":{"message":"Sandbox 'FY24Plan' is loaded by user 'Alice'."}}`,
+	}))
+
+	cap := captureAll(t, func() {
+		err := runSandboxMerge(sandboxMergeCmd, []string{"FY24Plan"})
+		if !errors.Is(err, errSilent) {
+			t.Fatalf("expected errSilent, got: %v", err)
+		}
+	})
+
+	if !strings.Contains(cap.Stderr, "loaded by another user") {
+		t.Errorf("stderr should report loaded by another user, got: %s", cap.Stderr)
+	}
+}
+
+func TestRunSandboxMerge_LockedTakesPrecedenceOverConflict(t *testing.T) {
+	resetCmdFlags(t)
+	sandboxMergeYes = true
+	// Body contains both 'loaded by' and 'conflict' — locked check must win.
+	setupMockTM1(t, newMergeHandler(mergeHandlerOpts{
+		status: http.StatusBadRequest,
+		body:   `{"error":"Sandbox is loaded by user 'Bob'; merge conflict deferred."}`,
+	}))
+
+	cap := captureAll(t, func() {
+		_ = runSandboxMerge(sandboxMergeCmd, []string{"FY24Plan"})
+	})
+
+	if !strings.Contains(cap.Stderr, "loaded by another user") {
+		t.Errorf("stderr should pick locked message, got: %s", cap.Stderr)
+	}
+	if strings.Contains(cap.Stderr, "Merge conflict") {
+		t.Errorf("stderr should NOT pick merge conflict when locked, got: %s", cap.Stderr)
+	}
+}
+
+func TestRunSandboxMerge_PermissionDenied(t *testing.T) {
+	resetCmdFlags(t)
+	sandboxMergeYes = true
+	setupMockTM1(t, newMergeHandler(mergeHandlerOpts{status: http.StatusForbidden, body: `{"error":"forbidden"}`}))
+
+	cap := captureAll(t, func() {
+		err := runSandboxMerge(sandboxMergeCmd, []string{"FY24Plan"})
+		if !errors.Is(err, errSilent) {
+			t.Fatalf("expected errSilent, got: %v", err)
+		}
+	})
+
+	if !strings.Contains(cap.Stderr, "Permission denied") {
+		t.Errorf("stderr should report permission denied, got: %s", cap.Stderr)
+	}
+}
+
+func TestRunSandboxMerge_JSONOutput(t *testing.T) {
+	resetCmdFlags(t)
+	sandboxMergeYes = true
+	flagOutput = "json"
+	setupMockTM1(t, newMergeHandler(mergeHandlerOpts{}))
+
+	cap := captureAll(t, func() {
+		if err := runSandboxMerge(sandboxMergeCmd, []string{"FY24Plan"}); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	var parsed map[string]interface{}
+	if err := json.Unmarshal([]byte(cap.Stdout), &parsed); err != nil {
+		t.Fatalf("stdout is not JSON: %v\nstdout: %s", err, cap.Stdout)
+	}
+	if parsed["status"] != "merged" {
+		t.Errorf("status = %v, want 'merged'", parsed["status"])
+	}
+	if parsed["source"] != "FY24Plan" {
+		t.Errorf("source = %v, want 'FY24Plan'", parsed["source"])
+	}
+}
+
+func TestRunSandboxMerge_EmptyNameRejected(t *testing.T) {
+	resetCmdFlags(t)
+	sandboxMergeYes = true
+	posts := 0
+	setupMockTM1(t, newMergeHandler(mergeHandlerOpts{posts: &posts}))
+
+	cap := captureAll(t, func() {
+		err := runSandboxMerge(sandboxMergeCmd, []string{"   "})
+		if !errors.Is(err, errSilent) {
+			t.Fatalf("expected errSilent, got: %v", err)
+		}
+	})
+
+	if posts != 0 {
+		t.Errorf("expected zero POST for empty name, got %d", posts)
+	}
+	if !strings.Contains(cap.Stderr, "Sandbox name cannot be empty.") {
+		t.Errorf("stderr should reject empty name, got: %s", cap.Stderr)
+	}
+}
+
+// ============================================================
+// Integration — runSandboxDelete
+// ============================================================
+
+type deleteHandlerOpts struct {
+	status      int
+	body        string
+	deletes     *int
+	deletePaths *[]string
+}
+
+func newDeleteHandler(opts deleteHandlerOpts) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			w.Write([]byte(`{"error":"unexpected method"}`))
+			return
+		}
+		if opts.deletes != nil {
+			*opts.deletes++
+		}
+		if opts.deletePaths != nil {
+			*opts.deletePaths = append(*opts.deletePaths, r.URL.Path)
+		}
+		status := opts.status
+		if status == 0 {
+			status = http.StatusNoContent
+		}
+		w.WriteHeader(status)
+		if opts.body != "" {
+			w.Write([]byte(opts.body))
+		}
+	}
+}
+
+func TestRunSandboxDelete_Success(t *testing.T) {
+	resetCmdFlags(t)
+	sandboxDeleteYes = true
+	deletes := 0
+	paths := []string{}
+	setupMockTM1(t, newDeleteHandler(deleteHandlerOpts{deletes: &deletes, deletePaths: &paths}))
+
+	cap := captureAll(t, func() {
+		if err := runSandboxDelete(sandboxDeleteCmd, []string{"FY24Plan"}); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	if deletes != 1 {
+		t.Fatalf("expected 1 DELETE, got %d", deletes)
+	}
+	if !strings.Contains(paths[0], "Sandboxes('FY24Plan')") {
+		t.Errorf("path = %q, want Sandboxes('FY24Plan')", paths[0])
+	}
+	if !strings.Contains(cap.Stdout, "Deleted sandbox 'FY24Plan'") {
+		t.Errorf("stdout should confirm delete, got: %s", cap.Stdout)
+	}
+}
+
+func TestRunSandboxDelete_NotFoundExits3(t *testing.T) {
+	resetCmdFlags(t)
+	sandboxDeleteYes = true
+	setupMockTM1(t, newDeleteHandler(deleteHandlerOpts{status: http.StatusNotFound, body: `{"error":"not found"}`}))
+
+	cap := captureAll(t, func() {
+		err := runSandboxDelete(sandboxDeleteCmd, []string{"FY24Plan"})
+		if exitCodeForError(err) != 3 {
+			t.Fatalf("expected exit code 3, got %d (err=%v)", exitCodeForError(err), err)
+		}
+	})
+
+	if !strings.Contains(cap.Stderr, "Sandbox 'FY24Plan' not found.") {
+		t.Errorf("stderr should report not found, got: %s", cap.Stderr)
+	}
+}
+
+func TestRunSandboxDelete_LockedByUser(t *testing.T) {
+	resetCmdFlags(t)
+	sandboxDeleteYes = true
+	setupMockTM1(t, newDeleteHandler(deleteHandlerOpts{
+		status: http.StatusBadRequest,
+		body:   `{"error":"Sandbox is currently loaded by another user."}`,
+	}))
+
+	cap := captureAll(t, func() {
+		err := runSandboxDelete(sandboxDeleteCmd, []string{"FY24Plan"})
+		if !errors.Is(err, errSilent) {
+			t.Fatalf("expected errSilent, got: %v", err)
+		}
+	})
+
+	if !strings.Contains(cap.Stderr, "loaded by another user") {
+		t.Errorf("stderr should report locked, got: %s", cap.Stderr)
+	}
+}
+
+func TestRunSandboxDelete_PermissionDenied(t *testing.T) {
+	resetCmdFlags(t)
+	sandboxDeleteYes = true
+	setupMockTM1(t, newDeleteHandler(deleteHandlerOpts{status: http.StatusForbidden, body: `{"error":"forbidden"}`}))
+
+	cap := captureAll(t, func() {
+		err := runSandboxDelete(sandboxDeleteCmd, []string{"FY24Plan"})
+		if !errors.Is(err, errSilent) {
+			t.Fatalf("expected errSilent, got: %v", err)
+		}
+	})
+
+	if !strings.Contains(cap.Stderr, "Permission denied") {
+		t.Errorf("stderr should report permission denied, got: %s", cap.Stderr)
+	}
+}
+
+func TestRunSandboxDelete_PromptDeclineSkipsHTTP(t *testing.T) {
+	resetCmdFlags(t)
+	deletes := 0
+	setupMockTM1(t, newDeleteHandler(deleteHandlerOpts{deletes: &deletes}))
+	injectStdin(t, "n\n")
+
+	cap := captureAll(t, func() {
+		if err := runSandboxDelete(sandboxDeleteCmd, []string{"FY24Plan"}); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	if deletes != 0 {
+		t.Errorf("expected zero DELETE when user declines, got %d", deletes)
+	}
+	if !strings.Contains(cap.Stderr, "About to permanently delete sandbox 'FY24Plan'") {
+		t.Errorf("stderr should warn before prompt, got: %s", cap.Stderr)
+	}
+}
+
+func TestRunSandboxDelete_DryRunSkipsHTTP(t *testing.T) {
+	resetCmdFlags(t)
+	sandboxDeleteDryRun = true
+	deletes := 0
+	setupMockTM1(t, newDeleteHandler(deleteHandlerOpts{deletes: &deletes}))
+
+	cap := captureAll(t, func() {
+		if err := runSandboxDelete(sandboxDeleteCmd, []string{"FY24Plan"}); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	if deletes != 0 {
+		t.Errorf("expected zero DELETE in dry-run, got %d", deletes)
+	}
+	if !strings.Contains(cap.Stdout, "[dry-run] Would delete sandbox 'FY24Plan'") {
+		t.Errorf("stdout should describe dry-run, got: %s", cap.Stdout)
+	}
+}
+
+func TestRunSandboxDelete_JSONOutput(t *testing.T) {
+	resetCmdFlags(t)
+	sandboxDeleteYes = true
+	flagOutput = "json"
+	setupMockTM1(t, newDeleteHandler(deleteHandlerOpts{}))
+
+	cap := captureAll(t, func() {
+		if err := runSandboxDelete(sandboxDeleteCmd, []string{"FY24Plan"}); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	var parsed map[string]string
+	if err := json.Unmarshal([]byte(cap.Stdout), &parsed); err != nil {
+		t.Fatalf("stdout is not JSON: %v\nstdout: %s", err, cap.Stdout)
+	}
+	if parsed["status"] != "deleted" {
+		t.Errorf("status = %v, want 'deleted'", parsed["status"])
+	}
+}
+
+func TestRunSandboxDelete_EmptyNameRejected(t *testing.T) {
+	resetCmdFlags(t)
+	sandboxDeleteYes = true
+	deletes := 0
+	setupMockTM1(t, newDeleteHandler(deleteHandlerOpts{deletes: &deletes}))
+
+	cap := captureAll(t, func() {
+		err := runSandboxDelete(sandboxDeleteCmd, []string{""})
+		if !errors.Is(err, errSilent) {
+			t.Fatalf("expected errSilent, got: %v", err)
+		}
+	})
+
+	if deletes != 0 {
+		t.Errorf("expected zero DELETE for empty name, got %d", deletes)
+	}
+	if !strings.Contains(cap.Stderr, "Sandbox name cannot be empty.") {
+		t.Errorf("stderr should reject empty name, got: %s", cap.Stderr)
+	}
+}
+
+// ============================================================
 // Helpers
 // ============================================================
 

--- a/cmd/sandbox_test.go
+++ b/cmd/sandbox_test.go
@@ -958,55 +958,75 @@ func TestIsSandboxMergeConflictError(t *testing.T) {
 // ============================================================
 
 // mergeHandlerOpts captures the merge mock behaviour. status overrides
-// the default 200 OK; body overrides the default empty JSON.
+// the default 200 OK for the merge/publish POST; body overrides the
+// default empty JSON. Base-merge routes through tm1.Publish (no body)
+// and may issue a follow-up DELETE on the source for --clean — both are
+// captured by this handler.
 type mergeHandlerOpts struct {
-	status     int
-	body       string
-	posts      *int
-	postPaths  *[]string
-	postBodies *[]map[string]interface{}
+	status      int
+	body        string
+	posts       *int
+	postPaths   *[]string
+	postBodies  *[]map[string]interface{}
+	deletes     *int
+	deletePaths *[]string
+	deleteStatus int // status returned for follow-up DELETE; 0 → 204
 }
 
 func newMergeHandler(opts mergeHandlerOpts) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodPost || !strings.Contains(r.URL.Path, "/tm1.Merge") {
+		switch {
+		case r.Method == http.MethodPost && (strings.Contains(r.URL.Path, "/tm1.Merge") || strings.Contains(r.URL.Path, "/tm1.Publish")):
+			if opts.posts != nil {
+				*opts.posts++
+			}
+			if opts.postPaths != nil {
+				*opts.postPaths = append(*opts.postPaths, r.URL.Path)
+			}
+			if opts.postBodies != nil {
+				raw, _ := io.ReadAll(r.Body)
+				var parsed map[string]interface{}
+				_ = json.Unmarshal(raw, &parsed)
+				*opts.postBodies = append(*opts.postBodies, parsed)
+			}
+			status := opts.status
+			if status == 0 {
+				status = http.StatusOK
+			}
+			w.WriteHeader(status)
+			if opts.body != "" {
+				w.Write([]byte(opts.body))
+			} else {
+				w.Write([]byte(`{}`))
+			}
+		case r.Method == http.MethodDelete:
+			if opts.deletes != nil {
+				*opts.deletes++
+			}
+			if opts.deletePaths != nil {
+				*opts.deletePaths = append(*opts.deletePaths, r.URL.Path)
+			}
+			status := opts.deleteStatus
+			if status == 0 {
+				status = http.StatusNoContent
+			}
+			w.WriteHeader(status)
+		default:
 			w.WriteHeader(http.StatusNotFound)
 			w.Write([]byte(`{"error":"unexpected route"}`))
-			return
-		}
-		if opts.posts != nil {
-			*opts.posts++
-		}
-		if opts.postPaths != nil {
-			*opts.postPaths = append(*opts.postPaths, r.URL.Path)
-		}
-		if opts.postBodies != nil {
-			raw, _ := io.ReadAll(r.Body)
-			var parsed map[string]interface{}
-			_ = json.Unmarshal(raw, &parsed)
-			*opts.postBodies = append(*opts.postBodies, parsed)
-		}
-		status := opts.status
-		if status == 0 {
-			status = http.StatusOK
-		}
-		w.WriteHeader(status)
-		if opts.body != "" {
-			w.Write([]byte(opts.body))
-		} else {
-			w.Write([]byte(`{}`))
 		}
 	}
 }
 
-func TestRunSandboxMerge_PostsToBaseByDefault(t *testing.T) {
+func TestRunSandboxMerge_BaseUsesPublishAction(t *testing.T) {
 	resetCmdFlags(t)
 	sandboxMergeYes = true
 
 	posts := 0
 	paths := []string{}
 	bodies := []map[string]interface{}{}
-	setupMockTM1(t, newMergeHandler(mergeHandlerOpts{posts: &posts, postPaths: &paths, postBodies: &bodies}))
+	deletes := 0
+	setupMockTM1(t, newMergeHandler(mergeHandlerOpts{posts: &posts, postPaths: &paths, postBodies: &bodies, deletes: &deletes}))
 
 	captureAll(t, func() {
 		if err := runSandboxMerge(sandboxMergeCmd, []string{"FY24Plan"}); err != nil {
@@ -1017,17 +1037,76 @@ func TestRunSandboxMerge_PostsToBaseByDefault(t *testing.T) {
 	if posts != 1 {
 		t.Fatalf("expected 1 POST, got %d", posts)
 	}
-	if !strings.Contains(paths[0], "Sandboxes('FY24Plan')/tm1.Merge") {
-		t.Errorf("path = %q, want Sandboxes('FY24Plan')/tm1.Merge", paths[0])
+	if !strings.Contains(paths[0], "Sandboxes('FY24Plan')/tm1.Publish") {
+		t.Errorf("path = %q, want Sandboxes('FY24Plan')/tm1.Publish (base merge routes through Publish)", paths[0])
 	}
-	if bodies[0]["Source@odata.bind"] != "Sandboxes('FY24Plan')" {
-		t.Errorf("Source@odata.bind = %v, want Sandboxes('FY24Plan')", bodies[0]["Source@odata.bind"])
+	// tm1.Publish takes no Source/Target/CleanAfter — verify body has no merge fields.
+	if _, has := bodies[0]["Source@odata.bind"]; has {
+		t.Errorf("publish body should not include Source@odata.bind, got: %v", bodies[0])
 	}
-	if bodies[0]["Target@odata.bind"] != "Sandboxes('')" {
-		t.Errorf("Target@odata.bind = %v, want Sandboxes('') for base", bodies[0]["Target@odata.bind"])
+	if _, has := bodies[0]["Target@odata.bind"]; has {
+		t.Errorf("publish body should not include Target@odata.bind, got: %v", bodies[0])
 	}
-	if bodies[0]["CleanAfter"] != false {
-		t.Errorf("CleanAfter = %v, want false", bodies[0]["CleanAfter"])
+	if deletes != 0 {
+		t.Errorf("expected zero DELETE without --clean, got %d", deletes)
+	}
+}
+
+func TestRunSandboxMerge_BaseCleanIssuesFollowupDelete(t *testing.T) {
+	resetCmdFlags(t)
+	sandboxMergeYes = true
+	sandboxMergeClean = true
+
+	posts := 0
+	postPaths := []string{}
+	deletes := 0
+	deletePaths := []string{}
+	setupMockTM1(t, newMergeHandler(mergeHandlerOpts{
+		posts:       &posts,
+		postPaths:   &postPaths,
+		deletes:     &deletes,
+		deletePaths: &deletePaths,
+	}))
+
+	cap := captureAll(t, func() {
+		if err := runSandboxMerge(sandboxMergeCmd, []string{"FY24Plan"}); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	if posts != 1 || !strings.Contains(postPaths[0], "tm1.Publish") {
+		t.Errorf("expected 1 Publish POST, got %d posts paths=%v", posts, postPaths)
+	}
+	if deletes != 1 {
+		t.Fatalf("expected 1 DELETE for --clean cleanup, got %d", deletes)
+	}
+	if !strings.Contains(deletePaths[0], "Sandboxes('FY24Plan')") {
+		t.Errorf("DELETE path = %q, want Sandboxes('FY24Plan')", deletePaths[0])
+	}
+	if !strings.Contains(cap.Stdout, "(source cleaned)") {
+		t.Errorf("stdout should report source cleaned, got: %s", cap.Stdout)
+	}
+}
+
+func TestRunSandboxMerge_BaseCleanFailureWarnsAndSucceeds(t *testing.T) {
+	resetCmdFlags(t)
+	sandboxMergeYes = true
+	sandboxMergeClean = true
+
+	// Publish succeeds; cleanup DELETE fails with 500.
+	setupMockTM1(t, newMergeHandler(mergeHandlerOpts{deleteStatus: http.StatusInternalServerError}))
+
+	cap := captureAll(t, func() {
+		if err := runSandboxMerge(sandboxMergeCmd, []string{"FY24Plan"}); err != nil {
+			t.Fatalf("merge should still succeed even if cleanup fails, got: %v", err)
+		}
+	})
+
+	if !strings.Contains(cap.Stderr, "cleanup DELETE failed") {
+		t.Errorf("stderr should warn about cleanup failure, got: %s", cap.Stderr)
+	}
+	if !strings.Contains(cap.Stdout, "source cleanup failed") {
+		t.Errorf("stdout should reflect cleanup-failed status, got: %s", cap.Stdout)
 	}
 }
 
@@ -1050,13 +1129,15 @@ func TestRunSandboxMerge_PostsToNamedTarget(t *testing.T) {
 	}
 }
 
-func TestRunSandboxMerge_CleanAfterTrueWhenFlagSet(t *testing.T) {
+func TestRunSandboxMerge_NamedTargetCleanAfterTrue(t *testing.T) {
 	resetCmdFlags(t)
 	sandboxMergeYes = true
 	sandboxMergeClean = true
+	sandboxMergeTarget = "FY24Forecast"
 
 	bodies := []map[string]interface{}{}
-	setupMockTM1(t, newMergeHandler(mergeHandlerOpts{postBodies: &bodies}))
+	paths := []string{}
+	setupMockTM1(t, newMergeHandler(mergeHandlerOpts{postBodies: &bodies, postPaths: &paths}))
 
 	cap := captureAll(t, func() {
 		if err := runSandboxMerge(sandboxMergeCmd, []string{"FY24Plan"}); err != nil {
@@ -1064,6 +1145,9 @@ func TestRunSandboxMerge_CleanAfterTrueWhenFlagSet(t *testing.T) {
 		}
 	})
 
+	if !strings.Contains(paths[0], "tm1.Merge") {
+		t.Errorf("path = %q, want tm1.Merge for named target", paths[0])
+	}
 	if bodies[0]["CleanAfter"] != true {
 		t.Errorf("CleanAfter = %v, want true", bodies[0]["CleanAfter"])
 	}
@@ -1222,6 +1306,7 @@ func TestRunSandboxMerge_NotFoundExits3(t *testing.T) {
 func TestRunSandboxMerge_MergeConflictMessage(t *testing.T) {
 	resetCmdFlags(t)
 	sandboxMergeYes = true
+	sandboxMergeTarget = "FY24Forecast" // merge conflict only meaningful for tm1.Merge (named target)
 	setupMockTM1(t, newMergeHandler(mergeHandlerOpts{
 		status: http.StatusBadRequest,
 		body:   `{"error":{"message":"Sandbox cannot be merged due to conflict."}}`,
@@ -1262,6 +1347,7 @@ func TestRunSandboxMerge_LockedByUserMessage(t *testing.T) {
 func TestRunSandboxMerge_LockedTakesPrecedenceOverConflict(t *testing.T) {
 	resetCmdFlags(t)
 	sandboxMergeYes = true
+	sandboxMergeTarget = "FY24Forecast" // precedence check uses tm1.Merge path
 	// Body contains both 'loaded by' and 'conflict' — locked check must win.
 	setupMockTM1(t, newMergeHandler(mergeHandlerOpts{
 		status: http.StatusBadRequest,

--- a/cmd/testhelpers_test.go
+++ b/cmd/testhelpers_test.go
@@ -13,6 +13,8 @@ import (
 	"tm1cli/internal/config"
 	"tm1cli/internal/model"
 
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 	"github.com/zalando/go-keyring"
 )
 
@@ -280,6 +282,17 @@ func zeroAllFlags() {
 	sandboxMergeDryRun = false
 	sandboxDeleteYes = false
 	sandboxDeleteDryRun = false
+
+	// Reset cobra's per-flag Changed bit so tests that drive commands
+	// through rootCmd.Execute() don't leak flag state into later tests
+	// that inspect cmd.Flags().Changed(...) directly.
+	resetSandboxFlagChanged()
+}
+
+func resetSandboxFlagChanged() {
+	for _, c := range []*cobra.Command{sandboxMergeCmd, sandboxDeleteCmd} {
+		c.Flags().VisitAll(func(f *pflag.Flag) { f.Changed = false })
+	}
 }
 
 // cubesJSON returns JSON for a TM1 Cubes response.

--- a/cmd/testhelpers_test.go
+++ b/cmd/testhelpers_test.go
@@ -274,6 +274,12 @@ func zeroAllFlags() {
 	sandboxListCount = false
 	sandboxListLoaded = false
 	sandboxListActive = false
+	sandboxMergeYes = false
+	sandboxMergeClean = false
+	sandboxMergeTarget = ""
+	sandboxMergeDryRun = false
+	sandboxDeleteYes = false
+	sandboxDeleteDryRun = false
 }
 
 // cubesJSON returns JSON for a TM1 Cubes response.


### PR DESCRIPTION
## Summary
- Adds `tm1cli sandbox merge <name>` — merges a sandbox into the base (via TM1's `tm1.Publish` action) or into a named target sandbox (via `tm1.Merge`)
- Adds `tm1cli sandbox delete <name>` — `DELETE /Sandboxes('name')`
- Both honor `--yes` (skip confirm) and `--dry-run` (preview, takes precedence over `--yes`); merge additionally supports `--target <name>` and `--clean` (drop source after successful merge)

## Design notes
- **Base merge routes through `tm1.Publish`**, not `tm1.Merge` with `Target=Sandboxes('')`, because an empty OData key is not portable across TM1 versions
- **Named-target merge omits `Source@odata.bind`** from the body — the action is already bound to the source via the URL path; some TM1 versions reject the extra Source field
- **`--clean` on base-merge** is non-atomic: `tm1.Publish` doesn't accept `CleanAfter`, so an explicit DELETE follows. Cleanup failure surfaces as a warning + JSON `cleaned:false`, not a failure of the whole operation
- **Explicit empty `--target` fails fast** (e.g. `--target \"\$TARGET\"` in a script with TARGET unset) — distinguished from \"flag not set\" via `cmd.Flags().Changed(\"target\")`
- **Error funnel** maps 404 → exit 3 + \"not found\", 403 → \"Permission denied\", HTTP 400/409 with \"loaded by\"/\"currently loaded\"/\"is in use\" → \"loaded by another user\", HTTP 400/409 with \"conflict\"/\"cannot be merged\" → \"Merge conflict\". Locked-check runs before conflict-check (more-specific failure wins)

## Test plan
- [x] \`go build ./...\` clean
- [x] \`go vet ./...\` clean
- [x] \`gofmt -l\` clean on all changed files
- [x] \`go test ./...\` — 1,402 passing across 6 packages (+30 vs origin/dev)
- [x] 30 new tests in \`cmd/sandbox_test.go\` cover: base routes via Publish, named-target routes via Merge without Source@odata.bind, --clean follow-up DELETE on base (success + cleanup-failure-as-warning), --target=source guard, explicit-empty --target rejection via rootCmd.Execute, prompt accept (y/yes) / decline (n) / EOF stdin, --yes suppression, dry-run zero-HTTP, --output json, 404 → exit 3, 403, locked-by-user, merge-conflict, locked-takes-precedence over conflict, empty/whitespace name rejection
- [x] Unit tests for \`isSandboxLockedError\` (9 cases) and \`isSandboxMergeConflictError\` (5 cases)
- [x] \`resetSandboxFlagChanged\` helper added so cobra's per-flag \`Changed\` bit doesn't leak between tests

Closes #86