### PR TITLE
fix(#131): handle TM1 message log responses

### DIFF
--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -146,8 +146,15 @@ func buildMessageLogFilter(sinceTS, level string) string {
 	return strings.Join(parts, " and ")
 }
 
-// buildMessageLogQuery builds the full endpoint URL path with $filter, $top, and $orderby
-// using url.Values for safe encoding.
+// encodeODataQuery uses percent encoding for spaces. net/url's query encoder
+// normally emits '+', but TM1's OData parser treats that as a literal token
+// rather than a space (for example, "TimeStamp+desc" is rejected).
+func encodeODataQuery(v url.Values) string {
+	return strings.ReplaceAll(v.Encode(), "+", "%20")
+}
+
+// buildMessageLogQuery builds the full endpoint URL path with $filter, $top,
+// and $orderby using OData-compatible query encoding.
 func buildMessageLogQuery(filter string, top int, orderDesc bool) string {
 	v := url.Values{}
 	if filter != "" {
@@ -162,7 +169,7 @@ func buildMessageLogQuery(filter string, top int, orderDesc bool) string {
 	if len(v) == 0 {
 		return "MessageLogEntries"
 	}
-	return "MessageLogEntries?" + v.Encode()
+	return "MessageLogEntries?" + encodeODataQuery(v)
 }
 
 // isFilterRejection returns true for HTTP 400/501 with a body referencing

--- a/cmd/logs_audit.go
+++ b/cmd/logs_audit.go
@@ -128,7 +128,7 @@ func buildAuditFilter(sinceTS, untilTS, objectType, objectName, user string) str
 }
 
 // buildAuditQuery builds the endpoint URL with $filter, $top, $orderby using
-// url.Values for safe encoding. orderBy must be "", orderTimeStampAsc, or
+// OData-compatible query encoding. orderBy must be "", orderTimeStampAsc, or
 // orderTimeStampDesc — empty means no $orderby clause (use server default).
 func buildAuditQuery(filter string, top int, orderBy string) string {
 	v := url.Values{}
@@ -144,7 +144,7 @@ func buildAuditQuery(filter string, top int, orderBy string) string {
 	if len(v) == 0 {
 		return "AuditLogEntries"
 	}
-	return "AuditLogEntries?" + v.Encode()
+	return "AuditLogEntries?" + encodeODataQuery(v)
 }
 
 // fetchAuditEntries performs GET. On HTTP 400/501 with a filter-rejection body,

--- a/cmd/logs_audit_test.go
+++ b/cmd/logs_audit_test.go
@@ -98,6 +98,13 @@ func TestBuildAuditQuery_EmptyOrderByOmitsOrderby(t *testing.T) {
 	}
 }
 
+func TestBuildAuditQuery_EncodesODataSpacesAsPercent20(t *testing.T) {
+	got := buildAuditQuery("ObjectType eq 'Cube'", 50, orderTimeStampDesc)
+	if strings.Contains(got, "+") {
+		t.Fatalf("query contains '+', which TM1 does not accept as an OData space: %q", got)
+	}
+}
+
 // ============================================================
 // Unit tests — applyAuditClientFilters
 // ============================================================

--- a/cmd/logs_test.go
+++ b/cmd/logs_test.go
@@ -368,6 +368,21 @@ func TestBuildMessageLogQuery(t *testing.T) {
 	}
 }
 
+func TestBuildMessageLogQuery_EncodesODataSpacesAsPercent20(t *testing.T) {
+	got := buildMessageLogQuery("Level eq 'Error'", 100, true)
+	if strings.Contains(got, "+") {
+		t.Fatalf("query contains '+', which TM1 does not accept as an OData space: %q", got)
+	}
+	for _, want := range []string{
+		"%24filter=Level%20eq%20%27Error%27",
+		"%24orderby=TimeStamp%20desc",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("query %q missing %q", got, want)
+		}
+	}
+}
+
 // ============================================================
 // Unit Tests — applyClientFilters
 // ============================================================

--- a/cmd/logs_tx.go
+++ b/cmd/logs_tx.go
@@ -148,7 +148,7 @@ const (
 )
 
 // buildTxQuery builds the endpoint URL with $filter, $top, $orderby using
-// url.Values for safe encoding. orderBy must be "", orderTimeStampAsc, or
+// OData-compatible query encoding. orderBy must be "", orderTimeStampAsc, or
 // orderTimeStampDesc — empty means no $orderby clause (use server default).
 func buildTxQuery(filter string, top int, orderBy string) string {
 	v := url.Values{}
@@ -164,7 +164,7 @@ func buildTxQuery(filter string, top int, orderBy string) string {
 	if len(v) == 0 {
 		return "TransactionLogEntries"
 	}
-	return "TransactionLogEntries?" + v.Encode()
+	return "TransactionLogEntries?" + encodeODataQuery(v)
 }
 
 // fetchTxEntries performs GET. On HTTP 400/501 with a filter-rejection body,

--- a/cmd/logs_tx_test.go
+++ b/cmd/logs_tx_test.go
@@ -273,6 +273,13 @@ func TestBuildTxQuery(t *testing.T) {
 			t.Errorf("query %q should not contain $orderby", got)
 		}
 	})
+
+	t.Run("encodes OData spaces as percent20", func(t *testing.T) {
+		got := buildTxQuery("Cube eq 'Sales'", 50, orderTimeStampDesc)
+		if strings.Contains(got, "+") {
+			t.Fatalf("query contains '+', which TM1 does not accept as an OData space: %q", got)
+		}
+	})
 }
 
 // ============================================================

--- a/internal/model/messagelog.go
+++ b/internal/model/messagelog.go
@@ -1,5 +1,12 @@
 package model
 
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
 // MessageLogEntry represents a single entry in the TM1 message log.
 // User is omitempty because older TM1 versions may not include the field.
 type MessageLogEntry struct {
@@ -9,6 +16,55 @@ type MessageLogEntry struct {
 	Level     string `json:"Level"`
 	Message   string `json:"Message"`
 	User      string `json:"User,omitempty"`
+}
+
+// UnmarshalJSON accepts both representations of the OData Edm.Int64 ID.
+// TM1 normally emits a JSON number, while IEEE754-compatible OData responses
+// and some older versions emit a quoted decimal string.
+func (e *MessageLogEntry) UnmarshalJSON(data []byte) error {
+	var wire struct {
+		ID        json.RawMessage `json:"ID"`
+		TimeStamp string          `json:"TimeStamp"`
+		Logger    string          `json:"Logger"`
+		Level     string          `json:"Level"`
+		Message   string          `json:"Message"`
+		User      string          `json:"User"`
+	}
+	if err := json.Unmarshal(data, &wire); err != nil {
+		return err
+	}
+
+	id, err := parseMessageLogID(wire.ID)
+	if err != nil {
+		return err
+	}
+	*e = MessageLogEntry{
+		ID:        id,
+		TimeStamp: wire.TimeStamp,
+		Logger:    wire.Logger,
+		Level:     wire.Level,
+		Message:   wire.Message,
+		User:      wire.User,
+	}
+	return nil
+}
+
+func parseMessageLogID(raw json.RawMessage) (string, error) {
+	value := strings.TrimSpace(string(raw))
+	if value == "" || value == "null" {
+		return "", nil
+	}
+	if strings.HasPrefix(value, `"`) {
+		var id string
+		if err := json.Unmarshal(raw, &id); err != nil {
+			return "", fmt.Errorf("cannot parse message log ID: %w", err)
+		}
+		return id, nil
+	}
+	if _, err := strconv.ParseInt(value, 10, 64); err != nil {
+		return "", fmt.Errorf("cannot parse message log ID %q as Int64: %w", value, err)
+	}
+	return value, nil
 }
 
 // MessageLogResponse is the OData collection wrapper for GET /MessageLogEntries.

--- a/internal/model/messagelog_test.go
+++ b/internal/model/messagelog_test.go
@@ -1,0 +1,37 @@
+package model
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestMessageLogEntryUnmarshalID(t *testing.T) {
+	tests := []struct {
+		name    string
+		payload string
+		wantID  string
+	}{
+		{
+			name:    "OData Int64 number",
+			payload: `{"ID":123,"TimeStamp":"2026-06-20T00:00:00Z","Level":"Info","Message":"ready"}`,
+			wantID:  "123",
+		},
+		{
+			name:    "IEEE754-compatible string",
+			payload: `{"ID":"456","TimeStamp":"2026-06-20T00:00:00Z","Level":"Info","Message":"ready"}`,
+			wantID:  "456",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var entry MessageLogEntry
+			if err := json.Unmarshal([]byte(tt.payload), &entry); err != nil {
+				t.Fatalf("json.Unmarshal() error = %v", err)
+			}
+			if entry.ID != tt.wantID {
+				t.Errorf("ID = %q, want %q", entry.ID, tt.wantID)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- encode OData query spaces as `%20` for message, transaction, and audit log endpoints
- decode message log IDs returned as numeric `Edm.Int64` values while retaining string compatibility
- add regression coverage for query encoding and ID decoding

## Root cause
`url.Values.Encode()` represented spaces as `+`, which the TM1 OData parser treated as an unsupported token. After correcting the request, numeric message log IDs failed to unmarshal into the existing string field.

## Impact
`tm1cli logs messages` now works for default, filtered, and time-bounded queries against TM1 servers.

## Testing
- `go test ./...`
- `go vet ./...`
- live checks for default, `--since`, and filtered message log commands

Closes #131
